### PR TITLE
GSF-13 Do not use Microsoft.Owin.Security base classes for AuthenticationMiddleware

### DIFF
--- a/Source/Libraries/GSF.Web/Security/AuthenticationOptions.cs
+++ b/Source/Libraries/GSF.Web/Security/AuthenticationOptions.cs
@@ -32,7 +32,7 @@ namespace GSF.Web.Security
     /// <summary>
     /// Represents options for authentication using <see cref="AuthenticationHandler"/>.
     /// </summary>
-    public sealed class AuthenticationOptions : Microsoft.Owin.Security.AuthenticationOptions
+    public sealed class AuthenticationOptions
     {
         #region [ Members ]
 
@@ -109,7 +109,7 @@ namespace GSF.Web.Security
         /// <summary>
         /// Creates a new instance of the <see cref="AuthenticationOptions"/> class.
         /// </summary>
-        public AuthenticationOptions() : base(SessionHandler.DefaultAuthenticationToken)
+        public AuthenticationOptions()
         {
             m_authFailureRedirectResourceCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             m_anonymousResourceCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
`AuthenticationHandler` does not depend on any of the underlying logic in the `Microsoft.Owin.Security` base classes. Removing them helps to simplify the code a bit in `AuthenticationHandler`. Furthermore, although we have not determined the root cause of the major performance issues we are seeing on client systems, testing suggests we can very likely avoid it by removing these base classes from the Owin pipeline.

Changes basically consist of implementing a handful of properties that were provided by the base classes, some minor cleanups in `AuthenticationHandler` methods, and implementing the `AuthenticationMiddleware.Invoke()` method. Nothing changes about how the middleware is used, so there should be no breaking changes downstream.