### PR TITLE
Fixed Azure query to match email instead of ID

### DIFF
--- a/Source/Libraries/GSF.Security/AdoSecurityProvider.cs
+++ b/Source/Libraries/GSF.Security/AdoSecurityProvider.cs
@@ -441,9 +441,7 @@ namespace GSF.Security
                         try
                         {
                             // Load user data - note that external users need to be looked up by userPrincipalName
-                            User user = userData.Username.Contains("#EXT#") ? 
-                                graphClient.Users.Request().Filter($"userPrincipalName eq '{userData.Username}'").GetAsync().Result.FirstOrDefault() : 
-                                graphClient.Users[userData.Username].Request().GetAsync().Result;
+                            User user = graphClient.Users.Request().Filter($"mail eq '{userData.Username}'").GetAsync().Result.FirstOrDefault();
 
                             if (user is null)
                                 throw new SecurityException($"Failed to load user \"{userData.Username}\" from Azure AD application \"{config.ClientID}\".");
@@ -792,9 +790,7 @@ namespace GSF.Security
                                     try
                                     {
                                         // Load user data in application context - note that external users need to be looked up by userPrincipalName
-                                        User user = username.Contains("#EXT#") ?
-                                            graphClient.Users.Request().Filter($"userPrincipalName eq '{username}'").GetAsync().Result.FirstOrDefault() :
-                                            graphClient.Users[username].Request().GetAsync().Result;
+                                        User user = graphClient.Users.Request().Filter($"mail eq '{username}'").GetAsync().Result.FirstOrDefault();
 
                                         isAuthenticated = user is not null;
                                     }

--- a/Source/Libraries/GSF.Web/Security/SecurityHub.cs
+++ b/Source/Libraries/GSF.Web/Security/SecurityHub.cs
@@ -450,7 +450,7 @@ namespace GSF.Web.Security
                 return false;
 
             // Load user data - note that external users need to be looked up by userPrincipalName
-            User user = (await graphClient.Users.Request().Filter($"mail eq '{userName}'").GetAsync()).FirstOrDefault() 
+            User user = (await graphClient.Users.Request().Filter($"mail eq '{userName}'").GetAsync()).FirstOrDefault();
             return user is not null;
         }
 

--- a/Source/Libraries/GSF.Web/Security/SecurityHub.cs
+++ b/Source/Libraries/GSF.Web/Security/SecurityHub.cs
@@ -450,10 +450,7 @@ namespace GSF.Web.Security
                 return false;
 
             // Load user data - note that external users need to be looked up by userPrincipalName
-            User user = userName.Contains("#EXT#") ? 
-                (await graphClient.Users.Request().Filter($"userPrincipalName eq '{userName}'").GetAsync()).FirstOrDefault() :
-                await graphClient.Users[userName].Request().GetAsync();
-
+            User user = (await graphClient.Users.Request().Filter($"mail eq '{userName}'").GetAsync()).FirstOrDefault() 
             return user is not null;
         }
 


### PR DESCRIPTION
Changed ADOSecurity Provider to use email field to match users instead of ID. That way we don't have to add `#Ext#` anywhere