### PR TITLE
PhasorMeasurementMapper: Optional alternate access ID specification fix

### DIFF
--- a/Source/Libraries/Adapters/PhasorProtocolAdapters/PhasorMeasurementMapper.cs
+++ b/Source/Libraries/Adapters/PhasorProtocolAdapters/PhasorMeasurementMapper.cs
@@ -965,13 +965,18 @@ namespace PhasorProtocolAdapters
                     string[] parts = server.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
                     if (parts.Length == 0)
-                        continue;
+                    {
+                        serverList.Add(server);
+                        accessIDList.Add(defaultAccessID);
+                    }
+                    else
+                    {
+                        if (parts.Length < 2 || !ushort.TryParse(parts[1], out ushort accessID))
+                            accessID = defaultAccessID;
 
-                    if (parts.Length < 2 || !ushort.TryParse(parts[1], out ushort accessID))
-                        accessID = defaultAccessID;
-
-                    serverList.Add(parts[0].Trim());
-                    accessIDList.Add(accessID);
+                        serverList.Add(parts[0].Trim());
+                        accessIDList.Add(accessID);
+                    }
                 }
 
                 settings["server"] = string.Join(",", serverList);


### PR DESCRIPTION
Updated `PhasorMeasurementMapper` alternate access ID specification to properly handle optional specification.

This fix came about after copying same code into the `StreamSplitter` `StreamProxy` class for equivalent functionality.