### PR TITLE
GSF.Core: Fix GetValue() function for 24-bit integers

### DIFF
--- a/Source/Libraries/GSF.Core.Shared/Int24.cs
+++ b/Source/Libraries/GSF.Core.Shared/Int24.cs
@@ -1468,15 +1468,15 @@ namespace GSF
             int valueInt;
             if (BitConverter.IsLittleEndian)
             {
-                valueInt = value[0] |
-                         value[1] << 8 |
-                         value[2] << 16;
+                valueInt = value[startIndex] |
+                         value[startIndex + 1] << 8 |
+                         value[startIndex + 2] << 16;
             }
             else
             {
-                valueInt = value[0] << 16 |
-                         value[1] << 8 |
-                         value[2];
+                valueInt = value[startIndex] << 16 |
+                         value[startIndex + 1] << 8 |
+                         value[startIndex + 2];
 
             }
             // Deserialize value

--- a/Source/Libraries/GSF.Core.Shared/UInt24.cs
+++ b/Source/Libraries/GSF.Core.Shared/UInt24.cs
@@ -1489,15 +1489,15 @@ namespace GSF
             int valueInt;
             if (BitConverter.IsLittleEndian)
             {
-                valueInt = value[0] |
-                         value[1] << 8 |
-                         value[2] << 16;
+                valueInt = value[startIndex] |
+                         value[startIndex + 1] << 8 |
+                         value[startIndex + 2] << 16;
             }
             else
             {
-                valueInt = value[0] << 16 |
-                         value[1] << 8 |
-                         value[2];
+                valueInt = value[startIndex] << 16 |
+                         value[startIndex + 1] << 8 |
+                         value[startIndex + 2];
 
             }
             // Deserialize value


### PR DESCRIPTION
Fixes migrated from gemstone:
https://github.com/gemstone/numeric/pull/4
https://github.com/gemstone/numeric/pull/5