### PR TITLE
GSF.Core: Avoid converting empty path to absolute path in AddPathSuffix()

### DIFF
--- a/Source/Libraries/GSF.Core.Shared/IO/FilePath.cs
+++ b/Source/Libraries/GSF.Core.Shared/IO/FilePath.cs
@@ -788,7 +788,7 @@ namespace GSF.IO
         {
             if (string.IsNullOrEmpty(filePath))
             {
-                filePath = Path.DirectorySeparatorChar.ToString();
+                filePath = "." + Path.DirectorySeparatorChar;
             }
             else
             {


### PR DESCRIPTION
See https://github.com/gemstone/common/pull/9