### PR TITLE
[DataMigrationUtility] Usability updates

### DIFF
--- a/Source/Tools/DataMigrationUtility/DataMigrationUtilityScreen.Designer.cs
+++ b/Source/Tools/DataMigrationUtility/DataMigrationUtilityScreen.Designer.cs
@@ -395,6 +395,8 @@ namespace DataMigrationUtility
             this.Messages.Size = new System.Drawing.Size(621, 133);
             this.Messages.TabIndex = 5;
             this.Messages.Text = "Messages:";
+            this.Messages.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Messages_KeyDown);
+            this.Messages.MouseDown += new System.Windows.Forms.MouseEventHandler(this.Messages_MouseDown);
             // 
             // OverallProgress
             // 

--- a/Source/Tools/DataMigrationUtility/DataMigrationUtilityScreen.Designer.cs
+++ b/Source/Tools/DataMigrationUtility/DataMigrationUtilityScreen.Designer.cs
@@ -386,9 +386,11 @@ namespace DataMigrationUtility
             this.Messages.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.Messages.BackColor = System.Drawing.SystemColors.Window;
             this.Messages.Location = new System.Drawing.Point(9, 368);
             this.Messages.Multiline = true;
             this.Messages.Name = "Messages";
+            this.Messages.ReadOnly = true;
             this.Messages.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.Messages.Size = new System.Drawing.Size(621, 133);
             this.Messages.TabIndex = 5;


### PR DESCRIPTION
The other day, Ritchie and I spent some hours trying to think of clever ways to get useful error messages out of the `DataMigrationUtility` on a customer's system while it was spamming tangentially related foreign key errors. I'm hoping this update would make it a whole lot easier to get the information we need for troubleshooting.