### PR TITLE
Time deviation threshold improvements with use remote time option

### DIFF
--- a/Source/Libraries/Adapters/GrafanaAdapters/GrafanaDataSourceBase_AncillaryOperations.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/GrafanaDataSourceBase_AncillaryOperations.cs
@@ -340,7 +340,7 @@ partial class GrafanaDataSourceBase
                 // Don't use current map for distribution if it already exists in group-by map
                 if (!string.IsNullOrEmpty(groupBy) && groupMap.ContainsKey(FunctionParsing.ParseLabel(groupBy, metadata)))
                 {
-                    //Don't use this one for distribution if it is in an existing Group
+                    // Add map to list of maps with group-by
                     mapsWithGroupBy.Add(currentMap);
                     continue;
                 }
@@ -362,7 +362,7 @@ partial class GrafanaDataSourceBase
             if (matchingMaps.Count > 1)
                 groupedMaps.Add(matchingMaps.ToArray());
 
-            // Create rectangular distribution for overlapped coordinates, leaving one item at center
+            // Create translated distribution for overlapped coordinates, leaving one item at center
             EPSG3857 coordinateReference = new();
 
             foreach (MetadataMap[] maps in groupedMaps)

--- a/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/OutputStream.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/OutputStream.cs
@@ -188,6 +188,22 @@ namespace GSF.PhasorProtocols.UI.DataModels
 
                 if (leadTimeValue is not null && double.TryParse(leadTimeValue.ToString(), out double leadTime) && leadTime > 0.0D)
                     m_leadTime = leadTime;
+
+                // Set default use local clock as real-time and perform timestamp reasonability setting to that used by manager screens
+                object useRemoteTimeValue = IsolatedStorageManager.ReadFromIsolatedStorage("UseRemoteTime");
+
+                if (useRemoteTimeValue is not null && bool.TryParse(useRemoteTimeValue.ToString(), out bool useRemoteTime))
+                {
+                    if (useRemoteTime)
+                        m_useLocalClockAsRealTime = false;
+
+                    m_performTimestampReasonabilityCheck = !useRemoteTime;
+                }
+
+                object useLocalClockAsRealTimeValue = IsolatedStorageManager.ReadFromIsolatedStorage("UseLocalClockAsRealTime");
+
+                if (useLocalClockAsRealTimeValue is not null && bool.TryParse(useLocalClockAsRealTimeValue.ToString(), out bool useLocalClockAsRealTime))
+                    m_useLocalClockAsRealTime = useLocalClockAsRealTime;
             }
             catch (Exception ex)
             {

--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/HomeUserControl.xaml
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/HomeUserControl.xaml
@@ -179,16 +179,31 @@
                         <StackPanel Orientation="Vertical">
                             <GroupBox x:Name="TimeReasonabilityGroupBox" Header="Change Local Time Reasonability Parameters" FontWeight="DemiBold" Margin="5">
                                 <StackPanel Orientation="Vertical">
-                                    <Label x:Name="RecommendedValues" FontSize="10" FontStyle="Italic" HorizontalContentAlignment="Center" Margin="0 -2 0 -6">
+                                    <Label HorizontalAlignment="Stretch" Height="5" />
+                                    <Rectangle HorizontalAlignment="Stretch" Fill="Blue" Height="3"/>
+                                    <CheckBox x:Name="UseRemoteTime" IsChecked="False" HorizontalAlignment="Center" ToolTip="This turns off adapter timestamp reasonability checks and&#x0a;uses latest incoming device time as current time.">Use Remote Device Time</CheckBox>
+                                    <Rectangle HorizontalAlignment="Stretch" Fill="Blue" Height="3" Margin="0"/>
+                                    <Label x:Name="RecommendedValues" FontSize="10" FontStyle="Italic" HorizontalContentAlignment="Center" Margin="0,-2,1,-6">
                                         <TextBlock TextAlignment="Center" Margin="0">
                                             The following are recommended lag and lead time<LineBreak/>
                                             values calculated based on current clock deviation:
                                         </TextBlock>
                                     </Label>
+                                    <StackPanel Orientation="Horizontal" Margin="0 -5 0 -10">
+                                        <Label Width="80"/>
+                                        <Label Width="60" FontSize="10" HorizontalContentAlignment="Right" ClipToBounds="False" Margin="-4 5 0 0">
+                                            <TextBlock Text="Current:" ClipToBounds="False"/>
+                                        </Label>
+                                        <Label Width="70" FontSize="10"  HorizontalContentAlignment="Right" ClipToBounds="False" Margin="-1 5 0 0">
+                                            <TextBlock Text="Suggested:" ClipToBounds="False"/>
+                                        </Label>
+                                        <Label Width="10"/>
+                                    </StackPanel>
                                     <StackPanel Orientation="Horizontal">
                                         <Label Width="80" HorizontalContentAlignment="Right">
-                                            <TextBlock Text="Lag Time:"  Margin="0 3 -5 0"/>
+                                            <TextBlock Text="Lag Time:" Margin="0 3 -5 0"/>
                                         </Label>
+                                        <TextBox x:Name="CurrentLagTime" Width="50" IsEnabled="False" IsReadOnly="True" />
                                         <TextBox x:Name="LagTime" Width="50" PreviewTextInput="TimeReasonability_PreviewTextInput" TextChanged="TimeReasonability_TextChanged" />
                                         <Label Margin="-10 -2 0 0">
                                             <TextBlock Text="seconds" TextAlignment="Left"/>
@@ -198,6 +213,7 @@
                                         <Label Width="80" HorizontalContentAlignment="Right">
                                             <TextBlock Text="Lead Time:" TextAlignment="Right" Margin="0 1 -5 0"/>
                                         </Label>
+                                        <TextBox x:Name="CurrentLeadTime" Width="50" IsEnabled="False" IsReadOnly="True" />
                                         <TextBox x:Name="LeadTime" Width="50" PreviewTextInput="TimeReasonability_PreviewTextInput" TextChanged="TimeReasonability_TextChanged" />
                                         <Label Margin="-10 -3 0 0">
                                             <TextBlock Text="seconds" TextAlignment="Left"/>
@@ -219,8 +235,11 @@
                                     </Label>
                                     <CheckBox x:Name="ApplyToServer" IsChecked="False" Checked="ApplyToServer_OnChecked" Unchecked="ApplyToServer_OnUnchecked">Apply to host service (use with caution)</CheckBox>
                                     <Label x:Name="LabelServerUpdateNote" Width="250" HorizontalContentAlignment="Center">
-                                        <TextBlock x:Name="ServerUpdateNote" TextWrapping="Wrap" TextAlignment="Left" FontStyle="Italic" FontWeight="DemiBold" FontSize="11" Margin="0 0 0 0"
-                                            Text="Reasonability changes will be applied to all adapters in host service, adjust with caution." />
+                                        <TextBlock x:Name="ServerUpdateNote" TextWrapping="Wrap" TextAlignment="Left" FontStyle="Italic" FontWeight="DemiBold" FontSize="11" Margin="0 0 0 0">
+                                            Reasonability changes will be applied to all adapters in host service, adjust with caution.
+                                            <LineBreak />
+                                            If config changes later, e.g., with addition of new adapter, reapplication may be needed.
+                                        </TextBlock>
                                     </Label>
                                 </StackPanel>
                             </GroupBox>

--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputStatusMonitorUserControl.xaml.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputStatusMonitorUserControl.xaml.cs
@@ -389,7 +389,7 @@ namespace GSF.PhasorProtocols.UI.UserControls
             m_displayPhaseAngleYAxis = IsolatedStorageManager.ReadFromIsolatedStorage("DisplayPhaseAngleYAxis").ToString().ParseBoolean();
             m_displayCurrentYAxis = IsolatedStorageManager.ReadFromIsolatedStorage("DisplayCurrentYAxis").ToString().ParseBoolean();
             m_displayVoltageYAxis = IsolatedStorageManager.ReadFromIsolatedStorage("DisplayVoltageYAxis").ToString().ParseBoolean();
-            m_useLocalClockAsRealtime = IsolatedStorageManager.ReadFromIsolatedStorage("UseLocalClockAsRealtime").ToString().ParseBoolean();
+            m_useLocalClockAsRealtime = IsolatedStorageManager.ReadFromIsolatedStorage("UseLocalClockAsRealTime").ToString().ParseBoolean();
             m_ignoreBadTimestamps = IsolatedStorageManager.ReadFromIsolatedStorage("IgnoreBadTimestamps").ToString().ParseBoolean();
             ValidateSettingsAfterRead();
 


### PR DESCRIPTION
This PR adds "_current_" lead/lag time as well as configurable "_suggestion_" to lead/lag time adjustment pop-up on TSF home screens to reduce confusion on current value during updates.

Screen also now adds a checkbox that can optionally prefer most recent device time, e.g., GPS-timestamped PMU time, instead of depending on time-reasonability checks against local clock, e.g., when PMU time can be trusted more than local clock. This handles scenarios such as server having wide, floating clock time when server is domain-attached, and end user not having any other clock control options.

![image](https://github.com/user-attachments/assets/5fc1d1a8-cae6-4b85-aabc-396b194771d7)
