### PR TITLE
Disable form autocompletion by default on paged view model

### DIFF
--- a/Source/Libraries/GSF.Web/Model/Views/PagedViewModel.cshtml
+++ b/Source/Libraries/GSF.Web/Model/Views/PagedViewModel.cshtml
@@ -255,7 +255,7 @@
                 </h4>
             </div>
             <div class="modal-body auto-height" data-bind="with: currentRecord, validationOptions: {messageTemplate: 'validationMessageTemplate'}, css: {'modal-readonly': recordMode()===RecordMode.View}">
-                <form role="form">
+                <form role="form" @((ViewBag.AddNewEditAutocomplete ?? false) ? "" : "autocomplete=\"off\"")>
                     @Raw(ViewBag.AddNewEditDialog)
                 </form>
             </div>


### PR DESCRIPTION
This solves issues where form autocompletion would autofill credentials for things like field devices and file shares using the browser's credentials. This change disables autocompletion by default so paged view models will have to opt-in to get form autocompletion.

https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion