### PR TITLE
Updated SQLSearchModifier to return string

### DIFF
--- a/Source/Libraries/GSF.Web/Model/ModelController.cs
+++ b/Source/Libraries/GSF.Web/Model/ModelController.cs
@@ -521,11 +521,10 @@ namespace GSF.Web.Model
                         search.SearchText = search.SearchText.Replace("*", "%");
                 }
 
-                SQLSearchFilter updated = search;
                 if (SQLSearchModifier is not null)
-                    updated = (SQLSearchFilter)SQLSearchModifier.Invoke(null, new[] { search });
-
-                clauses.Add(updated.GenerateConditional(parameters));
+                    clauses.Add((string)SQLSearchModifier.Invoke(null, new[] { search, parameters }));
+                else
+                    clauses.Add(search.GenerateConditional(parameters));
             }
 
             return string.Join(" AND ", clauses);

--- a/Source/Libraries/GSF.Web/Model/ModelController.cs
+++ b/Source/Libraries/GSF.Web/Model/ModelController.cs
@@ -522,7 +522,7 @@ namespace GSF.Web.Model
                 }
 
                 if (SQLSearchModifier is not null)
-                    clauses.Add((string)SQLSearchModifier.Invoke(null, new[] { search, parameters }));
+                    clauses.Add((string)SQLSearchModifier.Invoke(null, new object[] { search, parameters }));
                 else
                     clauses.Add(search.GenerateConditional(parameters));
             }


### PR DESCRIPTION
I realized the whole point of the `SQLSearchModifier` is to generate complex conditions that won't work inside a `SQLSearch`object with SQL injection avoidance. 