### PR TITLE
GSF.InstallerActions: Fix command used to remove HTTP namespace reservations

### DIFF
--- a/Source/Libraries/GSF.InstallerActions/CustomActions.cs
+++ b/Source/Libraries/GSF.InstallerActions/CustomActions.cs
@@ -914,7 +914,7 @@ namespace GSF.InstallerActions
         private static void RemoveHttpNamespaceReservation(string endPoint)
         {
             // Vista, Windows 2008, Window 7, etc use "netsh" for reservations
-            string parameters = $@"http delete urlacl url=http://{endPoint}";
+            string parameters = $@"http delete urlacl url=http://{endPoint}/";
 
             ProcessStartInfo psi = new("netsh", parameters)
             {


### PR DESCRIPTION
Without the trailing slash, the reservation doesn't get removed.

```
C:\WINDOWS\system32>netsh http add urlacl http://+:8989/ user=GPA\Testing

URL reservation successfully added


C:\WINDOWS\system32>netsh http delete urlacl http://+:8989

URL reservation delete failed, Error: 87
The parameter is incorrect.



C:\WINDOWS\system32>netsh http delete urlacl http://+:8989/

URL reservation successfully deleted
```