### PR TITLE
GSF-4 TSFManager localization fixes

### DIFF
--- a/Source/Applications/TsfManager/App.xaml.cs
+++ b/Source/Applications/TsfManager/App.xaml.cs
@@ -24,11 +24,13 @@
 //******************************************************************************************************
 
 using System;
+using System.Globalization;
 using System.Security.Principal;
 using System.Windows;
-using GSF.Windows.ErrorManagement;
+using System.Windows.Markup;
 using GSF.Reflection;
 using GSF.TimeSeries.UI;
+using GSF.Windows.ErrorManagement;
 
 namespace TsfManager
 {
@@ -54,6 +56,7 @@ namespace TsfManager
         public App()
         {
             AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
+            Current.Startup += Application_Startup;
 
             m_errorLogger = new ErrorLogger
             {
@@ -97,6 +100,12 @@ namespace TsfManager
         #endregion
 
         #region [ Methods ]
+
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            XmlLanguage xmlLanguage = XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag);
+            FrameworkElement.LanguageProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(xmlLanguage));
+        }
 
         private string ErrorText()
         {

--- a/Source/Applications/TsfManager/App.xaml.cs
+++ b/Source/Applications/TsfManager/App.xaml.cs
@@ -28,6 +28,7 @@ using System.Globalization;
 using System.Security.Principal;
 using System.Windows;
 using System.Windows.Markup;
+using GSF.Diagnostics;
 using GSF.Reflection;
 using GSF.TimeSeries.UI;
 using GSF.Windows.ErrorManagement;
@@ -103,8 +104,15 @@ namespace TsfManager
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
-            XmlLanguage xmlLanguage = XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag);
-            FrameworkElement.LanguageProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(xmlLanguage));
+            try
+            {
+                XmlLanguage xmlLanguage = XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.Name);
+                FrameworkElement.LanguageProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(xmlLanguage));
+            }
+            catch (Exception ex)
+            {
+                Logger.SwallowException(ex);
+            }
         }
 
         private string ErrorText()

--- a/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/Device.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/Device.cs
@@ -314,7 +314,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
         /// Gets or sets <see cref="Device"/> Longitude.
         /// </summary>
         // Because of database design, no validation attributes are applied.        
-        [RegularExpression(@"^[-]?([0-9]{1,3})?([.][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in decimal(9,6) format.")]
+        [RegularExpression(@"^[-]?([0-9]{1,3})?([.,][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in decimal(9,6) format.")]
         public decimal? Longitude
         {
             get => m_longitude;
@@ -329,7 +329,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
         /// Gets or sets <see cref="Device"/> Latitude.
         /// </summary>
         // Because of database design, no validation attributes are applied.        
-        [RegularExpression(@"^[-]?([0-9]{1,3})?([.][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in decimal(9,6) format.")]
+        [RegularExpression(@"^[-]?([0-9]{1,3})?([.,][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in decimal(9,6) format.")]
         public decimal? Latitude
         {
             get => m_latitude;

--- a/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/Device.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/Device.cs
@@ -314,7 +314,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
         /// Gets or sets <see cref="Device"/> Longitude.
         /// </summary>
         // Because of database design, no validation attributes are applied.        
-        [RegularExpression(@"^[-]?([0-9]{1,3})?([.,][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in decimal(9,6) format.")]
+        [RegularExpression(@"^[-]?([0-9]{1,3})?([.,][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in degrees between -180 and 180 with up to six decimal places.")]
         public decimal? Longitude
         {
             get => m_longitude;
@@ -329,7 +329,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
         /// Gets or sets <see cref="Device"/> Latitude.
         /// </summary>
         // Because of database design, no validation attributes are applied.        
-        [RegularExpression(@"^[-]?([0-9]{1,3})?([.,][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in decimal(9,6) format.")]
+        [RegularExpression(@"^[-]?([0-9]{1,3})?([.,][0-9]{1,6})?$", ErrorMessage = "Invalid value. Please provide value in degrees between -90 and 90 with up to six decimal places.")]
         public decimal? Latitude
         {
             get => m_latitude;


### PR DESCRIPTION
The first commit applies the system's current culture settings to the WPF UI. Without this, it will default to en-US, which explains why numbers were displaying with periods instead of commas when using `en-AT` culture.

The second commit relaxes the regex validation for lat/long so that a number like `-98,6` will not fail validation. The regex was being applied to a string created using the current culture settings regardless of what was being used for the display. This explains why the validation was failing despite the UI showing a number with a valid format.

The first commit will need to be applied to every Manager application individually, not just TSFManager.