### PR TITLE
GSF.Core.Shared.ArrayExtensions.CountOfSequence extension and Tests

### DIFF
--- a/Source/Libraries/Tests/GSF.Core.Shared.Tests/ArrayExtensionsTest.cs
+++ b/Source/Libraries/Tests/GSF.Core.Shared.Tests/ArrayExtensionsTest.cs
@@ -1,0 +1,116 @@
+﻿//******************************************************************************************************
+//  ArrayExtensionsTest.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://www.opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/27/2023 - AJ Stadlin
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GSF.Core.Shared.Tests
+{
+    [TestClass]
+    public class ArrayExtensionsTest
+    {
+        public TestContext TestContext { get; set; }
+
+        private const string TestString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789GHI";
+
+        /// <summary>
+        /// Count the instances of a sequence in the array
+        /// When the sequence is not found
+        /// </summary>
+        [TestMethod]
+        public void CountOfSequence0NotFound()
+        {
+            const string lookFor = "def";
+            int actual = TestString.ToArray().CountOfSequence(lookFor.ToCharArray(), 0);
+            int expected = 0;
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Count the instances of a sequence in the array
+        /// When the sequence is found at the start of the array
+        /// </summary>
+        [TestMethod]
+        public void CountOfSequence1AtIndex0()
+        {
+            const string lookFor = "ABC";
+            int actual = TestString.ToArray().CountOfSequence(lookFor.ToCharArray(), 0);
+            int expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Count the instances of a sequence in the array
+        /// When the sequence is found in the middle of the array
+        /// </summary>
+        [TestMethod]
+        public void CountOfSequence1Mid()
+        {
+            const string lookFor = "DEF";
+            int actual = TestString.ToArray().CountOfSequence(lookFor.ToCharArray(), 0);
+            int expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Count the instances of a sequence in the array
+        /// When search starts in the middle of the array
+        /// And the sequence is found at the end of the array
+        /// </summary>
+        [TestMethod]
+        public void CountOfSequence1Start20MidAndEnd()
+        {
+            const string lookFor = "GHI";
+            int actual = TestString.ToArray().CountOfSequence(lookFor.ToCharArray(), 20);
+            int expected = 1;
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Count the instances of a sequence in the array
+        /// When multiple instances of the sequence are found
+        /// </summary>
+        [TestMethod]
+        public void CountOfSequence2MidAndEnd()
+        {
+            const string lookFor = "GHI";
+            int actual = TestString.ToArray().CountOfSequence(lookFor.ToCharArray(), 0);
+            int expected = 2;
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// Count the instances of a sequence in the array
+        /// When search starts in the middle of the array
+        /// And multiple instances of the sequence are found
+        /// </summary>
+        [TestMethod]
+        public void CountOfSequence2Start5MidAndEnd()
+        {
+            const string lookFor = "GHI";
+            int actual = TestString.ToArray().CountOfSequence(lookFor.ToCharArray(), 5);
+            int expected = 2;
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/Source/Libraries/Tests/GSF.Core.Shared.Tests/GSF.Core.Shared.Tests.csproj
+++ b/Source/Libraries/Tests/GSF.Core.Shared.Tests/GSF.Core.Shared.Tests.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{55EDF2C5-79EA-4667-A479-C71F4DC95351}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GSF.Core.Shared.Tests</RootNamespace>
+    <AssemblyName>GSF.Core.Shared.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\..\Build\Output\Debug\Tests\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\..\Build\Output\Release\Tests\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mono|AnyCPU'">
+    <OutputPath>..\..\..\..\Build\Output\Mono\Tests\</OutputPath>
+    <DefineConstants>TRACE;MONO</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration.Install" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ArrayExtensionsTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Adapters\CsvAdapters\CsvAdapters.csproj">
+      <Project>{a8861372-0fe2-45e5-9ded-73b55ac4196c}</Project>
+      <Name>CsvAdapters</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GSF.Communication\GSF.Communication.csproj">
+      <Project>{2b2eb9be-e6a9-406f-bfe6-ff46dd6bd264}</Project>
+      <Name>GSF.Communication</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GSF.Core\GSF.Core.csproj">
+      <Project>{FF3FCBA6-F01A-4EC2-BC3F-6BA832AFCF88}</Project>
+      <Name>GSF.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GSF.TimeSeries\GSF.TimeSeries.csproj">
+      <Project>{412f9f59-d9b9-4c8e-96d2-20492644198c}</Project>
+      <Name>GSF.TimeSeries</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Libraries/Tests/GSF.Core.Shared.Tests/Properties/AssemblyInfo.cs
+++ b/Source/Libraries/Tests/GSF.Core.Shared.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,64 @@
+﻿//******************************************************************************************************
+//  AssemblyInfo.cs - Gbtc
+//
+//  Copyright © 2013, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://www.opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  05/09/2013 - J. Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GSF.Core.Shared.Tests")]
+[assembly: AssemblyDescription("GSF Core.Shared Test Assembly")]
+[assembly: AssemblyCompany("Grid Protection Alliance")]
+[assembly: AssemblyProduct("Grid Solutions Framework")]
+[assembly: AssemblyCopyright("Copyright © GPA, 2013.  All Rights Reserved.")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Assembly manifest attributes.
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug Build")]
+#else
+[assembly: AssemblyConfiguration("Release Build")]
+#endif
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8cbc9ff6-34ef-4b01-a42b-ff59d741f4c5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("2.4.158.0")]
+[assembly: AssemblyFileVersion("2.4.158.0")]
+[assembly: AssemblyInformationalVersion("2.4.158-beta")]


### PR DESCRIPTION
Added new CountOfSequence extensions to ArrayExtensions.

Array.CountOfSequence returns the count of instances a sequence can be found in an Array.

Usage is similar to the IndexOfSequence extensions that return the location of a sequence in an Array.

Also added is GSF.Core.Shared.Tests with unit tests for the ArrayExtensions.CountOfSequence extension.

Review and feedback are welcome!

//AJ