### PR TITLE
Add logout endpoint for applications using AuthenticationHandler

### DIFF
--- a/Source/Libraries/GSF.Web/Security/AuthenticationOptions.cs
+++ b/Source/Libraries/GSF.Web/Security/AuthenticationOptions.cs
@@ -66,6 +66,11 @@ namespace GSF.Web.Security
         public const string DefaultLoginPage = Resources.Root + "/Security/Views/Login.cshtml";
 
         /// <summary>
+        /// Default value for <see cref="LogoutPage"/>.
+        /// </summary>
+        public const string DefaultLogoutPage = "/Security/logout";
+
+        /// <summary>
         /// Default value for <see cref="AuthTestPage"/>.
         /// </summary>
         public const string DefaultAuthTestPage = "/AuthTest";
@@ -158,6 +163,11 @@ namespace GSF.Web.Security
         /// Gets or sets the login page used as a redirect location when authentication fails.
         /// </summary>
         public string LoginPage { get; set; } = DefaultLoginPage;
+
+        /// <summary>
+        /// Gets or sets the path for the logout page.
+        /// </summary>
+        public string LogoutPage { get; set; } = DefaultLogoutPage;
 
         /// <summary>
         /// Gets or sets the page name used to test user authorization.
@@ -358,6 +368,11 @@ namespace GSF.Web.Security
         /// Gets the login page used as a redirect location when authentication fails.
         /// </summary>
         public string LoginPage => m_authenticationOptions.LoginPage;
+
+        /// <summary>
+        /// Gets the path for the logout page.
+        /// </summary>
+        public string LogoutPage => m_authenticationOptions.LogoutPage;
 
         /// <summary>
         /// Gets the page name used to test user authorization.

--- a/Source/Libraries/GSF.Web/Security/Scripts/Login.js
+++ b/Source/Libraries/GSF.Web/Security/Scripts/Login.js
@@ -170,17 +170,34 @@ function loginComplete(success, response) {
     }
 }
 
-function logoutComplete(success) {
+function logoutComplete(success, response) {
     $("#workingIcon").hide();
     $("#reloginForm").show();
 
-    if (getBool(getParameterByName("sessionCleared"))) {
+    var sessionClearedParameter = getParameterByName("sessionCleared");
+
+    if (sessionClearedParameter && getBool(sessionClearedParameter)) {
         if (success) {
             $("#response").text("Logout Succeeded");
         }
         else {
             $("#response").text("Partial Logout - Session Only");
             $("#message").text("Client session cache cleared but failed to clear browser cached credentials");
+            $("#responsePanel").show();
+        }
+    }
+    else if (response) {
+        if (success && response === "Logout complete") {
+            $("#response").text("Logout Succeeded");
+        }
+        else if (success) {
+            $("#response").text("Partial Logout - Browser Credentials Only");
+            $("#message").text("Cleared browser cached credentials but failed to clear client session cache");
+            $("#responsePanel").show();
+        }
+        else {
+            $("#response").text("Failed to Logout");
+            $("#message").text("Failed to clear client session cache and failed to clear browser cached credentials");
             $("#responsePanel").show();
         }
     }
@@ -241,8 +258,8 @@ function logout() {
     persistentStorage.removeItem("passthrough");
 
     // Attempt to clear any credentials cached by browser
-    clearCachedCredentials(clearCredentialsPage, function (success) {
-        logoutComplete(success);
+    clearCachedCredentials(logoutPage, function (success, response) {
+        logoutComplete(success, response);
     });
 }
 

--- a/Source/Libraries/GSF.Web/Security/Scripts/Login.js
+++ b/Source/Libraries/GSF.Web/Security/Scripts/Login.js
@@ -174,7 +174,7 @@ function logoutComplete(success, response) {
     $("#workingIcon").hide();
     $("#reloginForm").show();
 
-    var sessionClearedParameter = getParameterByName("sessionCleared");
+    const sessionClearedParameter = getParameterByName("sessionCleared");
 
     if (sessionClearedParameter && getBool(sessionClearedParameter)) {
         if (success) {

--- a/Source/Libraries/GSF.Web/Security/Views/Login.cshtml
+++ b/Source/Libraries/GSF.Web/Security/Views/Login.cshtml
@@ -64,8 +64,7 @@
             loginPage = options.LoginPage;
         }
 
-        if (!string.IsNullOrWhiteSpace(options.LogoutPage))
-        {
+        if (!string.IsNullOrWhiteSpace(options.LogoutPage)) {
             logoutPage = options.LogoutPage;
         }
 

--- a/Source/Libraries/GSF.Web/Security/Views/Login.cshtml
+++ b/Source/Libraries/GSF.Web/Security/Views/Login.cshtml
@@ -35,6 +35,7 @@
     string redirectPage;
     string authTestPage = AuthenticationOptions.DefaultAuthTestPage;
     string loginPage = AuthenticationOptions.DefaultLoginPage;
+    string logoutPage = AuthenticationOptions.DefaultLogoutPage;
     string clearCredentials = AuthenticationOptions.DefaultClearCredentialsParameter;
     string verificationHeader = AuthenticationOptions.DefaultRequestVerificationToken;
     string verificationValue = Html.RequestVerificationHeaderToken();
@@ -63,6 +64,11 @@
             loginPage = options.LoginPage;
         }
 
+        if (!string.IsNullOrWhiteSpace(options.LogoutPage))
+        {
+            logoutPage = options.LogoutPage;
+        }
+
         if (!string.IsNullOrWhiteSpace(options.ClearCredentialsParameter)) {
             clearCredentials = options.ClearCredentialsParameter;
         }
@@ -83,22 +89,23 @@
         const redirectPage = ""{0}"";
         const securePage = ""{1}"";
         const loginPage = ""{2}"";
-        const clearCredentialsPage = securePage + ""?{3}=true"";
-        const unsecureConnection = {4};
-        const verificationHeader = ""{5}"";
-        const verificationValue = ""{6}"";
-        const useAjaxVerfication = ""{7}"";
-        const redirectPageLabel = ""{8}"";
+        const logoutPage = ""{3}"" + ""?{4}=true"";
+        const unsecureConnection = {5};
+        const verificationHeader = ""{6}"";
+        const verificationValue = ""{7}"";
+        const useAjaxVerfication = ""{8}"";
+        const redirectPageLabel = ""{9}"";
     ",
         /* 0 */ redirectPage.JavaScriptEncode(),
         /* 1 */ authTestPage.JavaScriptEncode(),
         /* 2 */ loginPage.JavaScriptEncode(),
-        /* 3 */ clearCredentials.JavaScriptEncode(),
-        /* 4 */ unsecureConnection.ToString().ToLowerInvariant(),
-        /* 5 */ verificationHeader.JavaScriptEncode(),
-        /* 6 */ verificationValue.JavaScriptEncode(),
-        /* 7 */ useAjaxVerfication.JavaScriptEncode(),
-        /* 8 */ redirectPageLabel.JavaScriptEncode()
+        /* 3 */ logoutPage.JavaScriptEncode(),
+        /* 4 */ clearCredentials.JavaScriptEncode(),
+        /* 5 */ unsecureConnection.ToString().ToLowerInvariant(),
+        /* 6 */ verificationHeader.JavaScriptEncode(),
+        /* 7 */ verificationValue.JavaScriptEncode(),
+        /* 8 */ useAjaxVerfication.JavaScriptEncode(),
+        /* 9 */ redirectPageLabel.JavaScriptEncode()
     );
 }
 <!DOCTYPE html>
@@ -265,11 +272,11 @@
     </div>
     <script src="@Resources.Root/Shared/Scripts/jquery.js"></script>
     <script src="@Resources.Root/Shared/Scripts/bootstrap.js"></script>
-    <script src="@Resources.Root/Shared/Scripts/gsf.web.client.js"></script>
+    <script src="@Resources.Root/Shared/Scripts/gsf.web.client.js?ver=1"></script>
     <script src="@Resources.Root/Security/Scripts/core.js"></script>
     <script src="@Resources.Root/Security/Scripts/sha256.js"></script>
     <script src="@Resources.Root/Security/Scripts/enc-base64.js"></script>
     <script src="@Resources.Root/Security/Scripts/ntlm.js?ver=1"></script>
-    <script src="@Resources.Root/Security/Scripts/Login.js?ver=1"></script>
+    <script src="@Resources.Root/Security/Scripts/Login.js?ver=2"></script>
 </body>
 </html>

--- a/Source/Libraries/GSF.Web/Shared/Scripts/gsf.web.client.js
+++ b/Source/Libraries/GSF.Web/Shared/Scripts/gsf.web.client.js
@@ -136,7 +136,7 @@ function clearCachedCredentials(securedUrl, successCallback) {
         if (successCallback)
             xhr.onreadystatechange = function() {
                 if (this.readyState === XMLHttpRequest.DONE)
-                    successCallback(this.status === 401 || this.status === 403);
+                    successCallback(this.status === 200, this.responseText);
             };
 
         xhr.send();


### PR DESCRIPTION
Adds a `/Security/logout` endpoint to applications using [AuthenticationHandler](https://github.com/GridProtectionAlliance/gsf/blob/master/Source/Libraries/GSF.Web/Security/AuthenticationHandler.cs). Logging out of such applications is as easy as navigating to the endpoint.

This PR also updates `Login.cshtml` to make use of this endpoint automatically, eliminating the need to call [SecurityHub.Logout()](https://github.com/GridProtectionAlliance/gsf/blob/a2f461ae55805b9bde5f50bb0dd75f49b3540574/Source/Libraries/GSF.Web/Security/SecurityHub.cs#L112) in every application. Instead, applications can simply navigate to `/@GSF/Web/Security/Views/Login.cshtml?logout` to get a user-friendly logout page.