### PR TITLE
GSF.TimeSeries: Fixed HistorianMetadata SQL views

### DIFF
--- a/Source/Libraries/GSF.TimeSeries/Data/MySQL/GSFSchema.sql
+++ b/Source/Libraries/GSF.TimeSeries/Data/MySQL/GSFSchema.sql
@@ -1161,7 +1161,8 @@ CREATE VIEW HistorianMetadata
 AS
 SELECT PointID AS HistorianID, IF(SignalAcronym = N'DIGI', 1, 0) AS DataType, PointTag AS Name, SignalReference AS Synonym1, 
     SignalAcronym AS Synonym2, AlternateTag AS Synonym3, Description, VendorDeviceDescription AS HardwareInfo, N'' AS Remarks, 
-    HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled, 1 / FramesPerSecond AS ScanRate, 
+    HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled,
+    IF(FramesPerSecond = 0, 1.0, 1.0 / FramesPerSecond) AS ScanRate, 
     0 AS CompressionMinTime, 0 AS CompressionMaxTime, EngineeringUnits,
     CASE SignalAcronym WHEN N'FREQ' THEN 59.95 WHEN N'VPHM' THEN 475000 WHEN N'IPHM' THEN 0 WHEN N'VPHA' THEN -181 WHEN N'IPHA' THEN -181 ELSE 0 END AS LowWarning,
     CASE SignalAcronym WHEN N'FREQ' THEN 60.05 WHEN N'VPHM' THEN 525000 WHEN N'IPHM' THEN 3150 WHEN N'VPHA' THEN 181 WHEN N'IPHA' THEN 181 ELSE 0 END AS HighWarning,

--- a/Source/Libraries/GSF.TimeSeries/Data/Oracle/GSFSchema.sql
+++ b/Source/Libraries/GSF.TimeSeries/Data/Oracle/GSFSchema.sql
@@ -1553,7 +1553,8 @@ CREATE VIEW HistorianMetadata
 AS
 SELECT PointID AS HistorianID, CASE SignalAcronym WHEN 'DIGI' THEN 1 ELSE 0 END AS DataType, PointTag AS Name, SignalReference AS Synonym1, 
     SignalAcronym AS Synonym2, AlternateTag AS Synonym3, Description, VendorDeviceDescription AS HardwareInfo, '' AS Remarks, 
-    HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled, CAST(1 / FramesPerSecond AS NUMBER(10,10)) AS ScanRate, 
+    HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled, 
+    CASE WHEN FramesPerSecond = 0 THEN CAST(1.0 AS NUMBER(10,10)) ELSE CAST(1 / FramesPerSecond AS NUMBER(10,10)) END AS ScanRate,
     0 AS CompressionMinTime, 0 AS CompressionMaxTime, EngineeringUnits,
     CASE SignalAcronym WHEN 'FREQ' THEN 59.95 WHEN 'VPHM' THEN 475000 WHEN 'IPHM' THEN 0 WHEN 'VPHA' THEN -181 WHEN 'IPHA' THEN -181 ELSE 0 END AS LowWarning,
     CASE SignalAcronym WHEN 'FREQ' THEN 60.05 WHEN 'VPHM' THEN 525000 WHEN 'IPHM' THEN 3150 WHEN 'VPHA' THEN 181 WHEN 'IPHA' THEN 181 ELSE 0 END AS HighWarning,

--- a/Source/Libraries/GSF.TimeSeries/Data/PostgreSQL/GSFSchema.sql
+++ b/Source/Libraries/GSF.TimeSeries/Data/PostgreSQL/GSFSchema.sql
@@ -1076,7 +1076,8 @@ CREATE VIEW HistorianMetadata
 AS
 SELECT PointID AS HistorianID, CASE WHEN SignalAcronym = 'DIGI' THEN 1 ELSE 0 END AS DataType, PointTag AS Name, SignalReference AS Synonym1, 
 SignalAcronym AS Synonym2, AlternateTag AS Synonym3, Description, VendorDeviceDescription AS HardwareInfo, ''::VARCHAR(512) AS Remarks, 
-HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled, 1.0 / FramesPerSecond AS ScanRate, 
+HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled, 
+CASE WHEN FramesPerSecond = 0 THEN 1.0 ELSE 1.0 / FramesPerSecond END AS ScanRate,
 0 AS CompressionMinTime, 0 AS CompressionMaxTime, EngineeringUnits,
 CASE SignalAcronym WHEN 'FREQ' THEN 59.95 WHEN 'VPHM' THEN 475000 WHEN 'IPHM' THEN 0 WHEN 'VPHA' THEN -181 WHEN 'IPHA' THEN -181 ELSE 0 END AS LowWarning,
 CASE SignalAcronym WHEN 'FREQ' THEN 60.05 WHEN 'VPHM' THEN 525000 WHEN 'IPHM' THEN 3150 WHEN 'VPHA' THEN 181 WHEN 'IPHA' THEN 181 ELSE 0 END AS HighWarning,

--- a/Source/Libraries/GSF.TimeSeries/Data/SQL Server/GSFSchema.sql
+++ b/Source/Libraries/GSF.TimeSeries/Data/SQL Server/GSFSchema.sql
@@ -2277,7 +2277,7 @@ SELECT
     SystemName              = DeviceAcronym,
     SourceID                = ProtocolID,
     Enabled                 = Enabled,
-    ScanRate                = 1.0 / FramesPerSecond,
+    ScanRate                = CASE WHEN FramesPerSecond = 0 THEN 1.0 ELSE 1.0 / FramesPerSecond END,
     CompressionMinTime      = 0,
     CompressionMaxTime      = 0,
     EngineeringUnits        = EngineeringUnits,

--- a/Source/Libraries/GSF.TimeSeries/Data/SQLite/GSFSchema.sql
+++ b/Source/Libraries/GSF.TimeSeries/Data/SQLite/GSFSchema.sql
@@ -1067,7 +1067,8 @@ CREATE VIEW HistorianMetadata
 AS
 SELECT PointID AS HistorianID, CASE WHEN SignalAcronym = 'DIGI' THEN 1 ELSE 0 END AS DataType, PointTag AS Name, SignalReference AS Synonym1, 
 SignalAcronym AS Synonym2, AlternateTag AS Synonym3, Description, VendorDeviceDescription AS HardwareInfo, '' AS Remarks, 
-HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled, 1.0 / FramesPerSecond AS ScanRate, 
+HistorianAcronym AS PlantCode, 1 AS UnitNumber, DeviceAcronym AS SystemName, ProtocolID AS SourceID, Enabled,
+CASE WHEN FramesPerSecond = 0 THEN 1.0 ELSE 1.0 / FramesPerSecond END AS ScanRate,
 0 AS CompressionMinTime, 0 AS CompressionMaxTime, EngineeringUnits,
 CASE SignalAcronym WHEN 'FREQ' THEN 59.95 WHEN 'VPHM' THEN 475000 WHEN 'IPHM' THEN 0 WHEN 'VPHA' THEN -181 WHEN 'IPHA' THEN -181 ELSE 0 END AS LowWarning,
 CASE SignalAcronym WHEN 'FREQ' THEN 60.05 WHEN 'VPHM' THEN 525000 WHEN 'IPHM' THEN 3150 WHEN 'VPHA' THEN 181 WHEN 'IPHA' THEN 181 ELSE 0 END AS HighWarning,

--- a/Source/Tools/AdapterExplorer/AdapterExplorer.csproj
+++ b/Source/Tools/AdapterExplorer/AdapterExplorer.csproj
@@ -61,9 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MainForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Include="MainForm.cs" />
     <Compile Include="MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
When `FramesPerSecond` is zero, the `HistorianMetadata` view can/will fail. 
This PR makes sure view does not fail for each SQL database represented.