### PR TITLE
Fix issue when EventLog Source does not exist

### DIFF
--- a/Source/Libraries/GSF.TimeSeries/ServiceHostBase.cs
+++ b/Source/Libraries/GSF.TimeSeries/ServiceHostBase.cs
@@ -738,7 +738,8 @@ namespace GSF.TimeSeries
                     .AppendLine("Certificate Generation Log:")
                     .AppendLine(string.Join(Environment.NewLine, certificateGenerator.DebugLog ?? new List<string>()))
                     .ToString();
-                WriteEventLog(message, EventLogEntryType.Information);
+
+                TryWriteToEventLog(message, EventLogEntryType.Information);
             }
             catch (Exception ex)
             {
@@ -748,7 +749,8 @@ namespace GSF.TimeSeries
                     .AppendLine("Certificate Generation Log:")
                     .AppendLine(string.Join(Environment.NewLine, certificateGenerator?.DebugLog ?? new List<string>()))
                     .ToString();
-                WriteEventLog(message, EventLogEntryType.Error);
+
+                TryWriteToEventLog(message, EventLogEntryType.Error);
             }
         }
 
@@ -1364,12 +1366,10 @@ namespace GSF.TimeSeries
             }
         }
 
-        /// <summary>
-        /// Attempt to log event to Windows event log.
-        /// On failure continue System Initalization.
-        /// Eventually GSF Logging will come up and can handle exceptions when writting to the event log.
-        /// </summary>
-        private void WriteEventLog(string message, EventLogEntryType entryType)
+        // Attempt to log event to Windows event log during system initialization.
+        // On failure, ignore errors and continue system initalization.
+        // Eventually GSF logger will be initialized and can handle exceptions that occur when writing to the event log.
+        private void TryWriteToEventLog(string message, EventLogEntryType entryType)
         {
             try
             {
@@ -1377,6 +1377,7 @@ namespace GSF.TimeSeries
             }
             catch {}
         }
+
         #endregion
 
         #region [ Service Binding ]

--- a/Source/Libraries/GSF.TimeSeries/ServiceHostBase.cs
+++ b/Source/Libraries/GSF.TimeSeries/ServiceHostBase.cs
@@ -45,6 +45,7 @@ using System.ServiceProcess;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using System.Xml;
 using GSF.Collections;
 using GSF.Communication;
@@ -737,8 +738,7 @@ namespace GSF.TimeSeries
                     .AppendLine("Certificate Generation Log:")
                     .AppendLine(string.Join(Environment.NewLine, certificateGenerator.DebugLog ?? new List<string>()))
                     .ToString();
-
-                EventLog.WriteEntry(ServiceName, message, EventLogEntryType.Information, 0);
+                WriteEventLog(message, EventLogEntryType.Information);
             }
             catch (Exception ex)
             {
@@ -748,8 +748,7 @@ namespace GSF.TimeSeries
                     .AppendLine("Certificate Generation Log:")
                     .AppendLine(string.Join(Environment.NewLine, certificateGenerator?.DebugLog ?? new List<string>()))
                     .ToString();
-
-                EventLog.WriteEntry(ServiceName, message, EventLogEntryType.Error, 0);
+                WriteEventLog(message, EventLogEntryType.Error);
             }
         }
 
@@ -1365,6 +1364,19 @@ namespace GSF.TimeSeries
             }
         }
 
+        /// <summary>
+        /// Attempt to log event to Windows event log.
+        /// On failure continue System Initalization.
+        /// Eventually GSF Logging will come up and can handle exceptions when writting to the event log.
+        /// </summary>
+        private void WriteEventLog(string message, EventLogEntryType entryType)
+        {
+            try
+            {
+                EventLog.WriteEntry(ServiceName, message, entryType, 0);
+            }
+            catch {}
+        }
         #endregion
 
         #region [ Service Binding ]


### PR DESCRIPTION
When the application tries to write to a windows event log source that does not affect it currently fails to start without any error.
The installer usually creates the datasource so this is only an issue when running debug on a system that has never had the installer run.

This commit just prevents an exception in the EventLog writing from failing out the entire startup/initialization routine. Note that the GSF logger may not be up at that point so writing there is not an option until later. 