### PR TITLE
Skip NULL values in JoinKeyValuePairs

### DIFF
--- a/Source/Libraries/GSF.Core.Shared/StringExtensions.cs
+++ b/Source/Libraries/GSF.Core.Shared/StringExtensions.cs
@@ -358,7 +358,6 @@ namespace GSF
 
             foreach (string key in pairs.Keys)
             {
-               
                 value = pairs[key];
                 
                 if (value is null)

--- a/Source/Libraries/GSF.Core.Shared/StringExtensions.cs
+++ b/Source/Libraries/GSF.Core.Shared/StringExtensions.cs
@@ -358,7 +358,11 @@ namespace GSF
 
             foreach (string key in pairs.Keys)
             {
+               
                 value = pairs[key];
+                
+                if (value is null)
+                    continue;
 
                 if (value.IndexOfAny(delimiters) >= 0)
                     value = startValueDelimiter + value + endValueDelimiter;


### PR DESCRIPTION
After discussing with Stephen this seemed like the best course of action if a value is `NULL`.
Currently it throws a `NullReferenceException` which causes problems.

We did discuss using an empty string in this case, but that may cause issues if something is trying to parse it into something else later on. In theory a `NULL` setting should now default to the default value of the setting (same as if it was not specified at all)