### PR TITLE
GrafanaAdapters: Implement square distribution to differentiate overlapping points on a map

### DIFF
--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/QueryParameters.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/QueryParameters.cs
@@ -72,6 +72,11 @@ public class QueryParameters
     public string RadialDistribution { get; set; }
 
     /// <summary>
+    /// Gets or sets any defined rectangular distribution request parameters defined in the query
+    /// </summary>
+    public string SquareDistribution { get; set; }
+
+    /// <summary>
     /// Gets or sets metadata selections for the query.
     /// </summary>
     public (string tableName, string[] fieldNames)[] MetadataSelections { get; set; }


### PR DESCRIPTION
The square distribution supports laying out overlapping points in a grid pattern. It places points in an order that builds out from the center so that no matter how many points there are in an overlapping group of points, the formation still appears to be centered around the original location of the points.

You can also do a simple horizontal or vertical distribution by specifying only one of the two offset values.

**Example Grafana query:**
`FILTER ActiveMeasurements WHERE SignalType = 'FREQ'; squareDistribution={xOffset=15; yOffset=15; zoom=8}`