### PR TITLE
View only field

### DIFF
--- a/Source/Libraries/GSF.Core/Data/Model/TableOperations.cs
+++ b/Source/Libraries/GSF.Core/Data/Model/TableOperations.cs
@@ -2279,6 +2279,7 @@ namespace GSF.Data.Model
 
                 property.TryGetAttribute(out PrimaryKeyAttribute primaryKeyAttribute);
                 property.TryGetAttribute(out SearchableAttribute searchableAttribute);
+                bool isViewOnlny = property.AttributeExists<PropertyInfo, ViewOnlyFieldAttribute>();
 
                 if (property.TryGetAttribute(out EncryptDataAttribute encryptDataAttribute) && property.PropertyType == typeof(string))
                 {
@@ -2316,7 +2317,7 @@ namespace GSF.Data.Model
                     {
                         s_hasPrimaryKeyIdentityField = true;
                     }
-                    else
+                    else if (!isViewOnlny)
                     {
                         addNewFields.Append($"{(addNewFields.Length > 0 ? ", " : "")}{fieldName}");
                         addNewFormat.Append($"{(addNewFormat.Length > 0 ? ", " : "")}{{{addNewFieldIndex++}}}");
@@ -2327,7 +2328,7 @@ namespace GSF.Data.Model
                     primaryKeyFields.Append($"{(primaryKeyFields.Length > 0 ? ", " : "")}{fieldName}");
                     primaryKeyProperties.Add(property);
                 }
-                else
+                else if (!isViewOnlny)
                 {
                     addNewFields.Append($"{(addNewFields.Length > 0 ? ", " : "")}{fieldName}");
                     addNewFormat.Append($"{(addNewFormat.Length > 0 ? ", " : "")}{{{addNewFieldIndex++}}}");

--- a/Source/Libraries/GSF.Core/Data/Model/ViewOnlyFieldAttribute.cs
+++ b/Source/Libraries/GSF.Core/Data/Model/ViewOnlyFieldAttribute.cs
@@ -1,0 +1,33 @@
+﻿//******************************************************************************************************
+//  ViewOnlyFieldAttribute.cs - Gbtc
+//
+//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/29/2023 - Gabriel Santos
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+
+namespace GSF.Data.Model
+{
+    /// <summary>
+    /// Defines an attribute that will allow setting view only record field.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple=false)]
+    public sealed class ViewOnlyFieldAttribute : Attribute { }
+}

--- a/Source/Libraries/GSF.Core/GSF.Core.csproj
+++ b/Source/Libraries/GSF.Core/GSF.Core.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Data\Model\DefaultSortOrderAttribute.cs" />
     <Compile Include="Data\Model\DeleteRolesAttribute.cs" />
     <Compile Include="Data\Model\ReturnLimitAttribute.cs" />
+    <Compile Include="Data\Model\ViewOnlyFieldAttribute.cs" />
     <Compile Include="Data\Model\ViewOnlyAttribute.cs" />
     <Compile Include="Data\Model\AllowSearchAttribute.cs" />
     <Compile Include="Data\Model\CustomViewAttribute.cs" />


### PR DESCRIPTION
Addition of view only fields for a couple of reasons:
   1. It's cumbersome to add custom endpoints for custom view that just pull in slightly more information on model controllers.
   2. There is a legitimate use-case for fields that don't make sense to be updated within openXDA, such as primary keys. The primary key use-case is covered, but the use case of similar generated fields is not.