### PR TITLE
GSF.ServiceProcess: Pass client ID into ServiceHelper status update queue

### DIFF
--- a/Source/Libraries/GSF.ServiceProcess/ServiceHelper.cs
+++ b/Source/Libraries/GSF.ServiceProcess/ServiceHelper.cs
@@ -1721,7 +1721,7 @@ namespace GSF.ServiceProcess
         [StringFormatMethod("message")]
         public void UpdateStatusAppendLine(Guid client, UpdateType type, string message, params object[] args)
         {
-            UpdateStatus(type, $"{message}\r\n", args);
+            UpdateStatus(client, type, $"{message}\r\n", args);
         }
 
         /// <summary>


### PR DESCRIPTION
Caught this bug while investigating a separate issue in MiMD.