### PR TITLE
GSF.COMTRADE: Use invariant culture for double-to-string conversion when parsing timestamps

### DIFF
--- a/Source/Libraries/GSF.COMTRADE/Timestamp.cs
+++ b/Source/Libraries/GSF.COMTRADE/Timestamp.cs
@@ -66,7 +66,7 @@ namespace GSF.COMTRADE
 
             seconds += milliseconds;
 
-            parts[parts.Length - 1] = seconds.ToString("00.000000");
+            parts[parts.Length - 1] = seconds.ToString("00.000000", CultureInfo.InvariantCulture);
 
             lineImage = string.Join(":", parts).RemoveWhiteSpace();
 


### PR DESCRIPTION
See https://github.com/gemstone/comtrade/pull/8