### PR TITLE
GSF.Core: Clear watcher thread when FileProcessor is disposed to help prevent ObjectDisposedExceptions

### DIFF
--- a/Source/Libraries/GSF.Core/IO/FileProcessor.cs
+++ b/Source/Libraries/GSF.Core/IO/FileProcessor.cs
@@ -848,6 +848,7 @@ namespace GSF.IO
                 {
                     StopEnumeration();
                     ClearTrackedDirectories();
+                    m_watcherThread.Clear();
                     m_fileWatchTimer.Stop();
                     m_fileWatchTimer.Dispose();
                     m_requeueTokenSource.Dispose();


### PR DESCRIPTION
In openXDA, a massive flood of `Watcher_Changed` events caused a massive backlog of actions to build up on the watcher thread, which then caused a massive flood of `ObjectDisposedException`s to be thrown when working through that backlog after the `FileProcessor` was disposed. Forcefully clearing the thread's queue of actions should help prevent that, and doing so after detaching from events in `ClearTrackedDirectories()` should prevent more actions from queuing up in the meantime.