### PR TITLE
GSF.Communication: Updated GetInterfaceIPStack to better select IPStack

### DIFF
--- a/Source/Libraries/GSF.Communication/Transport.cs
+++ b/Source/Libraries/GSF.Communication/Transport.cs
@@ -295,12 +295,14 @@ namespace GSF.Communication
 
         /// <summary>
         /// Derives the desired <see cref="IPStack"/> from the "interface" setting in the connection string key/value pairs.
+        /// If interface is not specified, <see cref="IPStack"/> is derived from the server value in connectionStringEntries
         /// </summary>
         /// <param name="connectionStringEntries">Connection string key/value pairs.</param>
         /// <returns>Desired <see cref="IPStack"/> based on "interface" setting.</returns>
         /// <remarks>
         /// The "interface" setting will be added to the <paramref name="connectionStringEntries"/> if it
-        /// doesn't exist, in this case return value will be <see cref="IPStack.Default"/>.
+        /// doesn't exist. in this case the return value will be based off of the "server" value. If the server parameter 
+        /// doesn't exist, the return value will be <see cref="IPStack.Default"/>.
         /// </remarks>
         public static IPStack GetInterfaceIPStack(Dictionary<string, string> connectionStringEntries)
         {
@@ -310,6 +312,9 @@ namespace GSF.Communication
                 return IsIPv6IP(ipAddress) ? IPStack.IPv6 : IPStack.IPv4;
 
             connectionStringEntries.Add("interface", string.Empty);
+
+            if (connectionStringEntries.TryGetValue("server", out ipAddress))
+                return IsIPv6IP(ipAddress) ? IPStack.IPv6 : IPStack.IPv4;
 
             return IPStack.Default;
         }


### PR DESCRIPTION
We are using an oscillation detection program that uses the GSF library to connect to an openPDC instance. When running remotely, I found the IPStack was always being set to IPv6. I ran a debugger and found that when "interface" is not specified in the config string, IPStack.Default is returned. This eventually defaults to the first IPStack of the local machine.

I made this change so that the IPStack is based on the server address rather than the client when the interface value is not provided. In my case, my local machine is configured for IPv6 and IPv4 while the server only supports IPv4. This caused the connection to fail.

By checking the address type of the server in the connection string, the communication library handles this edge case while keeping the same behavior if the interface parameter is provided.