### PR TITLE
GSF.COMTRADE: Fix parsing for fields starting with TimeFactor

### DIFF
--- a/Source/Libraries/GSF.COMTRADE/Schema.cs
+++ b/Source/Libraries/GSF.COMTRADE/Schema.cs
@@ -310,22 +310,31 @@ namespace GSF.COMTRADE
             AnalogChannels = analogChannels.ToArray();
 
             // Parse time factor
-            TimeFactor = lines.Length < lineNumber ? double.Parse(lines[lineNumber++]) : 1;
+            TimeFactor = lineNumber < lines.Length ? double.Parse(lines[lineNumber++]) : 1;
 
             // Parse time information line
-            if (lines.Length < lineNumber)
+            if (lineNumber < lines.Length)
             {
                 parts = lines[lineNumber++].Split(',');
 
+                string timeCode = parts[0].Trim();
+                string localCode = parts[1].Trim();
+
+                if (useRelaxedValidation && timeCode.EndsWith("t"))
+                    timeCode = timeCode.Substring(0, timeCode.Length - 1);
+
+                if (useRelaxedValidation && localCode.EndsWith("t"))
+                    localCode = localCode.Substring(0, localCode.Length - 1);
+
                 if (parts.Length > 0)
-                    TimeCode = new TimeOffset(parts[0].Trim());
+                    TimeCode = new TimeOffset(timeCode);
 
                 if (parts.Length > 1)
-                    LocalCode = new TimeOffset(parts[1].Trim());
+                    LocalCode = new TimeOffset(localCode);
             }
 
             // Parse time state line
-            if (lines.Length < lineNumber)
+            if (lineNumber < lines.Length)
             {
                 parts = lines[lineNumber/*++*/].Split(',');
 


### PR DESCRIPTION
Fixes an issue reported in https://github.com/gemstone/comtrade/issues/3. Need to follow up with a PR for Gemstone as well.