### PR TITLE
Updated the VariableList expression to ignore empty values

### DIFF
--- a/Source/Libraries/Adapters/DynamicCalculator/DynamicCalculator.cs
+++ b/Source/Libraries/Adapters/DynamicCalculator/DynamicCalculator.cs
@@ -213,7 +213,7 @@ namespace DynamicCalculator
                     return;
 
                 // Build the collection of variable names with the new value
-                foreach (string token in value.Split(';'))
+                foreach (string token in value.Split([';'], StringSplitOptions.RemoveEmptyEntries))
                     AddVariable(token);
 
                 // Perform alias replacement on tokens that were not explicitly aliased


### PR DESCRIPTION
Client reported an issue with the following connection string expression:

```
VariableList={x = DMD_DIFESA!TRIGGER; y = DMD_DIFESA!WARNING;}
```

The trailing semi-colon caused an empty variable to be created.