### PR TITLE
Updated metadata measurement save to always call reloadconfig

### DIFF
--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/ViewModels/PhasorMeasurements.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/ViewModels/PhasorMeasurements.cs
@@ -94,26 +94,16 @@ namespace GSF.PhasorProtocols.UI.ViewModels
 
         public override void Save()
         {
-            if (CurrentItem.HistorianID != null && (int)CurrentItem.HistorianID > 0)
-            {
-                base.Save();
+            base.Save();
 
-                try
-                {
-                    // Note that a ReloadConfig will call RefreshMetadata on all relevant output adapters
-                    CommonFunctions.SendCommandToService("ReloadConfig");
-                }
-                catch (Exception ex)
-                {
-                    if ((object)ex.InnerException != null)
-                        CommonFunctions.LogException(null, "Save " + DataModelName, ex.InnerException);
-                    else
-                        CommonFunctions.LogException(null, "Save " + DataModelName, ex);
-                }
-            }
-            else
+            try
             {
-                base.Save();
+                // Note that a ReloadConfig will call RefreshMetadata on all relevant output adapters
+                CommonFunctions.SendCommandToService("ReloadConfig");
+            }
+            catch (Exception ex)
+            {
+                CommonFunctions.LogException(null, $"Save {DataModelName}", ex.InnerException ?? ex);
             }
         }
 


### PR DESCRIPTION
ReloadConfig call updated to run even when no historian is defined for measurement.

This allows changes to auto-propagate over STTP on manual update.