### PR TITLE
ExceedsAt function improvements

### DIFF
--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
@@ -114,7 +114,7 @@ public abstract class ExceedsAt<T> : GrafanaFunctionBase<T> where T : struct, ID
 
                 startValue = default;
             }
-            else if (startValue.Time == 0.0D)
+            else
             {
                 // If value does not exceed threshold, continue
                 if (!valueExceedsThreshold(dataValue))

--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
@@ -17,9 +17,10 @@ namespace GrafanaAdapters.Functions.BuiltIn;
 /// the threshold.
 /// </summary>
 /// <remarks>
-/// Signature: <c>Exceeds(threshold, [fallsBelow = false], [returnDurations = false], [reportEndMarker = false], expression)</c> -<br/>
+/// Signature: <c>ExceedsAt(threshold, [fallsBelow = false], [returnDurations = false], [reportEndMarker = false], expression)</c><br/>
 /// Returns: Series of values.<br/>
-/// Example: <c>Exceeds(60.05, true, FILTER ActiveMeasurements WHERE SignalType LIKE '%FREQ')</c><br/>
+/// Example 1: <c>ExceedsAt(60.05, false, FILTER ActiveMeasurements WHERE SignalType LIKE '%FREQ')</c><br/>
+/// Example 2: <c>Exceeds(59.95, true, FILTER ActiveMeasurements WHERE SignalType LIKE '%FREQ')</c><br/>
 /// Variants: ExceedsAt, Exceeds<br/>
 /// Execution: Deferred enumeration.
 /// </remarks>

--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
@@ -17,7 +17,7 @@ namespace GrafanaAdapters.Functions.BuiltIn;
 /// the threshold.
 /// </summary>
 /// <remarks>
-/// Signature: <c>Exceeds(threshold, [returnDurations = false], [reportEndMarker = false], expression)</c> -<br/>
+/// Signature: <c>Exceeds(threshold, [fallsBelow = false], [returnDurations = false], [reportEndMarker = false], expression)</c> -<br/>
 /// Returns: Series of values.<br/>
 /// Example: <c>Exceeds(60.05, true, FILTER ActiveMeasurements WHERE SignalType LIKE '%FREQ')</c><br/>
 /// Variants: ExceedsAt, Exceeds<br/>

--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/ExceedsAt.cs
@@ -9,11 +9,11 @@ namespace GrafanaAdapters.Functions.BuiltIn;
 
 /// <summary>
 /// Returns a series of values at which a value exceeds the given threshold. The <c>threhsold</c> parameter value is a
-/// floating-point numbers that represents the threshold to be exceeded. Second parameter, <c>fallsBelow</c>, optional,
+/// floating-point number that represents the threshold to be exceeded. Second parameter, <c>fallsBelow</c>, optional,
 /// is a boolean flag that determines if the value should be considered inversely as falling below the threshold instead
 /// of exceeding. <c>returnDurations</c>, optional, is a boolean that determines if the duration (in seconds) from where
 /// value exceeded threshold should be returned instead of the original value. Forth parameter, <c>reportEndMarker</c>,
-/// is a boolean flag that determines if a value should be reported at the point when threshold stops being exceeding.
+/// is a boolean flag that determines if a value should be reported at the point when threshold stops being exceeding
 /// the threshold.
 /// </summary>
 /// <remarks>
@@ -29,7 +29,7 @@ public abstract class ExceedsAt<T> : GrafanaFunctionBase<T> where T : struct, ID
     public override string Name => nameof(ExceedsAt<T>);
 
     /// <inheritdoc />
-    public override string Description => "Returns a series of values at which a value exceed the given threshold.";
+    public override string Description => "Returns a series of values at which a value exceeds the given threshold.";
 
     /// <inheritdoc />
     public override string[] Aliases => ["Exceeds"];
@@ -125,7 +125,7 @@ public abstract class ExceedsAt<T> : GrafanaFunctionBase<T> where T : struct, ID
             }
         }
 
-        // Handle edge case for reporting end marker where value exceeds threshold through end of series
+        // Handle edge case for reporting when value continues to exceed threshold through end of series
         if (startValue.Time == 0.0D || lastValue.Time == 0.0D)
             yield break;
 

--- a/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/FilterOutliers.cs
+++ b/Source/Libraries/Adapters/GrafanaAdapters/Functions/BuiltIn/FilterOutliers.cs
@@ -178,12 +178,12 @@ public abstract class FilterOutliers<T> : GrafanaFunctionBase<T> where T : struc
     }
 
     /// <inheritdoc />
-    public class ComputeMeasurementValue : Reference<MeasurementValue>
+    public class ComputeMeasurementValue : FilterOutliers<MeasurementValue>
     {
     }
 
     /// <inheritdoc />
-    public class ComputePhasorValue : Reference<PhasorValue>
+    public class ComputePhasorValue : FilterOutliers<PhasorValue>
     {
         // Operating on magnitude only
     }


### PR DESCRIPTION
1) Adds optional `fallsBelow` parameter that determines if the value should be considered inversely as falling below the threshold instead of exceeding.
2) Adds optional `reportEndMarker` parameter that determines if a value should be reported at the point when threshold stops being exceeding. Parameter is helpful for the Grafana state timeline panel, allowing span of threshold exceeded to be visualized (see images below). 

New signature:
```
Exceeds(threshold, [fallsBelow = false], [returnDurations = false], [reportEndMarker = false], expression)
```

![image](https://github.com/user-attachments/assets/8c5bf9c5-931d-404b-b340-608ac96afd9e)

Improved edge case handling:
![image](https://github.com/user-attachments/assets/589a3a23-59bf-4e17-93e2-78fc0f370f9d)

![image](https://github.com/user-attachments/assets/079330e9-3491-4352-9a32-17e17dae0d0a)

