### PR TITLE
Ensure the anonymous principal is not authenticated

### DIFF
--- a/Source/Libraries/GSF.Web/Security/AuthenticationHandler.cs
+++ b/Source/Libraries/GSF.Web/Security/AuthenticationHandler.cs
@@ -33,6 +33,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using System.Security.Claims;
 using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
@@ -109,8 +110,9 @@ namespace GSF.Web.Security
         {
             get
             {
-                IIdentity anonymousIdentity = new GenericIdentity("anonymous");
-                return new GenericPrincipal(anonymousIdentity, Array.Empty<string>());
+                Claim name = new(ClaimTypes.Name, "anonymous");
+                IIdentity anonymousIdentity = new ClaimsIdentity([name]);
+                return new ClaimsPrincipal(anonymousIdentity);
             }
         }
 


### PR DESCRIPTION
Resolves an issue with the anti-CSRF token validator.

When generating a form token, the token validator uses `IIdentity.IsAuthenticated` to determine whether to encode a username in the token. Due to the changes in #363, the `Login.cshtml` page was encoding the username "anonymous" in its form token. When validating the form token for the `AuthTest` page, the validator was expecting an empty username.

`GenericIdentity` is authenticated so long as it has a name. Therefore, it is impossible to use `GenericIdentity` to get an identity with the name `anonymous` that is not authenticated. `ClaimsIdentity` is authenticated so long as it has an authentication type so we can simply pass a name claim with no authentication type into the constructor.