### PR TITLE
Add csproj fields from VS

### DIFF
--- a/Source/Tools/APPPDCImporter/APPPDCImporter.csproj
+++ b/Source/Tools/APPPDCImporter/APPPDCImporter.csproj
@@ -94,6 +94,7 @@
     </Compile>
     <Compile Include="MainForm.ManageHostConfig.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="APPPDCConfig.cs" />
     <Compile Include="GSFPDCConfig.cs" />

--- a/Source/Tools/SELPDCImporter/SELPDCImporter.csproj
+++ b/Source/Tools/SELPDCImporter/SELPDCImporter.csproj
@@ -94,6 +94,7 @@
     </Compile>
     <Compile Include="MainForm.ManageHostConfig.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="SELPDCConfig.cs" />
     <Compile Include="GSFPDCConfig.cs" />


### PR DESCRIPTION
Whenever I open the project in Visual Studio, it adds these `SubType` fields automatically to these two csproj files.