### PR TITLE
GSF.Core: Use anonymous principal when accessing anonymous resources

### DIFF
--- a/Source/Libraries/GSF.Web/Security/AuthenticationHandler.cs
+++ b/Source/Libraries/GSF.Web/Security/AuthenticationHandler.cs
@@ -144,7 +144,10 @@ namespace GSF.Web.Security
 
                 // No authentication required for anonymous resources
                 if (Options.IsAnonymousResource(Request.Path.Value))
+                {
+                    Request.User = AnonymousPrincipal;
                     return;
+                }
 
                 NameValueCollection queryParameters = System.Web.HttpUtility.ParseQueryString(Request.QueryString.Value);
 


### PR DESCRIPTION
The anonymous principal is used at the end of the authentication process if no `SecurityProvider` is found to assign to `Request.User`. But in the case of anonymous resources, the `AuthenticationHandler` allows the user passed in by IIS to leak into the pipeline. Then, in `AuthorizeAsync()`, the `UserHasLogoutRole()` function calls `WindowsPrincipal.IsInRole()` using a `WindowsPrincipal` representing a nonexistent Windows user on a group called `logout` that likely doesn't exist. If we replace the `WindowsPrincipal` with the anonymous principal, this should no longer happen.

Tested using SE Browser, and this change didn't cause any problems.