### PR TITLE
Dnp3Adapters Updates

### DIFF
--- a/Source/GridSolutionsFramework.sln.DotSettings
+++ b/Source/GridSolutionsFramework.sln.DotSettings
@@ -364,10 +364,12 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AF/@EntryIndexedValue">AF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CS/@EntryIndexedValue">CS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DNP/@EntryIndexedValue">DNP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IEEEC/@EntryIndexedValue">IEEEC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KV/@EntryIndexedValue">KV</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OID/@EntryIndexedValue">OID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PDC/@EntryIndexedValue">PDC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PI/@EntryIndexedValue">PI</s:String>
@@ -409,6 +411,8 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CIANG/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CLEAREDALARMS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=commandchannel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=comms/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Crain/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cstream/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Danyelle/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=datapoint/@EntryIndexedValue">True</s:Boolean>
@@ -476,6 +480,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requestdeviceconfiguration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ritchie/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=servername/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=setpoint/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SETSUM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SHELBYPA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=skipdisablerealtimedata/@EntryIndexedValue">True</s:Boolean>

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3Adapters.csproj
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3Adapters.csproj
@@ -15,8 +15,6 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -75,6 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Dnp3InputAdapter.cs" />
+    <Compile Include="IsExternalInit.cs" />
     <Compile Include="MasterConfiguration.cs" />
     <Compile Include="MeasurementLookup.cs" />
     <Compile Include="MeasurementMap.cs" />

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
@@ -118,11 +118,11 @@ public class DNP3InputAdapter : InputAdapterBase
     private const string DefaultQualityTagSuffix = "!FLAGS";
 
     // Fields
-    private TimeSpan m_pollingInterval; // Interval, in seconds, at which the adapter will poll the DNP3 device
+    private TimeSpan m_pollingInterval;         // Interval, in seconds, at which the adapter will poll the DNP3 device
     private MasterConfiguration m_masterConfig; // Configuration for the master set during the Initialize call
-    private TimeSeriesSOEHandler m_soeHandler; // Time-series sequence of events handler
-    private IChannel m_channel; // Communications channel set during the AttemptConnection call and used in AttemptDisconnect
-    private bool m_active; // Flag that determines if the port/master has been added so that the resource can be cleaned up
+    private TimeSeriesSOEHandler m_soeHandler;  // Time-series sequence of events handler
+    private IChannel m_channel;                 // Communications channel set during the AttemptConnection call and used in AttemptDisconnect
+    private bool m_active;                      // Flag that determines if the port/master has been added so that the resource can be cleaned up
     private bool m_disposed;
 
     #endregion

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
@@ -164,7 +164,7 @@ public class DNP3InputAdapter : InputAdapterBase
     public bool MapQualityToStateFlags { get; set; }
 
     /// <summary>
-    /// Gets or sets flag that determines if DNP3 quality flags should be added to measurement outputs.
+    /// Gets or sets flag that determines if DNP3 quality flags should be added as separate measurement outputs.
     /// </summary>
     // NOTE: Like value measurements, quality measurements are expected to be pre-defined outside the adapter, i.e., the
     // adapter does not currently auto-create tags. There is an external Python script that exists for this purpose.
@@ -174,7 +174,7 @@ public class DNP3InputAdapter : InputAdapterBase
     // be a variation of the value tag format with a suffix appended to the tag name, e.g., "<TagName><SignalType>!FLAGS".
     // In this current implementation, quality flags measurements are expected to be an analog signal type, i.e.: "ALOG".
     [ConnectionStringParameter]
-    [Description("Define flag that determines if DNP3 quality flags should be added to measurement outputs.")]
+    [Description("Define flag that determines if DNP3 quality flags should be added as separate measurement outputs.")]
     [DefaultValue(DefaultAddQualityToMeasurementOutputs)]
     public bool AddQualityToMeasurementOutputs { get; set; }
 

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
@@ -356,7 +356,8 @@ public class DNP3InputAdapter : InputAdapterBase
             PollingInterval = pollingInterval;
 
         // Attach to output measurements for DNP3 device - just informs routing engine of expected measurements
-        OutputMeasurements = ParseOutputMeasurements(DataSource, false, $"FILTER ActiveMeasurements WHERE Device = '{Name}'");
+        if (OutputMeasurements?.Length == 0)
+            OutputMeasurements = ParseOutputMeasurements(DataSource, false, $"FILTER ActiveMeasurements WHERE Device = '{Name}'");
 
         lock (s_adapters)
         {

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
@@ -113,7 +113,7 @@ public class DNP3InputAdapter : InputAdapterBase
     private const double DefaultPollingInterval = 2.0D;
     private const double DefaultTimestampDifferentiation = 1.0D;
     private const bool DefaultMapQualityToStateFlags = true;
-    private const bool DefaultAddQualityToMeasurementOutputs = false;
+    private const bool DefaultPublishFlagsAsSeparateMeasurements = false;
     private const string DefaultTagMatchPattern = @"(?<TagName>.+)(?<SignalType>\:(ALOG|DIGI))\d+";
     private const string DefaultQualityTagSuffix = "!FLAGS";
 
@@ -164,7 +164,7 @@ public class DNP3InputAdapter : InputAdapterBase
     public bool MapQualityToStateFlags { get; set; }
 
     /// <summary>
-    /// Gets or sets flag that determines if DNP3 quality flags should be added as separate measurement outputs.
+    /// Gets or sets flag that determines if DNP3 quality flags should be published as separate measurement outputs.
     /// </summary>
     // NOTE: Like value measurements, quality measurements are expected to be pre-defined outside the adapter, i.e., the
     // adapter does not currently auto-create tags. There is an external Python script that exists for this purpose.
@@ -174,9 +174,9 @@ public class DNP3InputAdapter : InputAdapterBase
     // be a variation of the value tag format with a suffix appended to the tag name, e.g., "<TagName><SignalType>!FLAGS".
     // In this current implementation, quality flags measurements are expected to be an analog signal type, i.e.: "ALOG".
     [ConnectionStringParameter]
-    [Description("Define flag that determines if DNP3 quality flags should be added as separate measurement outputs.")]
-    [DefaultValue(DefaultAddQualityToMeasurementOutputs)]
-    public bool AddQualityToMeasurementOutputs { get; set; }
+    [Description("Define flag that determines if DNP3 quality flags should be published as separate measurement outputs.")]
+    [DefaultValue(DefaultPublishFlagsAsSeparateMeasurements)]
+    public bool PublishFlagsAsSeparateMeasurements { get; set; }
 
     /// <summary>
     /// Gets or sets the regular expression pattern used to match tag names for quality flag outputs.
@@ -323,7 +323,7 @@ public class DNP3InputAdapter : InputAdapterBase
         MeasurementMap measurementMap = ReadConfig<MeasurementMap>(MappingFilePath);
 
         MapQualityToStateFlags = !settings.TryGetValue(nameof(MapQualityToStateFlags), out setting) || setting.ParseBoolean();
-        AddQualityToMeasurementOutputs = settings.TryGetValue(nameof(AddQualityToMeasurementOutputs), out setting) && setting.ParseBoolean();
+        PublishFlagsAsSeparateMeasurements = settings.TryGetValue(nameof(PublishFlagsAsSeparateMeasurements), out setting) && setting.ParseBoolean();
         TagMatchPattern = settings.TryGetValue(nameof(TagMatchPattern), out setting) ? setting : DefaultTagMatchPattern;
 
         if (!TagMatchPattern.Contains("<TagName>") || !TagMatchPattern.Contains("<SignalType>"))
@@ -335,7 +335,7 @@ public class DNP3InputAdapter : InputAdapterBase
         {
             GetDataSource = () => DataSource,
             MapQualityToStateFlags = MapQualityToStateFlags,
-            AddQualityToMeasurementOutputs = AddQualityToMeasurementOutputs,
+            PublishFlagsAsSeparateMeasurements = PublishFlagsAsSeparateMeasurements,
             TagMatchRegex = new Regex(TagMatchPattern, RegexOptions.Compiled),
             QualityTagSuffix = QualityTagSuffix
         };

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
@@ -38,373 +38,375 @@ using GSF.Diagnostics;
 using GSF.IO;
 using GSF.TimeSeries.Adapters;
 
-namespace DNP3Adapters
+namespace DNP3Adapters;
+
+/// <summary>
+/// Input adapter that reads measurements from a remote dnp3 endpoint.
+/// </summary>
+[Description("DNP3: Reads measurements from a remote dnp3 endpoint")]
+public class DNP3InputAdapter : InputAdapterBase
 {
-    /// <summary>
-    /// Input adapter that reads measurements from a remote dnp3 endpoint.
-    /// </summary>
-    [Description("DNP3: Reads measurements from a remote dnp3 endpoint")]
-    public class DNP3InputAdapter : InputAdapterBase
+    #region [ Members ]
+
+    // Nested Types
+    private class ChannelListener(Action<ChannelState> onStateChange) : IChannelListener
     {
-        #region [ Members ]
-
-        // Nested Types
-
-        private class ChannelListener : IChannelListener
+        public void OnStateChange(ChannelState state)
         {
-            private readonly Action<ChannelState> m_onStateChange;
-
-            public ChannelListener(Action<ChannelState> onStateChange) => m_onStateChange = onStateChange;
-
-            public void OnStateChange(ChannelState state) => m_onStateChange(state);
+            onStateChange(state);
         }
+    }
 
-        // Class used to proxy dnp3 manager log entries to Iaon session
-        private class IaonProxyLogHandler : ILogHandler
+    // Class used to proxy dnp3 manager log entries to Iaon session
+    private class IaonProxyLogHandler : ILogHandler
+    {
+        /// <summary>
+        /// Handler for log entries.
+        /// </summary>
+        /// <param name="entry"><see cref="LogEntry"/> to handle.</param>
+        public void Log(LogEntry entry)
         {
-            /// <summary>
-            /// Handler for log entries.
-            /// </summary>
-            /// <param name="entry"><see cref="LogEntry"/> to handle.</param>
-            public void Log(LogEntry entry)
+            // We avoid race conditions by always making sure access to status proxy is locked - this only
+            // contends with adapter initialization and disposal so contention will not be the normal case
+            lock (s_adapters)
             {
-                // We avoid race conditions by always making sure access to status proxy is locked - this only
-                // contends with adapter initialization and disposal so contention will not be normal
-                lock (s_adapters)
-                {
-                    if (s_statusProxy is null || s_statusProxy.m_disposed)
-                        return;
-
-                    if ((entry.filter.Flags & LogFilters.ERROR) > 0)
-                    {
-                        // Expose errors through exception processor
-                        InvalidOperationException exception = new InvalidOperationException(FormatLogEntry(entry));
-                        s_statusProxy.OnProcessException(MessageLevel.Error, exception);
-                    }
-                    else
-                    {
-                        // For other messages, we just expose as a normal status
-                        string message = FormatLogEntry(entry);
-
-                        if ((entry.filter.Flags & LogFilters.WARNING) > 0)
-                            s_statusProxy.OnStatusMessage(MessageLevel.Warning, message);
-                        else if ((entry.filter.Flags & LogFilters.DEBUG) > 0)
-                            s_statusProxy.OnStatusMessage(MessageLevel.Debug, message);
-                        else
-                            s_statusProxy.OnStatusMessage(MessageLevel.Info, message);
-                    }
-                }
-            }
-
-            private static string FormatLogEntry(LogEntry entry)
-            {
-                StringBuilder entryText = new StringBuilder();
-
-                entryText.Append(entry.message);
-                entryText.AppendFormat(" ({0})", LogFilters.GetFilterString(entry.filter.Flags));
-
-                if (!string.IsNullOrWhiteSpace(entry.location))
-                    entryText.AppendFormat(" @ {0}", entry.location);
-
-                return entryText.ToString();
-            }
-        }
-
-        // Constants
-        private const double DefaultPollingInterval = 2.0D;
-        private const double DefaultTimestampDifferentiation = 1.0D;
-
-        // Fields
-        private string m_commsFilePath;             // Filename for the communication configuration file
-        private string m_mappingFilePath;           // Filename for the measurement mapping configuration file
-        private TimeSpan m_pollingInterval;         // Interval, in seconds, at which the adapter will poll the DNP3 device
-        private MasterConfiguration m_masterConfig; // Configuration for the master set during the Initialize call
-        private MeasurementMap m_measurementMap;    // Configuration for the measurement map set during the Initialize call
-        private TimeSeriesSOEHandler m_soeHandler;  // Time-series sequence of events handler
-        private IChannel m_channel;                 // Communications channel set during the AttemptConnection call and used in AttemptDisconnect
-        private bool m_active;                      // Flag that determines if the port/master has been added so that the resource can be cleaned up
-        private bool m_disposed;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Creates a new instance of the <see cref="DNP3Adapters"/> class.
-        /// </summary>
-        public DNP3InputAdapter()
-        {
-            m_pollingInterval = TimeSpan.FromSeconds(DefaultPollingInterval);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the name of the XML file from which the communication parameters will be read.
-        /// </summary>
-        [ConnectionStringParameter]
-        [Description("Define the name of the XML file from which the communication configuration will be read. Include fully qualified path if file name is not in installation folder.")]
-        public string CommsFilePath
-        {
-            get => m_commsFilePath;
-            set => m_commsFilePath = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the XML file from which the measurement mapping is read.
-        /// </summary>
-        [ConnectionStringParameter]
-        [Description("Define the name of the XML file from which the communication configuration will be read. Include fully qualified path if file name is not in installation folder.")]
-        public string MappingFilePath
-        {
-            get => m_mappingFilePath;
-            set => m_mappingFilePath = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the interval, in seconds, at which the adapter will poll the DNP3 device.
-        /// </summary>
-        [ConnectionStringParameter]
-        [Description("Define the interval, in seconds, at which the adapter will poll the DNP3 device.")]
-        [DefaultValue(DefaultPollingInterval)]
-        public double PollingInterval
-        {
-            get => m_pollingInterval.TotalSeconds;
-            set => m_pollingInterval = TimeSpan.FromSeconds(value);
-        }
-
-        /// <summary>
-        /// Gets or sets the time interval, in milliseconds, to insert between consecutive
-        /// data points for a given signal that were received at the exact same time.
-        /// </summary>
-        [ConnectionStringParameter]
-        [Description("Define the time interval, in milliseconds, to insert between consecutive data points for with the same ID and timestamp.")]
-        [DefaultValue(DefaultTimestampDifferentiation)]
-        public double TimestampDifferentiation
-        {
-            get => m_soeHandler?.TimestampDifferentiation.TotalMilliseconds ?? 0.0D;
-            set
-            {
-                if (m_soeHandler != null)
-                    m_soeHandler.TimestampDifferentiation = TimeSpan.FromMilliseconds(value);
-            }
-        }
-
-        /// <summary>
-        /// Gets the flag indicating if this adapter supports temporal processing.
-        /// </summary>
-        public override bool SupportsTemporalProcessing => false;
-
-        /// <summary>
-        /// Gets flag that determines if the data input connects asynchronously.
-        /// </summary>
-        /// <remarks>
-        /// Derived classes should return true when data input source is connects asynchronously, otherwise return false.
-        /// </remarks>
-        protected override bool UseAsyncConnect => false;
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="DNP3InputAdapter"/> object and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_disposed)
-                return;
-
-            try
-            {
-                if (!disposing)
+                if (s_statusProxy is null || s_statusProxy.m_disposed)
                     return;
 
-                if (m_active)
+                if ((entry.filter.Flags & LogFilters.ERROR) > 0)
                 {
-                    m_active = false;
-
-                    if (m_channel != null)
-                    {
-                        // Shutdown the communications channel
-                        m_channel.Shutdown();
-                        m_channel = null;
-                    }
+                    // Expose errors through exception processor
+                    InvalidOperationException exception = new(FormatLogEntry(entry));
+                    s_statusProxy.OnProcessException(MessageLevel.Error, exception);
                 }
-
-                // Detach from the time-series sequence of events new measurements event
-                if (m_soeHandler != null)
+                else
                 {
-                    m_soeHandler.NewMeasurements -= OnNewMeasurements;
-                    m_soeHandler = null;
-                }
+                    // For other messages, we just expose as a normal status
+                    string message = FormatLogEntry(entry);
 
-                lock (s_adapters)
-                {
-                    // Remove this adapter from the available list
-                    s_adapters.Remove(this);
-
-                    // See if we are disposing the status proxy instance
-                    if (ReferenceEquals(s_statusProxy, this))
-                    {
-                        // Attempt to find a new status proxy
-                        s_statusProxy = s_adapters.Count > 0 ? s_adapters[0] : null;
-                    }
+                    if ((entry.filter.Flags & LogFilters.WARNING) > 0)
+                        s_statusProxy.OnStatusMessage(MessageLevel.Warning, message);
+                    else if ((entry.filter.Flags & LogFilters.DEBUG) > 0)
+                        s_statusProxy.OnStatusMessage(MessageLevel.Debug, message);
+                    else
+                        s_statusProxy.OnStatusMessage(MessageLevel.Info, message);
                 }
-            }
-            finally
-            {
-                m_disposed = true;          // Prevent duplicate dispose.
-                base.Dispose(disposing);    // Call base class Dispose().
             }
         }
 
-        /// <summary>
-        /// Initializes <see cref="DNP3InputAdapter"/>
-        /// </summary>
-        public override void Initialize()
+        private static string FormatLogEntry(LogEntry entry)
         {
-            Dictionary<string, string> settings = Settings;
+            StringBuilder entryText = new();
 
-            base.Initialize();
+            entryText.Append(entry.message);
+            entryText.Append($" ({LogFilters.GetFilterString(entry.filter.Flags)})");
 
-            if (!settings.TryGetValue("CommsFilePath", out m_commsFilePath) || string.IsNullOrWhiteSpace(m_commsFilePath))
-                throw new ArgumentException($"The required {nameof(CommsFilePath)} parameter was not specified");
+            if (!string.IsNullOrWhiteSpace(entry.location))
+                entryText.Append($" @ {entry.location}");
 
-            m_commsFilePath = FilePath.GetAbsolutePath(m_commsFilePath);
+            return entryText.ToString();
+        }
+    }
 
-            if (!File.Exists(m_commsFilePath))
-                throw new FileNotFoundException($"The specified {nameof(CommsFilePath)} parameter \"{m_commsFilePath}\" was not found");
+    // Constants
+    private const double DefaultPollingInterval = 2.0D;
+    private const double DefaultTimestampDifferentiation = 1.0D;
+    private const bool DefaultMapQualityToStateFlags = true;
 
-            if (!settings.TryGetValue("MappingFilePath", out m_mappingFilePath) || string.IsNullOrWhiteSpace(m_mappingFilePath))
-                throw new ArgumentException($"The required {nameof(MappingFilePath)} parameter was not specified");
+    // Fields
+    private TimeSpan m_pollingInterval;         // Interval, in seconds, at which the adapter will poll the DNP3 device
+    private MasterConfiguration m_masterConfig; // Configuration for the master set during the Initialize call
+    private TimeSeriesSOEHandler m_soeHandler;  // Time-series sequence of events handler
+    private IChannel m_channel;                 // Communications channel set during the AttemptConnection call and used in AttemptDisconnect
+    private bool m_active;                      // Flag that determines if the port/master has been added so that the resource can be cleaned up
+    private bool m_disposed;
 
-            m_mappingFilePath = FilePath.GetAbsolutePath(m_mappingFilePath);
+    #endregion
 
-            if (!File.Exists(m_mappingFilePath))
-                throw new FileNotFoundException($"The specified {nameof(MappingFilePath)} parameter \"{m_mappingFilePath}\" was not found");
+    #region [ Constructors ]
 
-            if (settings.TryGetValue("PollingInterval", out string setting) && double.TryParse(setting, out double pollingInterval))
-                PollingInterval = pollingInterval;
+    /// <summary>
+    /// Creates a new instance of the <see cref="DNP3Adapters"/> class.
+    /// </summary>
+    public DNP3InputAdapter()
+    {
+        m_pollingInterval = TimeSpan.FromSeconds(DefaultPollingInterval);
+    }
 
-            m_masterConfig = ReadConfig<MasterConfiguration>(m_commsFilePath);
-            m_measurementMap = ReadConfig<MeasurementMap>(m_mappingFilePath);
+    #endregion
 
-            m_soeHandler = new TimeSeriesSOEHandler(new MeasurementLookup(m_measurementMap));
-            m_soeHandler.NewMeasurements += OnNewMeasurements;
+    #region [ Properties ]
 
-            // The TimestampDifferentiation property is a pass-through to the m_soeHandler.TimestampDifferentiation,
-            // so m_soeHandler must be initialized before reading this property from the connection string
-            if (settings.TryGetValue("TimestampDifferentiation", out setting) && double.TryParse(setting, out double timestampDifferentiation))
-                TimestampDifferentiation = timestampDifferentiation;
-            else
-                TimestampDifferentiation = DefaultTimestampDifferentiation;
+    /// <summary>
+    /// Gets or sets the name of the XML file from which the communication parameters will be read.
+    /// </summary>
+    [ConnectionStringParameter]
+    [Description("Define the name of the XML file from which the communication configuration will be read. Include fully qualified path if file name is not in installation folder.")]
+    public string CommsFilePath { get; set; }
 
-            m_soeHandler.TimestampDifferentiation = TimeSpan.FromMilliseconds(TimestampDifferentiation);
+    /// <summary>
+    /// Gets or sets the name of the XML file from which the measurement mapping is read.
+    /// </summary>
+    [ConnectionStringParameter]
+    [Description("Define the name of the XML file from which the communication configuration will be read. Include fully qualified path if file name is not in installation folder.")]
+    public string MappingFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets flag that determines if DNP3 quality flags should be mapped to measurement state flags.
+    /// </summary>
+    [ConnectionStringParameter]
+    [Description("Define flag that determines if DNP3 quality flags should be mapped to measurement state flags.")]
+    [DefaultValue(DefaultMapQualityToStateFlags)]
+    public bool MapQualityToStateFlags { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time interval, in milliseconds, to insert between consecutive
+    /// data points for a given signal that were received at the exact same time.
+    /// </summary>
+    [ConnectionStringParameter]
+    [Description("Define the time interval, in milliseconds, to insert between consecutive data points for with the same ID and timestamp.")]
+    [DefaultValue(DefaultTimestampDifferentiation)]
+    public double TimestampDifferentiation
+    {
+        get => m_soeHandler?.TimestampDifferentiation.TotalMilliseconds ?? 0.0D;
+        set
+        {
+            if (m_soeHandler is not null)
+                m_soeHandler.TimestampDifferentiation = TimeSpan.FromMilliseconds(value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the interval, in seconds, at which the adapter will poll the DNP3 device.
+    /// </summary>
+    [ConnectionStringParameter]
+    [Description("Define the interval, in seconds, at which the adapter will poll the DNP3 device.")]
+    [DefaultValue(DefaultPollingInterval)]
+    public double PollingInterval
+    {
+        get => m_pollingInterval.TotalSeconds;
+        set => m_pollingInterval = TimeSpan.FromSeconds(value);
+    }
+
+    /// <summary>
+    /// Gets the flag indicating if this adapter supports temporal processing.
+    /// </summary>
+    public override bool SupportsTemporalProcessing => false;
+
+    /// <summary>
+    /// Gets flag that determines if the data input connects asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// Derived classes should return true when data input source is connects asynchronously, otherwise return false.
+    /// </remarks>
+    protected override bool UseAsyncConnect => false;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the <see cref="DNP3InputAdapter"/> object and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (m_disposed)
+            return;
+
+        try
+        {
+            if (!disposing)
+                return;
+
+            if (m_active)
+            {
+                m_active = false;
+
+                if (m_channel is not null)
+                {
+                    // Shutdown the communications channel
+                    m_channel.Shutdown();
+                    m_channel = null;
+                }
+            }
+
+            // Detach from the time-series sequence of events new measurements event
+            if (m_soeHandler is not null)
+            {
+                m_soeHandler.NewMeasurements -= OnNewMeasurements;
+                m_soeHandler = null;
+            }
 
             lock (s_adapters)
             {
-                // Add adapter to list of available adapters 
-                s_adapters.Add(this);
+                // Remove this adapter from the available list
+                s_adapters.Remove(this);
 
-                // If no adapter has been designated as the status proxy, might as well be this one
-                if (s_statusProxy is null)
-                    s_statusProxy = this;
+                // See if we are disposing the status proxy instance
+                if (ReferenceEquals(s_statusProxy, this))
+                {
+                    // Attempt to find a new status proxy
+                    s_statusProxy = s_adapters.Count > 0 ? s_adapters[0] : null;
+                }
             }
         }
-
-        /// <summary>
-        /// Attempts to connect to data input source.
-        /// </summary>
-        /// <remarks>
-        /// Derived classes should attempt connection to data input source here.  Any exceptions thrown
-        /// by this implementation will result in restart of the connection cycle.
-        /// </remarks>
-        protected override void AttemptConnection()
+        finally
         {
-            TcpClientConfig tcpConfig = m_masterConfig.client;
-            string portName = tcpConfig.address + ":" + tcpConfig.port;
-            TimeSpan minRetry = TimeSpan.FromMilliseconds(tcpConfig.minRetryMs);
-            TimeSpan maxRetry = TimeSpan.FromMilliseconds(tcpConfig.maxRetryMs);
-            TimeSpan reconnectDelay = TimeSpan.FromMilliseconds(tcpConfig.reconnectDelayMs);
-            ChannelRetry channelRetry = new ChannelRetry(minRetry, maxRetry, reconnectDelay);
-            IChannelListener channelListener = new ChannelListener(state => OnStatusMessage(MessageLevel.Info, portName + " - Channel state change: " + state));
-
-            IChannel channel = s_manager.AddTCPClient(portName, tcpConfig.level, channelRetry, new[] { new IPEndpoint(tcpConfig.address, tcpConfig.port) }, channelListener);
-            m_channel = channel;
-
-            IMaster master = channel.AddMaster(portName, m_soeHandler, DefaultMasterApplication.Instance, m_masterConfig.master);
-
-            if (m_pollingInterval > TimeSpan.Zero)
-                master.AddClassScan(ClassField.AllClasses, m_pollingInterval, m_soeHandler, TaskConfig.Default);
-
-            master.Enable();
-            m_active = true;
+            m_disposed = true;          // Prevent duplicate dispose.
+            base.Dispose(disposing);    // Call base class Dispose().
         }
-
-        /// <summary>
-        /// Attempts to disconnect from data input source.
-        /// </summary>
-        /// <remarks>
-        /// Derived classes should attempt disconnect from data input source here.  Any exceptions thrown
-        /// by this implementation will be reported to host via <see cref="AdapterBase.ProcessException"/> event.
-        /// </remarks>
-        protected override void AttemptDisconnection()
-        {
-            if (!m_active)
-                return;
-
-            m_active = false;
-
-            if (m_channel != null)
-            {
-                m_channel.Shutdown();
-                m_channel = null;
-            }
-        }
-
-        /// <summary>
-        /// Gets a short one-line status of this <see cref="DNP3InputAdapter"/>.
-        /// </summary>
-        /// <param name="maxLength">Maximum number of available characters for display.</param>
-        /// <returns>A short one-line summary of the current status of this <see cref="DNP3InputAdapter"/>.</returns>
-        public override string GetShortStatus(int maxLength) => 
-            $"Received {ProcessedMeasurements:N0} measurements so far...".CenterText(maxLength);
-
-        #endregion
-
-        #region [ Static ]
-
-        // Static Fields
-
-        // DNP3 manager shared across all of the DNP3 input adapters, concurrency level defaults to number of processors
-        private static readonly IDNP3Manager s_manager;
-
-        // We maintain a list of dnp3 adapters that can be used as status adapters for proxying messages from manager
-        private static readonly List<DNP3InputAdapter> s_adapters;
-        private static DNP3InputAdapter s_statusProxy;
-
-        // Static Constructor
-        static DNP3InputAdapter()
-        {
-            s_adapters = new List<DNP3InputAdapter>();
-            s_manager = DNP3ManagerFactory.CreateManager(Environment.ProcessorCount, new IaonProxyLogHandler());
-        }
-
-        // Static Methods
-        private static T ReadConfig<T>(string path)
-        {
-            XmlSerializer serializer = new XmlSerializer(typeof(T));
-
-            using (TextReader reader = new StreamReader(FilePath.GetAbsolutePath(path)))
-            {
-                return (T)serializer.Deserialize(reader);
-            }
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes <see cref="DNP3InputAdapter"/>
+    /// </summary>
+    public override void Initialize()
+    {
+        Dictionary<string, string> settings = Settings;
+
+        base.Initialize();
+
+        if (!settings.TryGetValue(nameof(CommsFilePath), out string setting) || string.IsNullOrWhiteSpace(setting))
+            throw new ArgumentException($"The required {nameof(CommsFilePath)} parameter was not specified");
+
+        CommsFilePath = FilePath.GetAbsolutePath(setting);
+
+        if (!File.Exists(CommsFilePath))
+            throw new FileNotFoundException($"The specified {nameof(CommsFilePath)} \"{CommsFilePath}\" was not found");
+
+        m_masterConfig = ReadConfig<MasterConfiguration>(CommsFilePath);
+
+        if (!settings.TryGetValue(nameof(MappingFilePath), out setting) || string.IsNullOrWhiteSpace(setting))
+            throw new ArgumentException($"The required {nameof(MappingFilePath)} parameter was not specified");
+
+        MappingFilePath = FilePath.GetAbsolutePath(setting);
+
+        if (!File.Exists(MappingFilePath))
+            throw new FileNotFoundException($"The specified {nameof(MappingFilePath)} \"{MappingFilePath}\" was not found");
+
+        MeasurementMap measurementMap = ReadConfig<MeasurementMap>(MappingFilePath);
+
+        MapQualityToStateFlags = !settings.TryGetValue(nameof(MapQualityToStateFlags), out setting) || setting.ParseBoolean();
+
+        MeasurementLookup measurementLookup = new(measurementMap) { MapQualityToStateFlags = MapQualityToStateFlags };
+
+        m_soeHandler = new TimeSeriesSOEHandler(measurementLookup);
+        m_soeHandler.NewMeasurements += OnNewMeasurements;
+
+        // The TimestampDifferentiation property is a pass-through to the m_soeHandler.TimestampDifferentiation,
+        // so m_soeHandler must be initialized before reading this property from the connection string
+        if (settings.TryGetValue(nameof(TimestampDifferentiation), out setting) && double.TryParse(setting, out double timestampDifferentiation))
+            TimestampDifferentiation = timestampDifferentiation;
+        else
+            TimestampDifferentiation = DefaultTimestampDifferentiation;
+
+        m_soeHandler.TimestampDifferentiation = TimeSpan.FromMilliseconds(TimestampDifferentiation);
+
+        if (settings.TryGetValue(nameof(PollingInterval), out setting) && double.TryParse(setting, out double pollingInterval))
+            PollingInterval = pollingInterval;
+
+        // Attach to output measurements for DNP3 device - just informs routing engine of expected measurements
+        OutputMeasurements = ParseOutputMeasurements(DataSource, false, $"FILTER ActiveMeasurements WHERE Device = '{Name}'");
+
+        lock (s_adapters)
+        {
+            // Add adapter to list of available adapters 
+            s_adapters.Add(this);
+
+            // If no adapter has been designated as the status proxy, assign this one
+            s_statusProxy ??= this;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to connect to data input source.
+    /// </summary>
+    /// <remarks>
+    /// Derived classes should attempt connection to data input source here.  Any exceptions thrown
+    /// by this implementation will result in restart of the connection cycle.
+    /// </remarks>
+    protected override void AttemptConnection()
+    {
+        TcpClientConfig tcpConfig = m_masterConfig.client;
+        string endPoint = $"{tcpConfig.address}:{tcpConfig.port}";
+        TimeSpan minRetry = TimeSpan.FromMilliseconds(tcpConfig.minRetryMs);
+        TimeSpan maxRetry = TimeSpan.FromMilliseconds(tcpConfig.maxRetryMs);
+        TimeSpan reconnectDelay = TimeSpan.FromMilliseconds(tcpConfig.reconnectDelayMs);
+        ChannelRetry channelRetry = new(minRetry, maxRetry, reconnectDelay);
+        IChannelListener channelListener = new ChannelListener(state => OnStatusMessage(MessageLevel.Info, $"{endPoint} - Channel state change: {state}"));
+
+        IChannel channel = s_manager.AddTCPClient(endPoint, tcpConfig.level, channelRetry, [new IPEndpoint(tcpConfig.address, tcpConfig.port)], channelListener);
+        m_channel = channel;
+
+        IMaster master = channel.AddMaster(endPoint, m_soeHandler, DefaultMasterApplication.Instance, m_masterConfig.master);
+
+        if (m_pollingInterval > TimeSpan.Zero)
+            master.AddClassScan(ClassField.AllClasses, m_pollingInterval, m_soeHandler, TaskConfig.Default);
+
+        master.Enable();
+        m_active = true;
+    }
+
+    /// <summary>
+    /// Attempts to disconnect from data input source.
+    /// </summary>
+    /// <remarks>
+    /// Derived classes should attempt disconnect from data input source here.  Any exceptions thrown
+    /// by this implementation will be reported to host via <see cref="AdapterBase.ProcessException"/> event.
+    /// </remarks>
+    protected override void AttemptDisconnection()
+    {
+        if (!m_active)
+            return;
+
+        m_active = false;
+
+        if (m_channel is null)
+            return;
+
+        m_channel.Shutdown();
+        m_channel = null;
+    }
+
+    /// <summary>
+    /// Gets a short one-line status of this <see cref="DNP3InputAdapter"/>.
+    /// </summary>
+    /// <param name="maxLength">Maximum number of available characters for display.</param>
+    /// <returns>A short one-line summary of the current status of this <see cref="DNP3InputAdapter"/>.</returns>
+    public override string GetShortStatus(int maxLength)
+    {
+        return $"Received {ProcessedMeasurements:N0} measurements so far...".CenterText(maxLength);
+    }
+
+    #endregion
+
+    #region [ Static ]
+
+    // Static Fields
+
+    // DNP3 manager shared across all the DNP3 input adapters, concurrency level defaults to number of processors
+    private static readonly IDNP3Manager s_manager;
+
+    // We maintain a list of dnp3 adapters that can be used as status adapters for proxying messages from manager
+    private static readonly List<DNP3InputAdapter> s_adapters;
+    private static DNP3InputAdapter s_statusProxy;
+
+    // Static Constructor
+    static DNP3InputAdapter()
+    {
+        s_adapters = [];
+        s_manager = DNP3ManagerFactory.CreateManager(Environment.ProcessorCount, new IaonProxyLogHandler());
+    }
+
+    // Static Methods
+    private static T ReadConfig<T>(string path)
+    {
+        XmlSerializer serializer = new(typeof(T));
+
+        using TextReader reader = new StreamReader(FilePath.GetAbsolutePath(path));
+        return (T)serializer.Deserialize(reader);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
@@ -171,7 +171,7 @@ public class DNP3InputAdapter : InputAdapterBase
     // This flag is used to determine if the adapter should include DNP3 quality flags as part of the measurement outputs.
     // The "TagMatchPattern" and "QualityTagSuffix" properties are used to determine the tag name for the quality flags.
     // Generally, the value tag format is assumed to be "<TagName><SignalType>" and the quality tag format is assumed to
-    // be a variation of the value tag format with a suffix appended to the tag name, e.g., "<TagName><SignalType>!FLAGS".
+    // be a variation of the value tag format with a suffix appended to the tag name, e.g., "<TagName>!FLAGS<SignalType>".
     // In this current implementation, quality flags measurements are expected to be an analog signal type, i.e.: "ALOG".
     [ConnectionStringParameter]
     [Description("Define flag that determines if DNP3 quality flags should be published as separate measurement outputs.")]

--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3InputAdapter.cs
@@ -118,11 +118,11 @@ public class DNP3InputAdapter : InputAdapterBase
     private const string DefaultQualityTagSuffix = "!FLAGS";
 
     // Fields
-    private TimeSpan m_pollingInterval;         // Interval, in seconds, at which the adapter will poll the DNP3 device
+    private TimeSpan m_pollingInterval; // Interval, in seconds, at which the adapter will poll the DNP3 device
     private MasterConfiguration m_masterConfig; // Configuration for the master set during the Initialize call
-    private TimeSeriesSOEHandler m_soeHandler;  // Time-series sequence of events handler
-    private IChannel m_channel;                 // Communications channel set during the AttemptConnection call and used in AttemptDisconnect
-    private bool m_active;                      // Flag that determines if the port/master has been added so that the resource can be cleaned up
+    private TimeSeriesSOEHandler m_soeHandler; // Time-series sequence of events handler
+    private IChannel m_channel; // Communications channel set during the AttemptConnection call and used in AttemptDisconnect
+    private bool m_active; // Flag that determines if the port/master has been added so that the resource can be cleaned up
     private bool m_disposed;
 
     #endregion
@@ -288,8 +288,8 @@ public class DNP3InputAdapter : InputAdapterBase
         }
         finally
         {
-            m_disposed = true;          // Prevent duplicate dispose.
-            base.Dispose(disposing);    // Call base class Dispose().
+            m_disposed = true; // Prevent duplicate dispose.
+            base.Dispose(disposing); // Call base class Dispose().
         }
     }
 
@@ -356,7 +356,7 @@ public class DNP3InputAdapter : InputAdapterBase
             PollingInterval = pollingInterval;
 
         // Attach to output measurements for DNP3 device - just informs routing engine of expected measurements
-        if (OutputMeasurements?.Length == 0)
+        if (OutputMeasurements is null || OutputMeasurements.Length == 0)
             OutputMeasurements = ParseOutputMeasurements(DataSource, false, $"FILTER ActiveMeasurements WHERE Device = '{Name}'");
 
         lock (s_adapters)

--- a/Source/Libraries/Adapters/Dnp3Adapters/IsExternalInit.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/IsExternalInit.cs
@@ -1,0 +1,6 @@
+﻿// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices;
+
+// Class defined in .NET 5.0 and later, but not in .NET Framework or Standard 2.x.
+// Declared manually here to allow 'init' property operations.
+internal static class IsExternalInit { }

--- a/Source/Libraries/Adapters/Dnp3Adapters/MasterConfiguration.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/MasterConfiguration.cs
@@ -22,60 +22,60 @@
 //       Modified Header. 
 //
 //******************************************************************************************************
+// ReSharper disable InconsistentNaming
 
 using Automatak.DNP3.Interface;
 
-namespace DNP3Adapters
+namespace DNP3Adapters;
+
+/// <summary>
+/// Master Configuration
+/// </summary>
+public class MasterConfiguration
 {
     /// <summary>
-    /// Master Configuration
+    /// All the settings for the connection
     /// </summary>
-    public class MasterConfiguration
-    {
-        /// <summary>
-        /// All of the settings for the connection
-        /// </summary>
-        public TcpClientConfig client = new TcpClientConfig();
-
-        /// <summary>
-        /// All of the settings for the master
-        /// </summary>
-        public MasterStackConfig master = new MasterStackConfig();
-    }
+    public TcpClientConfig client = new();
 
     /// <summary>
-    /// TCP Client Configuration class.
+    /// All the settings for the master
     /// </summary>
-    public class TcpClientConfig
-    {
-        /// <summary>
-        /// IP address of host
-        /// </summary>
-        public string address = "127.0.0.1";
+    public MasterStackConfig master = new();
+}
 
-        /// <summary>
-        /// TCP port for connection
-        /// </summary>
-        public ushort port = 20000;
+/// <summary>
+/// TCP Client Configuration class.
+/// </summary>
+public class TcpClientConfig
+{
+    /// <summary>
+    /// IP address of host
+    /// </summary>
+    public string address = "127.0.0.1";
 
-        /// <summary>
-        /// Minimum connection retry interval in milliseconds
-        /// </summary>
-        public ulong minRetryMs = 5000;
+    /// <summary>
+    /// TCP port for connection
+    /// </summary>
+    public ushort port = 20000;
 
-        /// <summary>
-        /// Maximum connection retry interval in milliseconds
-        /// </summary>
-        public ulong maxRetryMs = 60000;
+    /// <summary>
+    /// Minimum connection retry interval in milliseconds
+    /// </summary>
+    public ulong minRetryMs = 5000;
 
-        /// <summary>
-        /// Reconnect delay interval in milliseconds
-        /// </summary>
-        public ulong reconnectDelayMs = 2000;
+    /// <summary>
+    /// Maximum connection retry interval in milliseconds
+    /// </summary>
+    public ulong maxRetryMs = 60000;
 
-        /// <summary>
-        /// DNP3 filter level for port messages
-        /// </summary>
-        public uint level = LogLevels.NORMAL;
-    }
+    /// <summary>
+    /// Reconnect delay interval in milliseconds
+    /// </summary>
+    public ulong reconnectDelayMs = 2000;
+
+    /// <summary>
+    /// DNP3 filter level for port messages
+    /// </summary>
+    public uint level = LogLevels.NORMAL;
 }

--- a/Source/Libraries/Adapters/Dnp3Adapters/MeasurementLookup.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/MeasurementLookup.cs
@@ -172,7 +172,7 @@ internal class MeasurementLookup
             if (qualityFlags.IsSet(DoubleBitBinaryQuality.STATE1))
                 stateFlags |= MeasurementStateFlags.AlarmHigh;
 
-            if (!qualityFlags.IsSet(DoubleBitBinaryQuality.STATE2))
+            if (qualityFlags.IsSet(DoubleBitBinaryQuality.STATE2))
                 stateFlags |= MeasurementStateFlags.AlarmLow;
 
             return stateFlags;

--- a/Source/Libraries/Adapters/Dnp3Adapters/MeasurementLookup.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/MeasurementLookup.cs
@@ -57,7 +57,7 @@ internal class MeasurementLookup
 
     public bool MapQualityToStateFlags { get; init; }
 
-    public bool AddQualityToMeasurementOutputs { get; init; }
+    public bool PublishFlagsAsSeparateMeasurements { get; init; }
 
     public Regex TagMatchRegex { get; init; }
 
@@ -352,7 +352,7 @@ internal class MeasurementLookup
 
         MeasurementKey valueKey = measurement.Key;
 
-        if (valueKey is null || !AddQualityToMeasurementOutputs)
+        if (valueKey is null || !PublishFlagsAsSeparateMeasurements)
             return;
 
         // Process quality flags as an output measurement - we cache these results since

--- a/Source/Libraries/Adapters/Dnp3Adapters/MeasurementMap.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/MeasurementMap.cs
@@ -22,92 +22,92 @@
 //       Modified Header. 
 //
 //******************************************************************************************************
+// ReSharper disable InconsistentNaming
 
 using System.Collections.Generic;
 
-namespace DNP3Adapters
+namespace DNP3Adapters;
+
+/// <summary>
+/// Mapping
+/// </summary>
+public class Mapping
 {
     /// <summary>
-    /// Mapping
+    /// Creates a new <see cref="Mapping"/>.
     /// </summary>
-    public class Mapping
+    public Mapping()
     {
-        /// <summary>
-        /// Creates a new <see cref="Mapping"/>.
-        /// </summary>
-        public Mapping()
-        {
-            tsfId = 0;
-            dnpIndex = 0;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Mapping"/> with the specified parameters.
-        /// </summary>
-        /// <param name="id">ID</param>
-        /// <param name="source">Source</param>
-        /// <param name="index">Index</param>
-        public Mapping(uint id, string source, uint index)
-        {
-            tsfId = id;
-            tsfSource = source;
-            dnpIndex = index;
-        }
-
-        /// <summary>
-        /// TSF ID
-        /// </summary>
-        public uint tsfId;
-
-        /// <summary>
-        /// TSF Source
-        /// </summary>
-        public string tsfSource;        
-        
-        /// <summary>
-        /// DNP Index
-        /// </summary>
-        public uint dnpIndex;
+        tsfId = 0;
+        dnpIndex = 0;
     }
 
     /// <summary>
-    /// Measurement Map
+    /// Creates a new <see cref="Mapping"/> with the specified parameters.
     /// </summary>
-    public class MeasurementMap
+    /// <param name="id">ID</param>
+    /// <param name="source">Source</param>
+    /// <param name="index">Index</param>
+    public Mapping(uint id, string source, uint index)
     {
-        /// <summary>
-        /// Binary Map
-        /// </summary>
-        public List<Mapping> binaryMap = new List<Mapping>();
-        
-        /// <summary>
-        /// Analog Map
-        /// </summary>
-        public List<Mapping> analogMap = new List<Mapping>();
-        
-        /// <summary>
-        /// Counter Map
-        /// </summary>
-        public List<Mapping> counterMap = new List<Mapping>();
-
-        /// <summary>
-        /// Frozen Counter Map
-        /// </summary>
-        public List<Mapping> frozenCounterMap = new List<Mapping>();
-
-        /// <summary>
-        /// double bit binary map
-        /// </summary>
-        public List<Mapping> doubleBitBinaryMap = new List<Mapping>();
-        
-        /// <summary>
-        /// Control Status Map
-        /// </summary>
-        public List<Mapping> controlStatusMap = new List<Mapping>();
-        
-        /// <summary>
-        /// Set Point Status Map
-        /// </summary>
-        public List<Mapping> setpointStatusMap = new List<Mapping>();
+        tsfId = id;
+        tsfSource = source;
+        dnpIndex = index;
     }
+
+    /// <summary>
+    /// TSF ID
+    /// </summary>
+    public uint tsfId;
+
+    /// <summary>
+    /// TSF Source
+    /// </summary>
+    public string tsfSource;        
+        
+    /// <summary>
+    /// DNP Index
+    /// </summary>
+    public uint dnpIndex;
+}
+
+/// <summary>
+/// Measurement Map
+/// </summary>
+public class MeasurementMap
+{
+    /// <summary>
+    /// Binary Map
+    /// </summary>
+    public List<Mapping> binaryMap = [];
+        
+    /// <summary>
+    /// Analog Map
+    /// </summary>
+    public List<Mapping> analogMap = [];
+        
+    /// <summary>
+    /// Counter Map
+    /// </summary>
+    public List<Mapping> counterMap = [];
+
+    /// <summary>
+    /// Frozen Counter Map
+    /// </summary>
+    public List<Mapping> frozenCounterMap = [];
+
+    /// <summary>
+    /// double bit binary map
+    /// </summary>
+    public List<Mapping> doubleBitBinaryMap = [];
+        
+    /// <summary>
+    /// Control Status Map
+    /// </summary>
+    public List<Mapping> controlStatusMap = [];
+        
+    /// <summary>
+    /// Set Point Status Map
+    /// </summary>
+    public List<Mapping> setpointStatusMap = [];
 }

--- a/Source/Tools/DNP3ConfigGenerator/Program.cs
+++ b/Source/Tools/DNP3ConfigGenerator/Program.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// ReSharper disable MustUseReturnValue
+
+using System;
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -8,91 +10,93 @@ using DNP3Adapters;
 using GSF.IO;
 using GSF.Reflection;
 
-namespace DNP3ConfigGenerator
+namespace DNP3ConfigGenerator;
+
+internal class Program
 {
-    class Program
+    private static void Main()
     {
-        static void Main()
-        {
-            // Create a new serialization of MasterConfiguration
-            XmlSerializer serializer = new XmlSerializer(typeof(MasterConfiguration));
-            StreamWriter stream = new StreamWriter("device.xml");
+        // Create a new serialization of MasterConfiguration
+        XmlSerializer serializer = new(typeof(MasterConfiguration));
+        StreamWriter stream = new("device.xml");
             
-            try
-            {
-                MasterConfiguration config = new MasterConfiguration();
-                serializer.Serialize(stream, config);
-            }
-            finally
-            {
-                stream.Close();
-            }
-
-            // Restore example mapping and latest VC redistributable
-            RestoreEmbeddedFiles();
-        }
-
-        private static void RestoreEmbeddedFiles()
+        try
         {
-            Assembly executingAssembly = AssemblyInfo.ExecutingAssembly.Assembly;
-            string targetPath = FilePath.AddPathSuffix(FilePath.GetAbsolutePath(""));
+            MasterConfiguration config = new();
+            serializer.Serialize(stream, config);
+        }
+        finally
+        {
+            stream.Close();
+        }
 
-            // This simple file restoration assumes embedded resources to restore are in root namespace
-            foreach (string name in executingAssembly.GetManifestResourceNames())
+        // Restore example mapping and needed VC redistributable installer
+        RestoreEmbeddedFiles();
+    }
+
+    private static void RestoreEmbeddedFiles()
+    {
+        Assembly executingAssembly = AssemblyInfo.ExecutingAssembly.Assembly;
+        string targetPath = FilePath.AddPathSuffix(FilePath.GetAbsolutePath(""));
+
+        // This simple file restoration assumes embedded resources to restore are in root namespace
+        foreach (string name in executingAssembly.GetManifestResourceNames())
+        {
+            using Stream resourceStream = executingAssembly.GetManifestResourceStream(name);
+
+            if (resourceStream is null)
+                continue;
+
+            const string SourceNamespace = $"{nameof(DNP3ConfigGenerator)}.";
+            string filePath = name;
+
+            // Remove namespace prefix from resource file name
+            if (filePath.StartsWith(SourceNamespace))
+                filePath = filePath.Substring(SourceNamespace.Length);
+
+            string targetFileName = Path.Combine(targetPath, filePath);
+            bool restoreFile = true;
+
+            if (File.Exists(targetFileName))
             {
-                using (Stream resourceStream = executingAssembly.GetManifestResourceStream(name))
-                {
-                    if (resourceStream == null)
-                        continue;
+                string resourceMD5 = GetMD5HashFromStream(resourceStream);
+                resourceStream.Seek(0, SeekOrigin.Begin);
+                restoreFile = !resourceMD5.Equals(GetMD5HashFromFile(targetFileName));
+            }
 
-                    string sourceNamespace = $"{nameof(DNP3ConfigGenerator)}.";
-                    string filePath = name;
+            if (!restoreFile)
+                continue;
 
-                    // Remove namespace prefix from resource file name
-                    if (filePath.StartsWith(sourceNamespace))
-                        filePath = filePath.Substring(sourceNamespace.Length);
+            string fileNameExtension = Path.GetExtension(targetFileName);
 
-                    string targetFileName = Path.Combine(targetPath, filePath);
-                    bool restoreFile = true;
+            if (string.Compare(fileNameExtension, ".exe", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(fileNameExtension, ".dll", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                // Binary file restore
+                using FileStream writer = File.Create(targetFileName);
+                resourceStream.CopyTo(writer);
+            }
+            else
+            {
+                // Text file restore
+                byte[] buffer = new byte[resourceStream.Length];
+                resourceStream.Read(buffer, 0, (int)resourceStream.Length);
 
-                    if (File.Exists(targetFileName))
-                    {
-                        string resourceMD5 = GetMD5HashFromStream(resourceStream);
-                        resourceStream.Seek(0, SeekOrigin.Begin);
-                        restoreFile = !resourceMD5.Equals(GetMD5HashFromFile(targetFileName));
-                    }
-
-                    if (!restoreFile)
-                        continue;
-
-                    if (string.Compare(Path.GetExtension(targetFileName), ".exe", StringComparison.OrdinalIgnoreCase) == 0 ||
-                        string.Compare(Path.GetExtension(targetFileName), ".dll", StringComparison.OrdinalIgnoreCase) == 0)
-                    {
-                        using (FileStream writer = File.Create(targetFileName))
-                            resourceStream.CopyTo(writer);
-                    }
-                    else
-                    {
-                        byte[] buffer = new byte[resourceStream.Length];
-                        resourceStream.Read(buffer, 0, (int)resourceStream.Length);
-
-                        using (StreamWriter writer = File.CreateText(targetFileName))
-                            writer.Write(Encoding.UTF8.GetString(buffer, 0, buffer.Length));
-                    }
-                }
+                using StreamWriter writer = File.CreateText(targetFileName);
+                writer.Write(Encoding.UTF8.GetString(buffer, 0, buffer.Length));
             }
         }
+    }
 
-        private static string GetMD5HashFromFile(string fileName)
-        {
-            using (FileStream stream = File.OpenRead(fileName))
-                return GetMD5HashFromStream(stream);
-        }
+    private static string GetMD5HashFromFile(string fileName)
+    {
+        using FileStream stream = File.OpenRead(fileName);
+        return GetMD5HashFromStream(stream);
+    }
 
-        private static string GetMD5HashFromStream(Stream stream)
-        {
-            using (MD5 md5 = MD5.Create())
-                return BitConverter.ToString(md5.ComputeHash(stream)).Replace("-", string.Empty);
-        }
+    private static string GetMD5HashFromStream(Stream stream)
+    {
+        using MD5 md5 = MD5.Create();
+        return BitConverter.ToString(md5.ComputeHash(stream)).Replace("-", string.Empty);
     }
 }


### PR DESCRIPTION
1) Added optional DNP3 quality to `MeasurementStateFlags` mappings (works for STTP) - see `MapQualityToStateFlags` property.
2) Added option to publish DNP3 quality flags as separate output measurements (works for IEEE C37.118 or STTP) - see `PublishFlagsAsSeparateMeasurements` property.


Like value measurements, quality measurements are expected to be pre-defined outside the adapter, i.e., the adapter does not currently auto-create tags. There is an external Python script that exists for this purpose. 

The `PublishFlagsAsSeparateMeasurements` property is used to determine if the adapter should include DNP3 quality flags as part of the measurement outputs. The `TagMatchPattern` and `QualityTagSuffix` properties are used to determine the tag name for the quality flags. 

Generally, the value tag format is assumed to be `<TagName><SignalType>` and the quality tag format is assumed to be a variation of the value tag format with a suffix appended to the tag name, e.g., `<TagName>!FLAGS<SignalType>`. In this initial implementation, quality flag measurements are expected to be an analog signal type, i.e.: `ALOG`.