### PR TITLE
Fix bug in PagedList endpoint

### DIFF
--- a/Source/Libraries/GSF.Web/Model/ModelController.cs
+++ b/Source/Libraries/GSF.Web/Model/ModelController.cs
@@ -897,8 +897,9 @@ namespace GSF.Web.Model
                 sql = $"SELECT COUNT(*) FROM {tblSelect} {whereClause}";
             }
 
-            if (param.Any())
-                return connection.ExecuteScalar<int>(sql, param);
+            object[] paramArray = param.ToArray();
+            if (paramArray.Any())
+                return connection.ExecuteScalar<int>(sql, paramArray);
             return connection.ExecuteScalar<int>(sql, "");
         }
 


### PR DESCRIPTION
This fixes an issue with the PagedList endpoint throwing an exception in `CountSearchResults` method because of `param` being a List instead of an array. 