### PR TITLE
Update comments. Create replacement for misnamed "FileName" property

### DIFF
--- a/Source/Libraries/GSF.PQDIF/Logical/ChannelInstance.cs
+++ b/Source/Libraries/GSF.PQDIF/Logical/ChannelInstance.cs
@@ -32,9 +32,9 @@ using GSF.PQDIF.Physical;
 namespace GSF.PQDIF.Logical
 {
     /// <summary>
-    /// Represents a channel instance in a PQDIF file. A channel instance
-    /// resides in an <see cref="ObservationRecord"/>, and is defined by
-    /// a <see cref="ChannelDefinition"/> inside the observation record's
+    /// Represents a channel instance in a PQDIF file. See IEEE 11593-2019 section 5.4.3
+    /// for details. A channel instance resides in an <see cref="ObservationRecord"/>, and 
+    /// is defined by a <see cref="ChannelDefinition"/> inside the observation record's
     /// <see cref="DataSourceRecord"/>.
     /// </summary>
     public class ChannelInstance : IEquatable<ChannelInstance>

--- a/Source/Libraries/GSF.PQDIF/Logical/LogicalParser.cs
+++ b/Source/Libraries/GSF.PQDIF/Logical/LogicalParser.cs
@@ -96,10 +96,10 @@ namespace GSF.PQDIF.Logical
         /// <summary>
         /// Creates a new instance of the <see cref="LogicalParser"/> class.
         /// </summary>
-        /// <param name="fileName">Name of the PQDIF file to be parsed.</param>
-        public LogicalParser(string fileName)
+        /// <param name="filePath">Path to the PQDIF file to be parsed.</param>
+        public LogicalParser(string filePath)
         {
-            m_physicalParser = new PhysicalParser(fileName);
+            m_physicalParser = new PhysicalParser(filePath);
             m_allDataSourceRecords = new List<DataSourceRecord>();
         }
 
@@ -122,17 +122,34 @@ namespace GSF.PQDIF.Logical
         #region [ Properties ]
 
         /// <summary>
-        /// Gets or sets the file name of the PQDIF file to be parsed.
+        /// Gets or sets the file path (not just the name) of the PQDIF file to be parsed.
+        /// Obsolete in favor of <see cref="FilePath"/>.
         /// </summary>
+        [Obsolete("Property is deprecated. Please use FilePath instead.")]
         public string FileName
         {
             get
             {
-                return m_physicalParser.FileName;
+                return m_physicalParser.FilePath;
             }
             set
             {
-                m_physicalParser.FileName = value;
+                m_physicalParser.FilePath = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the file path of the PQDIF file to be parsed.
+        /// </summary>
+        public string FilePath
+        {
+            get
+            {
+                return m_physicalParser.FilePath;
+            }
+            set
+            {
+                m_physicalParser.FilePath = value;
             }
         }
 
@@ -166,7 +183,7 @@ namespace GSF.PQDIF.Logical
         /// <summary>
         /// Opens the parser and parses the <see cref="ContainerRecord"/>.
         /// </summary>
-        /// <exception cref="InvalidOperationException"><see cref="FileName"/> has not been defined.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="FilePath"/> has not been defined.</exception>
         /// <exception cref="NotSupportedException">An unsupported compression mode was defined in the PQDIF file.</exception>
         public void Open()
         {

--- a/Source/Libraries/GSF.PQDIF/Logical/ObservationRecord.cs
+++ b/Source/Libraries/GSF.PQDIF/Logical/ObservationRecord.cs
@@ -175,8 +175,21 @@ namespace GSF.PQDIF.Logical
         }
 
         /// <summary>
-        /// Gets the starting time of the data in the observation record.
+        /// Gets the starting time of the data in the observation record. This time should
+        /// be used as the base time for all relative seconds recorded in the series instances.
         /// </summary>
+        /// <remarks>
+        /// The <see cref="ObservationRecord"/> contains two timestamp fields: <see cref="StartTime"/> and
+        /// <see cref="TimeTriggered"/>. The StartTime is a required part of any Observation, whereas the 
+        /// <see cref="TimeTriggered"/> is optional. 
+        /// 
+        /// The <see cref="StartTime"/> does not have to be the same as the trigger time and can therefore 
+        /// be chosen more or less arbitrarily. For instance, you can choose to record the 
+        /// <see cref="StartTime"/> as the timestamp of the first data point in the observation or the top 
+        /// of an interval in which the data was captured. The trigger time field is more well defined, 
+        /// essentially always representing the point in time at which the data source decided to capture 
+        /// some data in the PQDIF file.
+        /// </remarks>
         public DateTime StartTime
         {
             get
@@ -216,7 +229,8 @@ namespace GSF.PQDIF.Logical
 
 
         /// <summary>
-        /// Gets the time the observation was triggered.
+        /// Gets the time the observation was triggered. For more information regarding recording
+        /// time in PQD files, see <see cref="StartTime"/>.
         /// </summary>
         public DateTime TimeTriggered
         {

--- a/Source/Libraries/GSF.PQDIF/Physical/PhysicalParser.cs
+++ b/Source/Libraries/GSF.PQDIF/Physical/PhysicalParser.cs
@@ -131,8 +131,6 @@ namespace GSF.PQDIF.Physical
             public override ElementType TypeOfElement => m_typeOfElement;
         }
 
-        // Fields
-        private string m_fileName;
         private BinaryReader m_fileReader;
         private CompressionStyle m_compressionStyle;
         private CompressionAlgorithm m_compressionAlgorithm;
@@ -149,11 +147,11 @@ namespace GSF.PQDIF.Physical
         /// <summary>
         /// Creates a new instance of the <see cref="PhysicalParser"/> class.
         /// </summary>
-        /// <param name="fileName">Name of the PQDIF file to be parsed.</param>
-        public PhysicalParser(string fileName)
+        /// <param name="filePath">Path to the PQDIF file to be parsed.</param>
+        public PhysicalParser(string filePath)
             : this()
         {
-            FileName = fileName;
+            FilePath = filePath;
         }
 
         /// <summary>
@@ -180,19 +178,19 @@ namespace GSF.PQDIF.Physical
         #region [ Properties ]
 
         /// <summary>
-        /// Gets or sets the file name of the PQDIF file to be parsed.
+        /// Gets or sets the file path (not just the name) of the PQDIF file to be parsed.
+        /// Obsolete in favor of <see cref="FilePath"/>.
         /// </summary>
-        public string FileName
-        {
-            get
-            {
-                return m_fileName;
-            }
-            set
-            {
-                m_fileName = value;
-            }
+        [Obsolete("Property is deprecated. Please use FilePath instead.")]
+        public string FileName {
+            get { return FilePath; }
+            set { FilePath = value; }
         }
+
+        /// <summary>
+        /// Gets or sets the file path of the PQDIF file to be parsed.
+        /// </summary>
+        public string FilePath { get; set; }
 
         /// <summary>
         /// Gets all the exceptions encountered while parsing.
@@ -279,15 +277,15 @@ namespace GSF.PQDIF.Physical
         /// <summary>
         /// Opens the PQDIF file.
         /// </summary>
-        /// <exception cref="InvalidOperationException"><see cref="FileName"/> has not been defined.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="FilePath"/> has not been defined.</exception>
         public void Open()
         {
-            if ((object)m_fileName == null)
+            if ((object)FilePath == null)
                 throw new InvalidOperationException("Unable to open PQDIF file when no file name has been defined.");
 
             using (m_fileReader)
             {
-                m_fileReader = new BinaryReader(File.OpenRead(m_fileName));
+                m_fileReader = new BinaryReader(File.OpenRead(FilePath));
             }
 
             m_hasNextRecord = true;


### PR DESCRIPTION
Deprecate the "FileName" property in the parser layer in favor of the more correct "FilePath" (leaving the previous for backward compatibility).