### PR TITLE
GSF.Core: Split implementation of Middle() vs Median()

### DIFF
--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/Median.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/Median.cs
@@ -43,18 +43,18 @@ public abstract class Median<T> : GrafanaFunctionBase<T> where T : struct, IData
         public override async IAsyncEnumerable<MeasurementValue> ComputeAsync(Parameters parameters, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             // Median uses immediate in-memory array load
-            MeasurementValue[] values = (await GetDataSourceValues(parameters).OrderBy(dataValue => dataValue.Value).ToArrayAsync(cancellationToken).ConfigureAwait(false)).Median();
-            int length = values.Length;
+            List<MeasurementValue> values = await GetDataSourceValues(parameters)
+                .OrderBy(dataValue => dataValue.Value)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-            if (length == 0)
+            IEnumerable<MeasurementValue> median = values.Middle();
+
+            if (!median.Any())
                 yield break;
 
-            // Median can return two values if there is an even number of values
-            MeasurementValue result = values.Last();
-
-            if (length > 1)
-                result.Value = values[0].Value + (values[1].Value - values[0].Value) / 2.0D;
-
+            MeasurementValue result = median.Last();
+            result.Value = median.Average(mv => mv.Value);
             yield return result;
         }
     }
@@ -80,18 +80,9 @@ public abstract class Median<T> : GrafanaFunctionBase<T> where T : struct, IData
             if (magnitudes.Count == 0)
                 yield break;
 
-            double[] magnitudeMedians = magnitudes.OrderBy(value => value).Median();
-            double[] angleMedians = angles.OrderBy(value => value).Median();
-
-            double magnitudeMedian = magnitudeMedians.Last();
-            double angleMedian = angleMedians.Last();
-
             // Median can return two values if there is an even number of values
-            if (magnitudeMedians.Length > 1)
-                magnitudeMedian = magnitudeMedians[0] + (magnitudeMedians[1] - magnitudeMedians[0]) / 2.0D;
-
-            if (angleMedians.Length > 1)
-                angleMedian = angleMedians[0] + (angleMedians[1] - angleMedians[0]) / 2.0D;
+            double magnitudeMedian = magnitudes.Median().Average();
+            double angleMedian = angles.Median().Average();
 
             // Return computed results
             if (lastValue.Time > 0.0D)

--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/Median.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/Median.cs
@@ -48,9 +48,10 @@ public abstract class Median<T> : GrafanaFunctionBase<T> where T : struct, IData
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            IEnumerable<MeasurementValue> median = values.Middle();
+            // Avoid multiple enumeration warnings; memory usage is small anyway
+            List<MeasurementValue> median = values.Middle().ToList();
 
-            if (!median.Any())
+            if (median.Count == 0)
                 yield break;
 
             MeasurementValue result = median.Last();

--- a/Source/Libraries/GSF.Core/Collections/CollectionExtensions.cs
+++ b/Source/Libraries/GSF.Core/Collections/CollectionExtensions.cs
@@ -424,7 +424,7 @@ namespace GSF.Collections
         /// <returns>The median item(s) from an enumeration, or <c>null</c> if <paramref name="source"/> is <c>null</c>.</returns>
         public static IEnumerable<T> Median<T>(this IEnumerable<T> source)
         {
-            if (source == null)
+            if (source is null)
                 return null;
 
             return source
@@ -444,20 +444,21 @@ namespace GSF.Collections
         /// <returns>The middle item(s) from an enumeration, or <c>null</c> if <paramref name="source"/> is <c>null</c>.</returns>
         public static IEnumerable<T> Middle<T>(this IEnumerable<T> source)
         {
-            if (source == null)
+            if (source is null)
                 return null;
+
+            if (source is IList<T> sourceAsList)
+                return middleList(sourceAsList);
+
+            if (source is ICollection<T> sourceAsCollection)
+                return middleCollection(sourceAsCollection);
 
             // Instead of source.ToList(), we could use source.Count()
             // followed by source.Skip(...).Take(...) to avoid memory overhead
             // but at the cost of enumerating twice
-            if (source is IList<T> list)
-                return MiddleList(list);
-            if (source is ICollection<T> collection)
-                return MiddleCollection(collection);
-            else
-                return MiddleList(source.ToList());
+            return middleList(source.ToList());
 
-            IEnumerable<T> MiddleList(IList<T> list)
+            IEnumerable<T> middleList(IList<T> list)
             {
                 if (list.Count == 0)
                     yield break;
@@ -470,7 +471,7 @@ namespace GSF.Collections
                 yield return list[midIndex];
             }
 
-            IEnumerable<T> MiddleCollection(ICollection<T> collection)
+            IEnumerable<T> middleCollection(ICollection<T> collection)
             {
                 int midIndex = collection.Count / 2;
                 int takeCount = 1;


### PR DESCRIPTION
The name of the `Median()` function is misleading, which led to some sneaky logic errors in the islanding detection algorithm. Splitting the implementation like this should help to resolve potential confusion. I also snuck in some optimizations for non-array lists and collections which are not lists.