### PR TITLE
GSF.COMTRADE: Use invariant culture for all numeric conversions

### DIFF
--- a/Source/Libraries/GSF.COMTRADE/AnalogChannel.cs
+++ b/Source/Libraries/GSF.COMTRADE/AnalogChannel.cs
@@ -128,21 +128,21 @@ namespace GSF.COMTRADE
             if (parts.Length < 10 || (!useRelaxedValidation && parts.Length != 10 && parts.Length != 13))
                 throw new InvalidOperationException($"Unexpected number of line image elements for analog channel definition: {parts.Length} - expected 10 or 13{Environment.NewLine}Image = {lineImage}");
 
-            Index = int.Parse(parts[0].Trim());
+            Index = int.Parse(parts[0].Trim(), CultureInfo.InvariantCulture);
             Name = parts[1];
             Units = parts[4];   // Assign Units before PhaseID
             PhaseID = parts[2];
             CircuitComponent = parts[3];
-            Multiplier = double.Parse(parts[5].Trim());
-            Adder = double.Parse(parts[6].Trim());
-            Skew = double.Parse(parts[7].Trim());
-            MinValue = double.Parse(parts[8].Trim());
-            MaxValue = double.Parse(parts[9].Trim());
+            Multiplier = double.Parse(parts[5].Trim(), CultureInfo.InvariantCulture);
+            Adder = double.Parse(parts[6].Trim(), CultureInfo.InvariantCulture);
+            Skew = double.Parse(parts[7].Trim(), CultureInfo.InvariantCulture);
+            MinValue = double.Parse(parts[8].Trim(), CultureInfo.InvariantCulture);
+            MaxValue = double.Parse(parts[9].Trim(), CultureInfo.InvariantCulture);
 
             if (parts.Length >= 13)
             {
-                PrimaryRatio = double.Parse(parts[10].Trim());
-                SecondaryRatio = double.Parse(parts[11].Trim());
+                PrimaryRatio = double.Parse(parts[10].Trim(), CultureInfo.InvariantCulture);
+                SecondaryRatio = double.Parse(parts[11].Trim(), CultureInfo.InvariantCulture);
                 ScalingIdentifier = parts[12].Trim()[0];
             }
         }
@@ -535,7 +535,7 @@ namespace GSF.COMTRADE
             // An,ch_id,ph,ccbm,uu,a,b,skew,min,max
             List<string> values = new List<string>
             {
-                Index.ToString(),
+                Index.ToString(CultureInfo.InvariantCulture),
                 Name,
                 PhaseID,
                 CircuitComponent,

--- a/Source/Libraries/GSF.COMTRADE/DigitalChannel.cs
+++ b/Source/Libraries/GSF.COMTRADE/DigitalChannel.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace GSF.COMTRADE
@@ -73,7 +74,7 @@ namespace GSF.COMTRADE
 
             if (parts.Length >= 5)
             {
-                Index = int.Parse(parts[0].Trim());
+                Index = int.Parse(parts[0].Trim(), CultureInfo.InvariantCulture);
                 Name = parts[1];
                 PhaseID = parts[2];
                 CircuitComponent = parts[3];
@@ -81,7 +82,7 @@ namespace GSF.COMTRADE
             }
             else
             {
-                Index = int.Parse(parts[0].Trim());
+                Index = int.Parse(parts[0].Trim(), CultureInfo.InvariantCulture);
                 Name = parts[1];
                 NormalState = parts[2].Trim().ParseBoolean();
             }
@@ -197,7 +198,7 @@ namespace GSF.COMTRADE
                 // Dn,ch_id,ph,ccbm,y
                 values = new List<string>
                 {
-                    Index.ToString(),
+                    Index.ToString(CultureInfo.InvariantCulture),
                     Name,
                     PhaseID,
                     CircuitComponent,
@@ -209,7 +210,7 @@ namespace GSF.COMTRADE
                 // Dn,ch_id,y
                 values = new List<string>
                 {
-                    Index.ToString(),
+                    Index.ToString(CultureInfo.InvariantCulture),
                     Name,
                     NormalState ? "1" : "0"
                 };

--- a/Source/Libraries/GSF.COMTRADE/Parser.cs
+++ b/Source/Libraries/GSF.COMTRADE/Parser.cs
@@ -24,6 +24,7 @@
 //******************************************************************************************************
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -400,7 +401,7 @@ namespace GSF.COMTRADE
             }
 
             // Parse row of data
-            uint sample = uint.Parse(elems[0]);
+            uint sample = uint.Parse(elems[0], CultureInfo.InvariantCulture);
 
             // Capture initial sample index - this handles cases where sample index does not start at zero
             if (m_initialSample == uint.MaxValue)
@@ -424,7 +425,7 @@ namespace GSF.COMTRADE
 
             // Fall back on specified microsecond time
             if (Timestamp == DateTime.MinValue)
-                Timestamp = new DateTime(Ticks.FromMicroseconds(double.Parse(elems[1]) * m_schema.TimeFactor) + m_schema.StartTime.Value);
+                Timestamp = new DateTime(Ticks.FromMicroseconds(double.Parse(elems[1], CultureInfo.InvariantCulture) * m_schema.TimeFactor) + m_schema.StartTime.Value);
 
             // Apply timestamp offset to restore UTC timezone
             if (AdjustToUTC)
@@ -436,7 +437,7 @@ namespace GSF.COMTRADE
             // Parse all record values
             for (int i = 0; i < Values.Length; i++)
             {
-                Values[i] = double.Parse(elems[i + 2]);
+                Values[i] = double.Parse(elems[i + 2], CultureInfo.InvariantCulture);
 
                 if (i < m_schema.AnalogChannels.Length)
                     Values[i] = AdjustValue(Values[i], i);

--- a/Source/Libraries/GSF.COMTRADE/SampleRate.cs
+++ b/Source/Libraries/GSF.COMTRADE/SampleRate.cs
@@ -64,8 +64,8 @@ namespace GSF.COMTRADE
             if (parts.Length < 2 || (!useRelaxedValidation && parts.Length != 2))
                 throw new InvalidOperationException($"Unexpected number of line image elements for sample rate definition: {parts.Length} - expected 2{Environment.NewLine}Image = {lineImage}");
 
-            Rate = double.Parse(parts[0].Trim());
-            EndSample = long.Parse(parts[1].Trim());
+            Rate = double.Parse(parts[0].Trim(), CultureInfo.InvariantCulture);
+            EndSample = long.Parse(parts[1].Trim(), CultureInfo.InvariantCulture);
         }
 
         #endregion
@@ -75,11 +75,16 @@ namespace GSF.COMTRADE
         /// <summary>
         /// Converts <see cref="SampleRate"/> to its string format.
         /// </summary>
-        public override string ToString()
-        {
-            // samp,endsamp
-            return $"{Rate.ToString(CultureInfo.InvariantCulture)},{EndSample}";
-        }
+        public override string ToString() => // samp,endsamp
+            Format($"{Rate},{EndSample}");
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Methods
+        private static string Format(FormattableString formattableString) =>
+            formattableString.ToString(CultureInfo.InvariantCulture);
 
         #endregion
     }

--- a/Source/Libraries/GSF.COMTRADE/Schema.cs
+++ b/Source/Libraries/GSF.COMTRADE/Schema.cs
@@ -244,7 +244,7 @@ namespace GSF.COMTRADE
             DeviceID = parts[1].Trim();
 
             if (parts.Length >= 3 && !string.IsNullOrWhiteSpace(parts[2]))
-                Version = int.Parse(parts[2].Trim());
+                Version = int.Parse(parts[2].Trim(), CultureInfo.InvariantCulture);
             else
                 Version = 1991;
 
@@ -254,9 +254,9 @@ namespace GSF.COMTRADE
             if (parts.Length < 3 || (!useRelaxedValidation && parts.Length != 3))
                 throw new InvalidOperationException($"Unexpected number of line image elements for second configuration file line: {parts.Length} - expected 3{Environment.NewLine}Image = {lines[lineNumber - 1]}");
 
-            int totalChannels = int.Parse(parts[0].Trim());
-            int totalAnalogChannels = int.Parse(parts[1].Trim().Split('A')[0]);
-            int totalDigitalChannels = int.Parse(parts[2].Trim().Split('D')[0]);
+            int totalChannels = int.Parse(parts[0].Trim(), CultureInfo.InvariantCulture);
+            int totalAnalogChannels = int.Parse(parts[1].Trim().Split('A')[0], CultureInfo.InvariantCulture);
+            int totalDigitalChannels = int.Parse(parts[2].Trim().Split('D')[0], CultureInfo.InvariantCulture);
 
             if (totalChannels != totalAnalogChannels + totalDigitalChannels)
                 throw new InvalidOperationException($"Total defined channels must equal the sum of the total number of analog and digital channel definitions.{Environment.NewLine}Image = {lines[lineNumber - 1]}");
@@ -276,10 +276,10 @@ namespace GSF.COMTRADE
             DigitalChannels = digitalChannels.ToArray();
 
             // Parse line frequency
-            NominalFrequency = double.Parse(lines[lineNumber++]);
+            NominalFrequency = double.Parse(lines[lineNumber++], CultureInfo.InvariantCulture);
 
             // Parse total number of sample rates
-            int totalSampleRates = int.Parse(lines[lineNumber++]);
+            int totalSampleRates = int.Parse(lines[lineNumber++], CultureInfo.InvariantCulture);
 
             if (totalSampleRates == 0)
                 totalSampleRates = 1;
@@ -310,7 +310,7 @@ namespace GSF.COMTRADE
             AnalogChannels = analogChannels.ToArray();
 
             // Parse time factor
-            TimeFactor = lineNumber < lines.Length ? double.Parse(lines[lineNumber++]) : 1;
+            TimeFactor = lineNumber < lines.Length ? double.Parse(lines[lineNumber++], CultureInfo.InvariantCulture) : 1;
 
             // Parse time information line
             if (lineNumber < lines.Length)
@@ -339,10 +339,10 @@ namespace GSF.COMTRADE
                 parts = lines[lineNumber/*++*/].Split(',');
 
                 if (parts.Length > 0)
-                    TimeQualityIndicatorCode = (TimeQualityIndicatorCode)byte.Parse(parts[0], NumberStyles.HexNumber);
+                    TimeQualityIndicatorCode = (TimeQualityIndicatorCode)byte.Parse(parts[0], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
 
                 if (parts.Length > 1)
-                    LeapSecondIndicator = (LeapSecondIndicator)byte.Parse(parts[1]);
+                    LeapSecondIndicator = (LeapSecondIndicator)byte.Parse(parts[1], CultureInfo.InvariantCulture);
             }
         }
 
@@ -513,11 +513,11 @@ namespace GSF.COMTRADE
             {
                 StringBuilder fileImage = new StringBuilder();
 
-                void appendLine(string line)
+                void appendLine(FormattableString line)
                 {
                     // The standard .NET "Environment.NewLine" constant can just be a line feed on some operating systems,
                     // but the COMTRADE standard requires that end of line markers be both a carriage return and line feed.
-                    fileImage.Append(line);
+                    fileImage.Append(line.ToString(CultureInfo.InvariantCulture));
                     fileImage.Append(Writer.CRLF);
                 }
 
@@ -529,17 +529,17 @@ namespace GSF.COMTRADE
 
                 // Write analog definitions
                 for (int i = 0; i < TotalAnalogChannels; i++)
-                    appendLine(AnalogChannels[i].ToString());
+                    appendLine($"{AnalogChannels[i]}");
 
                 // Write digital definitions
                 for (int i = 0; i < TotalDigitalChannels; i++)
-                    appendLine(DigitalChannels[i].ToString());
+                    appendLine($"{DigitalChannels[i]}");
 
                 // Write line frequency
-                appendLine(NominalFrequency.ToString(CultureInfo.InvariantCulture));
+                appendLine($"{NominalFrequency}");
 
                 // Write total number of sample rates (zero signifies no fixed sample rates)
-                appendLine(TotalSampleRates.ToString());
+                appendLine($"{TotalSampleRates}");
 
                 int totalSampleRates = TotalSampleRates;
 
@@ -548,18 +548,18 @@ namespace GSF.COMTRADE
 
                 // Write sample rates
                 for (int i = 0; i < totalSampleRates; i++)
-                    appendLine(SampleRates[i].ToString());
+                    appendLine($"{SampleRates[i]}");
 
                 // Write timestamps
-                appendLine(StartTime.ToString());
-                appendLine(TriggerTime.ToString());
+                appendLine($"{StartTime}");
+                appendLine($"{TriggerTime}");
 
                 // Write file type
-                appendLine(FileType.ToString().ToUpper());
+                appendLine($"{FileType.ToString().ToUpper()}");
 
                 // Write time factor
                 if (Version >= 1999)
-                    appendLine(TimeFactor.ToString(CultureInfo.InvariantCulture));
+                    appendLine($"{TimeFactor}");
 
                 // Write per data set time info and state
                 if (Version >= 2013)

--- a/Source/Libraries/GSF.COMTRADE/TimeOffset.cs
+++ b/Source/Libraries/GSF.COMTRADE/TimeOffset.cs
@@ -22,6 +22,7 @@
 //******************************************************************************************************
 
 using System;
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace GSF.COMTRADE
@@ -71,14 +72,14 @@ namespace GSF.COMTRADE
                 switch (parts.Length)
                 {
                     case 1:
-                        validFormat = int.TryParse(lineImage, out hours);
+                        validFormat = int.TryParse(lineImage, NumberStyles.Integer, CultureInfo.InvariantCulture, out hours);
                         break;
                     case 2:
                     {
-                        validFormat = int.TryParse(parts[0], out hours);
+                        validFormat = int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out hours);
 
                         if (validFormat)
-                            validFormat = int.TryParse(parts[1], out minutes);
+                            validFormat = int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out minutes);
                         break;
                     }
                     default:
@@ -162,7 +163,15 @@ namespace GSF.COMTRADE
         /// Converts <see cref="TimeOffset"/> to its string format.
         /// </summary>
         public override string ToString() => 
-            NotApplicable ? "x" : $"{Hours}h{Minutes:00}";
+            NotApplicable ? "x" : Format($"{Hours}h{Minutes:00}");
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Methods
+        private static string Format(FormattableString formattableString) =>
+            formattableString.ToString(CultureInfo.InvariantCulture);
 
         #endregion
     }

--- a/Source/Libraries/GSF.COMTRADE/Timestamp.cs
+++ b/Source/Libraries/GSF.COMTRADE/Timestamp.cs
@@ -58,11 +58,11 @@ namespace GSF.COMTRADE
 
             if (parts.Length == 4)
             {
-                double.TryParse(parts[parts.Length - 1], out milliseconds);
+                TryParse(parts[parts.Length - 1], out milliseconds);
                 parts = new[] { parts[0], parts[1], parts[2] };
             }
 
-            double.TryParse(parts[parts.Length - 1], out double seconds);
+            TryParse(parts[parts.Length - 1], out double seconds);
 
             seconds += milliseconds;
 
@@ -95,6 +95,17 @@ namespace GSF.COMTRADE
         {
             // dd/mm/yyyy,hh:mm:ss.ssssss
             return Value.ToString("dd/MM/yyyy,HH:mm:ss.ffffff", CultureInfo.InvariantCulture);
+        }
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Methods
+        private static bool TryParse(string s, out double result)
+        {
+            NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands;
+            return double.TryParse(s, style, CultureInfo.InvariantCulture, out result);
         }
 
         #endregion

--- a/Source/Libraries/GSF.COMTRADE/Writer.cs
+++ b/Source/Libraries/GSF.COMTRADE/Writer.cs
@@ -44,7 +44,7 @@ namespace GSF.COMTRADE
         /// </remarks>
         public const long MaxFileSize = 281474976710656L;
 
-        private static readonly string MaxByteCountString = new string('0', $"{MaxFileSize}".Length);
+        private static readonly string MaxByteCountString = new string('0', MaxFileSize.ToString(CultureInfo.InvariantCulture).Length);
 
         /// <summary>
         /// Defines the maximum COMTRADE end sample number.
@@ -528,8 +528,8 @@ namespace GSF.COMTRADE
             if (parts.Length < 3)
                 throw new InvalidOperationException($"Unexpected number of line image elements for second configuration file line: {parts.Length} - expected 3{Environment.NewLine}Image = {line}");
 
-            int totalAnalogChannels = int.Parse(parts[1].Trim().Split('A')[0]);
-            int totalDigitalChannels = int.Parse(parts[2].Trim().Split('D')[0]);
+            int totalAnalogChannels = int.Parse(parts[1].Trim().Split('A')[0], CultureInfo.InvariantCulture);
+            int totalDigitalChannels = int.Parse(parts[2].Trim().Split('D')[0], CultureInfo.InvariantCulture);
 
             // Skip analog definitions
             for (int i = 0; i < totalAnalogChannels; i++)
@@ -543,7 +543,7 @@ namespace GSF.COMTRADE
             readLine();
 
             // Parse total number of sample rates
-            int totalSampleRates = int.Parse(readLine());
+            int totalSampleRates = int.Parse(readLine(), CultureInfo.InvariantCulture);
 
             if (totalSampleRates == 0)
                 totalSampleRates = 1;
@@ -630,9 +630,10 @@ namespace GSF.COMTRADE
             StringBuilder line = new StringBuilder();
             bool isFirstDigital = true;
 
-            line.Append(sample);
-            line.Append(',');
-            line.Append(microseconds);
+            void append(FormattableString formattableString) =>
+                line.Append(formattableString.ToString(CultureInfo.InvariantCulture));
+
+            append($"{sample},{microseconds}");
 
             for (int i = 0; i < values.Length; i++)
             {
@@ -643,8 +644,7 @@ namespace GSF.COMTRADE
                     value -= schema.AnalogChannels[i].Adder;
                     value /= schema.AnalogChannels[i].Multiplier;
 
-                    line.Append(',');
-                    line.Append(value.ToString(CultureInfo.InvariantCulture));
+                    append($",{value}");
                 }
                 else
                 {
@@ -657,8 +657,8 @@ namespace GSF.COMTRADE
                         {
                             for (int j = 0; j < 16; j++)
                             {
-                                line.Append(',');
-                                line.Append(fracSecValue.CheckBits(BitExtensions.BitVal(j)) ? 1 : 0);
+                                int fracSecBit = fracSecValue.CheckBits(BitExtensions.BitVal(j)) ? 1 : 0;
+                                append($",{fracSecBit}");
                             }
                         }
                     }
@@ -667,8 +667,8 @@ namespace GSF.COMTRADE
 
                     for (int j = 0; j < 16; j++)
                     {
-                        line.Append(',');
-                        line.Append(digitalWord.CheckBits(BitExtensions.BitVal(j)) ? 1 : 0);
+                        int digitalValue = digitalWord.CheckBits(BitExtensions.BitVal(j)) ? 1 : 0;
+                        append($",{digitalValue}");
                     }
                 }
             }
@@ -678,8 +678,8 @@ namespace GSF.COMTRADE
             {
                 for (int j = 0; j < 16; j++)
                 {
-                    line.Append(',');
-                    line.Append(fracSecValue.CheckBits(BitExtensions.BitVal(j)) ? 1 : 0);
+                    int fracSecBit = fracSecValue.CheckBits(BitExtensions.BitVal(j)) ? 1 : 0;
+                    append($",{fracSecBit}");
                 }
             }
 


### PR DESCRIPTION
Fix culture issues reported in https://github.com/gemstone/comtrade/issues/2