### PR TITLE
Copy root query restriction parameters in each TableOperations instance

### DIFF
--- a/Source/Libraries/GSF.Core/Data/Model/TableOperations.cs
+++ b/Source/Libraries/GSF.Core/Data/Model/TableOperations.cs
@@ -170,7 +170,9 @@ namespace GSF.Data.Model
             // Establish any modeled root query restriction parameters
             if ((object)s_rootQueryRestrictionAttribute != null)
             {
-                RootQueryRestriction = new RecordRestriction(s_rootQueryRestrictionAttribute.FilterExpression, s_rootQueryRestrictionAttribute.Parameters);
+                // Copy parameters array so that modifications to parameter values do not affect other instances
+                object[] parameters = s_rootQueryRestrictionAttribute.Parameters.ToArray();
+                RootQueryRestriction = new RecordRestriction(s_rootQueryRestrictionAttribute.FilterExpression, parameters);
                 ApplyRootQueryRestrictionToUpdates = s_rootQueryRestrictionAttribute.ApplyToUpdates;
                 ApplyRootQueryRestrictionToDeletes = s_rootQueryRestrictionAttribute.ApplyToDeletes;
             }


### PR DESCRIPTION
In a situation like the following where the root query restriction is intended to be modified by the user at runtime...

```c#
[RootQueryRestriction("MyField = {0}", 0)]
public class MyModel
{
    ...
}
```

```c#
TableOperations<MyModel> myTable = new TableOperations<MyModel>(connection);
myTable.RootQueryRestriction.Parameters[0] = myValue;
IEnumerable<MyModel> records = myTable.QueryRecords();
...
```

Without the change in this PR, every instance of `TableOperations<MyModel>` is using the same array instance for its `Parameters` array, so updating that value has a universal effect. This change prevents the update from inadvertently affecting other instances of `TableOperations<MyModel>`. However, it could also be argued that the attribute should be used only for static query restrictions and that the user should instead use the following pattern to apply the restriction at runtime.

```c#
TableOperations<MyModel> myTable = new TableOperations<MyModel>(connection);
myTable.RootQueryRestriction = new RecordRestriction("MyField = {0}", myValue);
IEnumerable<MyModel> records = myTable.QueryRecords();
...
```