### PR TITLE
Update to return loaded record even when primary keys are default values

### DIFF
--- a/Source/Libraries/GSF.Core/Data/AdoDataConnection.cs
+++ b/Source/Libraries/GSF.Core/Data/AdoDataConnection.cs
@@ -766,6 +766,32 @@ namespace GSF.Data
         }
 
         /// <summary>
+        /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="Connection"/>.
+        /// </summary>
+        /// <param name="sqlFormat">Format string for the SQL statement to be executed.</param>
+        /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+        /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters.</param>
+        /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+        public bool TryRetrieveRow(string sqlFormat, out DataRow row, params object[] parameters)
+        {
+            return TryRetrieveRow(DefaultTimeout, sqlFormat, out row, parameters);
+        }
+
+        /// <summary>
+        /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="Connection"/>.
+        /// </summary>
+        /// <param name="sqlFormat">Format string for the SQL statement to be executed.</param>
+        /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+        /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+        /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters.</param>
+        /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+        public bool TryRetrieveRow(int timeout, string sqlFormat, out DataRow row, params object[] parameters)
+        {
+            string sql = GenericParameterizedQueryString(sqlFormat, parameters);
+            return Connection.TryRetrieveRow(AdapterType, sql, timeout, out row, ResolveParameters(parameters));
+        }
+
+        /// <summary>
         /// Executes the SQL statement using <see cref="Connection"/>, and returns the first <see cref="DataTable"/> 
         /// of result set, if the result set contains at least one table.
         /// </summary>

--- a/Source/Libraries/GSF.Core/Data/DataExtensions.cs
+++ b/Source/Libraries/GSF.Core/Data/DataExtensions.cs
@@ -1251,7 +1251,7 @@ namespace GSF.Data
         /// Executes the SQL statement using <see cref="IDbConnection"/>, and returns the first <see cref="DataRow"/> in the result set.
         /// </summary>
         /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
         /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
@@ -1264,7 +1264,7 @@ namespace GSF.Data
         /// Executes the SQL statement using <see cref="IDbConnection"/>, and returns the first <see cref="DataRow"/> in the result set.
         /// </summary>
         /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
@@ -1277,6 +1277,45 @@ namespace GSF.Data
                 dataTable.Rows.Add(dataTable.NewRow());
 
             return dataTable.Rows[0];
+        }
+
+
+        /// <summary>
+        /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="IDbConnection"/>.
+        /// </summary>
+        /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
+        /// <param name="sql">The SQL statement to be executed.</param>
+        /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+        /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+        /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+        public static bool TryRetrieveRow(this IDbConnection connection, Type dataAdapterType, string sql, out DataRow row, params object[] parameters)
+        {
+            return connection.TryRetrieveRow(dataAdapterType, sql, DefaultTimeoutDuration, out row, parameters);
+        }
+
+        /// <summary>
+        /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="IDbConnection"/>.
+        /// </summary>
+        /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
+        /// <param name="sql">The SQL statement to be executed.</param>
+        /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+        /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+        /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+        /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+        public static bool TryRetrieveRow(this IDbConnection connection, Type dataAdapterType, string sql, int timeout, out DataRow row, params object[] parameters)
+        {
+            DataTable dataTable = connection.RetrieveData(dataAdapterType, sql, timeout, parameters);
+
+            if (dataTable.Rows.Count == 0)
+            {
+                row = default!;
+                return false;
+            }
+
+            row = dataTable.Rows[0];
+            return true;
         }
 
         /// <summary>
@@ -1442,7 +1481,7 @@ namespace GSF.Data
         /// Executes the SQL statement using <see cref="IDbCommand"/>, and returns the first <see cref="DataRow"/> in the result set.
         /// </summary>
         /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
         /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
@@ -1455,7 +1494,7 @@ namespace GSF.Data
         /// Executes the SQL statement using <see cref="IDbCommand"/>, and returns the first <see cref="DataRow"/> in the result set.
         /// </summary>
         /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
@@ -1468,6 +1507,44 @@ namespace GSF.Data
                 dataTable.Rows.Add(dataTable.NewRow());
 
             return dataTable.Rows[0];
+        }
+
+        /// <summary>
+        /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="IDbCommand"/>.
+        /// </summary>
+        /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
+        /// <param name="sql">The SQL statement to be executed.</param>
+        /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+        /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+        /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+        public static bool TryRetrieveRow(this IDbCommand command, Type dataAdapterType, string sql, out DataRow row, params object[] parameters)
+        {
+            return command.TryRetrieveRow(dataAdapterType, sql, DefaultTimeoutDuration, out row, parameters);
+        }
+
+        /// <summary>
+        /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="IDbCommand"/>.
+        /// </summary>
+        /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
+        /// <param name="sql">The SQL statement to be executed.</param>
+        /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+        /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+        /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+        /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+        public static bool TryRetrieveRow(this IDbCommand command, Type dataAdapterType, string sql, int timeout, out DataRow row, params object[] parameters)
+        {
+            DataTable dataTable = command.RetrieveData(dataAdapterType, sql, timeout, parameters);
+
+            if (dataTable.Rows.Count == 0)
+            {
+                row = default!;
+                return false;
+            }
+
+            row = dataTable.Rows[0];
+            return true;
         }
 
         #endregion
@@ -1647,7 +1724,7 @@ namespace GSF.Data
         /// of result set, if the result set contains multiple tables.
         /// </summary>
         /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
         /// <returns>A <see cref="DataTable"/> object.</returns>
@@ -1661,7 +1738,7 @@ namespace GSF.Data
         /// of result set, if the result set contains multiple tables.
         /// </summary>
         /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
@@ -1844,7 +1921,7 @@ namespace GSF.Data
         /// of result set, if the result set contains multiple tables.
         /// </summary>
         /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
         /// <returns>A <see cref="DataTable"/> object.</returns>
@@ -1858,7 +1935,7 @@ namespace GSF.Data
         /// of result set, if the result set contains multiple tables.
         /// </summary>
         /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
@@ -2073,7 +2150,7 @@ namespace GSF.Data
         /// may contain multiple tables, depending on the SQL statement.
         /// </summary>
         /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
         /// <returns>A <see cref="DataSet"/> object.</returns>
@@ -2087,7 +2164,7 @@ namespace GSF.Data
         /// may contain multiple tables, depending on the SQL statement.
         /// </summary>
         /// <param name="connection">The <see cref="IDbConnection"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
@@ -2297,7 +2374,7 @@ namespace GSF.Data
         /// may contain multiple tables, depending on the SQL statement.
         /// </summary>
         /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
         /// <returns>A <see cref="DataSet"/> object.</returns>
@@ -2311,7 +2388,7 @@ namespace GSF.Data
         /// may contain multiple tables, depending on the SQL statement.
         /// </summary>
         /// <param name="command">The <see cref="IDbCommand"/> to use for executing the SQL statement.</param>
-        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retreieve data.</param>
+        /// <param name="dataAdapterType">The <see cref="Type"/> of data adapter to use to retrieve data.</param>
         /// <param name="sql">The SQL statement to be executed.</param>
         /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
         /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>

--- a/Source/Libraries/GSF.Core/Data/Model/TableOperations.cs
+++ b/Source/Libraries/GSF.Core/Data/Model/TableOperations.cs
@@ -1155,7 +1155,7 @@ namespace GSF.Data.Model
         {
             try
             {
-                return LoadRecord(Connection.RetrieveRow(m_selectRowSql, GetInterpretedPrimaryKeys(primaryKeys)));
+                return Connection.TryRetrieveRow(m_selectRowSql, out DataRow row, GetInterpretedPrimaryKeys(primaryKeys)) ? LoadRecord(row) : default;
             }
             catch (Exception ex)
             {
@@ -1177,7 +1177,7 @@ namespace GSF.Data.Model
         {
             try
             {
-                return LoadRecord(Connection.RetrieveRow(m_selectRowSql, GetInterpretedPrimaryKeys(primaryKeys, true)), properties ?? s_properties.Values);
+                return Connection.TryRetrieveRow(m_selectRowSql, out DataRow row, GetInterpretedPrimaryKeys(primaryKeys, true)) ? LoadRecord(row, properties ?? s_properties.Values) : default;
             }
             catch (Exception ex)
             {
@@ -1205,10 +1205,6 @@ namespace GSF.Data.Model
             try
             {
                 T record = new T();
-
-                // Make sure record exists, if not return null instead of a blank record
-                if (s_hasPrimaryKeyIdentityField && GetPrimaryKeys(row).All(Common.IsDefaultValue))
-                    return null;
 
                 foreach (PropertyInfo property in properties)
                 {


### PR DESCRIPTION
Note that function of `AddNewOrUpdateRecord` is still dependent on detection of default primary keys values.

If a model use intends to insert a record with default values for primary keys, user will need to manually differentiate between "add" and "update" operation in code and not use `AddNewOrUpdateRecord` function in this scenario.