### PR TITLE
Fix logic to dispose requeue token source in FileProcessor

### DIFF
--- a/Source/Libraries/GSF.Core/GSF.Core.csproj
+++ b/Source/Libraries/GSF.Core/GSF.Core.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Text\Diff.cs" />
     <Compile Include="Text\DiffMatchPatch.cs" />
     <Compile Include="Text\Patch.cs" />
+    <Compile Include="Threading\ManagedCancellationTokenSource.cs" />
     <Compile Include="Threading\WaitHandleExtensions.cs" />
     <Compile Include="Trackable.cs" />
     <Compile Include="ReusableObjectPool.cs" />

--- a/Source/Libraries/GSF.Core/IO/FileProcessor.cs
+++ b/Source/Libraries/GSF.Core/IO/FileProcessor.cs
@@ -848,20 +848,16 @@ namespace GSF.IO
                 {
                     StopEnumeration();
                     ClearTrackedDirectories();
+                    m_fileWatchTimer.Stop();
+                    m_fileWatchTimer.Dispose();
 
-                    if (!(m_fileWatchTimer is null))
-                        m_fileWatchTimer.Dispose();
+                    Interlocked.Increment(ref m_requeuedFileCount);
+                    m_requeueTokenSource.Cancel();
 
-                    if (!(m_requeueTokenSource is null))
-                    {
-                        Interlocked.Increment(ref m_requeuedFileCount);
-                        m_requeueTokenSource.Cancel();
+                    int requeuedFileCount = Interlocked.Decrement(ref m_requeuedFileCount);
 
-                        int requeuedFileCount = Interlocked.Decrement(ref m_requeuedFileCount);
-
-                        if (requeuedFileCount == 0)
-                            m_requeueTokenSource.Dispose();
-                    }
+                    if (requeuedFileCount == 0)
+                        m_requeueTokenSource.Dispose();
                 }
                 finally
                 {

--- a/Source/Libraries/GSF.Core/Threading/ManagedCancellationTokenSource.cs
+++ b/Source/Libraries/GSF.Core/Threading/ManagedCancellationTokenSource.cs
@@ -1,0 +1,156 @@
+﻿//******************************************************************************************************
+//  ManagedCancellationTokenSource.cs - Gbtc
+//
+//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2021 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Threading;
+
+namespace GSF.Threading
+{
+    /// <summary>
+    /// Implements a reference counter for <see cref="System.Threading.CancellationTokenSource"/> to
+    /// provide thread safety around <see cref="CancellationTokenSource.Dispose()"/>.
+    /// </summary>
+    public class ManagedCancellationTokenSource : IDisposable
+    {
+        #region [ Members ]
+
+        // Nested Types
+        private class DisposeWrapper : IDisposable
+        {
+            private Action DisposeAction { get; }
+
+            public DisposeWrapper(Action disposeAction) =>
+                DisposeAction = disposeAction;
+
+            public void Dispose() =>
+                DisposeAction();
+        }
+
+        // Constants
+        private const int NotDisposed = 0;
+        private const int Disposing = 1;
+        private const int Disposed = 2;
+
+        // Fields
+        private int m_referenceCount = 1;
+        private int m_disposeState = NotDisposed;
+
+        #endregion
+
+        #region [ Constructors ]
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ManagedCancellationTokenSource"/> class.
+        /// </summary>
+        public ManagedCancellationTokenSource()
+            : this(new CancellationTokenSource())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ManagedCancellationTokenSource"/> class.
+        /// </summary>
+        /// <param name="cancellationTokenSourceFactory">Factory function for instantiating the underlying <see cref="System.Threading.CancellationTokenSource"/>.</param>
+        public ManagedCancellationTokenSource(Func<CancellationTokenSource> cancellationTokenSourceFactory)
+            : this(cancellationTokenSourceFactory())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ManagedCancellationTokenSource"/> class.
+        /// </summary>
+        /// <param name="underlyingTokenSource">The <see cref="System.Threading.CancellationTokenSource"/> to be managed.</param>
+        public ManagedCancellationTokenSource(CancellationTokenSource underlyingTokenSource) =>
+            CancellationTokenSource = underlyingTokenSource;
+
+        #endregion
+
+        #region [ Properties ]
+
+        private CancellationTokenSource CancellationTokenSource { get; }
+
+        private bool IsCanceled =>
+            Interlocked.CompareExchange(ref m_disposeState, 0, 0) != NotDisposed;
+
+        #endregion
+
+        #region [ Methods ]
+
+        /// <summary>
+        /// Retrieves the <see cref="System.Threading.CancellationToken"/> used to
+        /// check the state of cancellation.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A disposable object used to control the lifetime of the <paramref name="cancellationToken"/>.</returns>
+        public IDisposable RetrieveToken(out System.Threading.CancellationToken cancellationToken)
+        {
+            if (IsCanceled)
+            {
+                cancellationToken = new System.Threading.CancellationToken(true);
+                return null;
+            }
+
+            Interlocked.Increment(ref m_referenceCount);
+
+            if (IsCanceled)
+            {
+                ReleaseReference();
+                cancellationToken = new System.Threading.CancellationToken(true);
+                return null;
+            }
+
+            cancellationToken = CancellationTokenSource.Token;
+            return new DisposeWrapper(ReleaseReference);
+        }
+
+        /// <summary>
+        /// Cancels the underlying <see cref="System.Threading.CancellationTokenSource"/>
+        /// and schedules it for disposal.
+        /// </summary>
+        public void Dispose()
+        {
+            int disposeState = Interlocked.CompareExchange(ref m_disposeState, Disposing, NotDisposed);
+
+            if (disposeState == NotDisposed)
+            {
+                CancellationTokenSource.Cancel();
+                ReleaseReference();
+            }
+        }
+
+        private void ReleaseReference()
+        {
+            int referenceCount = Interlocked.Decrement(ref m_referenceCount);
+
+            if (referenceCount > 0)
+                return;
+
+            int disposeState = Interlocked.CompareExchange(ref m_disposeState, Disposed, Disposing);
+
+            if (disposeState == Disposing)
+                CancellationTokenSource.Dispose();
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
The `m_requeueTokenSource` variable in FileProcessor was being disposed prematurely due to a logic error in the async processing loop. This was causing errors in the file processors for MiMD and openXDA. However, fixing the logic error introduces a race condition so the logic needed to be redone. This resulted in the creation of the `ManagedCancellationTokenSource` class.