### PR TITLE
GSF-12 IndependentActionAdapterManagerBase fixes

### DIFF
--- a/Source/Libraries/GSF.TimeSeries/Adapters/IndependentActionAdapterManagerBase.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/IndependentActionAdapterManagerBase.cs
@@ -531,9 +531,9 @@ namespace GSF.TimeSeries.Adapters
                 }
 
                 // Create child adapter for provided inputs to the parent bulk collection-based adapter
-                for (int i = 0; i < inputMeasurementKeys.Length; i += inputsPerAdapter)
+                for (int i = 0, adapterIndex = 0; i < inputMeasurementKeys.Length; i += inputsPerAdapter, adapterIndex++)
                 {
-                    CurrentAdapterIndex = adapters.Count;
+                    CurrentAdapterIndex = adapterIndex;
                     inputsPerAdapter = PerAdapterInputCount;
 
                     Guid[] inputs = new Guid[inputsPerAdapter];

--- a/Source/Libraries/GSF.TimeSeries/Adapters/IndependentActionAdapterManagerBase.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/IndependentActionAdapterManagerBase.cs
@@ -80,7 +80,7 @@ namespace GSF.TimeSeries.Adapters
         // Fields
         private readonly LongSynchronizedOperation m_parseConnectionString;
         private readonly LongSynchronizedOperation m_initializeChildAdapters;
-        private readonly List<MeasurementKey[]> m_inputMeasurementKeysQueue;
+        private MeasurementKey[] m_inputMeasurementKeysForInitialization;
         private bool m_disposed;
 
         #endregion
@@ -104,8 +104,6 @@ namespace GSF.TimeSeries.Adapters
             {
                 IsBackground = true
             };
-
-            m_inputMeasurementKeysQueue = new List<MeasurementKey[]>(2);
         }
 
         #endregion
@@ -458,32 +456,21 @@ namespace GSF.TimeSeries.Adapters
         /// </remarks>
         protected virtual void InitializeChildAdapterManagement(MeasurementKey[] inputMeasurementKeys)
         {
-            lock (m_inputMeasurementKeysQueue)
-            {
-                if (m_inputMeasurementKeysQueue.Count < 2)
-                    m_inputMeasurementKeysQueue.Add(inputMeasurementKeys);
-                else
-                    m_inputMeasurementKeysQueue[1] = inputMeasurementKeys;
-
-                m_initializeChildAdapters.RunOnceAsync();
-            }
+            Interlocked.Exchange(ref m_inputMeasurementKeysForInitialization, inputMeasurementKeys);
+            m_initializeChildAdapters.RunOnceAsync();
         }
 
         private void InitializeChildAdapters()
         {
-            MeasurementKey[] inputMeasurementKeys;
-
-            lock (m_inputMeasurementKeysQueue)
-            {
-                if (m_inputMeasurementKeysQueue.Count == 0)
-                    return;
-
-                inputMeasurementKeys = m_inputMeasurementKeysQueue[0];
-                m_inputMeasurementKeysQueue.RemoveAt(0);
-            }
-
             try
             {
+                MeasurementKey[] inputMeasurementKeys = Interlocked.Exchange(ref m_inputMeasurementKeysForInitialization, null);
+
+                // Indicates an extremely unlikely race condition occurred,
+                // but this is expected so don't issue a warning
+                if (inputMeasurementKeys is null)
+                    return;
+
                 // If no inputs are defined, skip setup
                 if (inputMeasurementKeys.Length == 0)
                 {

--- a/Source/Libraries/GSF.TimeSeries/Adapters/IndependentActionAdapterManagerBase.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/IndependentActionAdapterManagerBase.cs
@@ -640,6 +640,10 @@ namespace GSF.TimeSeries.Adapters
         {
             this.HandleParseConnectionString();
 
+            InputMeasurementKeys = InputMeasurementKeys
+                .Where(key => this.SignalIDExists(key.SignalID))
+                .ToArray();
+
             if (FramesPerSecond < 1)
                 FramesPerSecond = DefaultFramesPerSecond;
 


### PR DESCRIPTION
The queue of input measurement keys was unnecessary, because the synchronized operation was copying the reference to a local variable anyway. However, by keeping an old collection of input measurement keys in the queue, the adapter is much more likely to use an old collection of inputs against an updated `DataSource` leading to mismatches.

---

If you specify inputs manually by signal ID, `InputMeasurementKeys` might end up with a measurement key for an inactive measurement. This results in an error:

> Failed to initialize adapter OSCILLATIONTEST!44291B81-4467-4A33-BD1A-6C19473BFD99: Cannot use NONE as input to frequency based oscillation detector. One voltage angle input measurement is required. Cannot initialize adapter.

By filtering inactive measurements early, we avoid these types of errors. We also avoid potential desyncs between the base class and the subclass during initialization. It's unlikely that an adapter developer would want an inactive measurement in their adapter, since they can't even query metadata for it from `ActiveMeasurements`.

---

The bulk calculation adapter updates its configuration whenever the `DataSource` is updated. If a child adapter was already initialized in a prior configuration update, the child adapter will be skipped and the `adapters` collection can no longer be used to reliably determine what the `CurrentAdapterIndex` is.

As an example, consider the case where `ADAPTER1` is at index 0 and `ADAPTER2` is at index 1. If you enable `ADAPTER2` after the bulk calculator was already initialized, the child adapter for `ADAPTER1` would already be initialized. Therefore, initialization of the child adapter for `ADAPTER1` would be skipped, and `adapters.Count` is still 0. When initializing the child adapter for `ADAPTER2`, the base class informs the subclass that `CurrentAdapterIndex` is 0 so the subclass mistakenly returns the device ID for `ADAPTER1`.