### PR TITLE
Added Public binding flag to GetMethods for SQLSearchModifer property

### DIFF
--- a/Source/Libraries/GSF.Web/Model/ModelController.cs
+++ b/Source/Libraries/GSF.Web/Model/ModelController.cs
@@ -137,7 +137,7 @@ namespace GSF.Web.Model
             SearchSettings = typeof(T).GetCustomAttribute<AdditionalFieldSearchAttribute>();
             Take = typeof(T).GetCustomAttribute<ReturnLimitAttribute>()?.Limit ?? null;
 
-            SQLSearchModifier = typeof(T).GetMethods(BindingFlags.Static).FirstOrDefault(p => p.GetCustomAttributes<SQLSearchModifierAttribute>().Any());
+            SQLSearchModifier = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Static).FirstOrDefault(p => p.GetCustomAttributes<SQLSearchModifierAttribute>().Any());
 
             // Custom View Models are ViewOnly.
             ViewOnly = (typeof(U).GetCustomAttribute<ViewOnlyAttribute>()?.ViewOnly ?? false) ||


### PR DESCRIPTION
Added Public BindingFlag to the `ModelController` constructor so that we are able to find the method under the `SQLSearchModifier` attribute. Without this SQLSearchModifier property will stay null, since GetMethods will be unable to find the method.