### PR TITLE
Fixed component subtypes for projects

### DIFF
--- a/Source/Libraries/GSF.Communication/GSF.Communication.csproj
+++ b/Source/Libraries/GSF.Communication/GSF.Communication.csproj
@@ -105,7 +105,9 @@
     <Compile Include="ServerBase.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="TlsClient.cs" />
+    <Compile Include="TlsClient.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="TlsServer.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/Source/Libraries/GSF.Windows/GSF.Windows.csproj
+++ b/Source/Libraries/GSF.Windows/GSF.Windows.csproj
@@ -75,7 +75,9 @@
     <Compile Include="ErrorManagement\ErrorDialog.Designer.cs">
       <DependentUpon>ErrorDialog.cs</DependentUpon>
     </Compile>
-    <Compile Include="ErrorManagement\ErrorLogger.cs" />
+    <Compile Include="ErrorManagement\ErrorLogger.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Forms\AboutDialog.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
This fixes GSF.Communictation and GSF.Windows `.csproj` files - newer VS versions are picky about this component subtype parameter.