### PR TITLE
GSF.Historian reverse query operations

### DIFF
--- a/Source/GridSolutionsFramework.sln.DotSettings
+++ b/Source/GridSolutionsFramework.sln.DotSettings
@@ -408,6 +408,7 @@
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=table_0020of_0020contents_0020section/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=_0027/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=_002C_0020best_0020possible_0020case/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ABBV/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=accessid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ALOG/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Aniket/@EntryIndexedValue">True</s:Boolean>
@@ -451,6 +452,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=indexable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Initializers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=INPM/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=intervaled/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IPHA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IPHM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISEQ/@EntryIndexedValue">True</s:Boolean>
@@ -488,6 +490,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Redeclared/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reinitializes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requestdeviceconfiguration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=resumable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ritchie/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=servername/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=setpoint/@EntryIndexedValue">True</s:Boolean>
@@ -504,10 +507,12 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Thakkar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=threadsafe/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Timelock/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=timeseriesdata/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=transportprotocol/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Trunc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unboxed/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unboxes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=UNIXTIME/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unregister/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unregistering/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unregisters/@EntryIndexedValue">True</s:Boolean>

--- a/Source/Libraries/GSF.Core/BitExtensions.cs
+++ b/Source/Libraries/GSF.Core/BitExtensions.cs
@@ -466,7 +466,7 @@ namespace GSF
         /// <returns><see cref="sbyte"/> value with specified <paramref name="bits"/> set.</returns>
         public static sbyte SetBits(this sbyte source, sbyte bits)
         {
-            return ((sbyte)(source | bits));
+            return (sbyte)(source | bits);
         }
 
         /// <summary>
@@ -491,7 +491,7 @@ namespace GSF
         /// <returns><see cref="byte"/> value with specified <paramref name="bits"/> set.</returns>
         public static byte SetBits(this byte source, byte bits)
         {
-            return ((byte)(source | bits));
+            return (byte)(source | bits);
         }
 
         /// <summary>
@@ -516,7 +516,7 @@ namespace GSF
         /// <returns><see cref="short"/> value with specified <paramref name="bits"/> set.</returns>
         public static short SetBits(this short source, short bits)
         {
-            return ((short)(source | bits));
+            return (short)(source | bits);
         }
 
         /// <summary>
@@ -541,7 +541,7 @@ namespace GSF
         /// <returns><see cref="ushort"/> value with specified <paramref name="bits"/> set.</returns>
         public static ushort SetBits(this ushort source, ushort bits)
         {
-            return ((ushort)(source | bits));
+            return (ushort)(source | bits);
         }
 
         /// <summary>
@@ -566,7 +566,7 @@ namespace GSF
         /// <returns><see cref="Int24"/> value with specified <paramref name="bits"/> set.</returns>
         public static Int24 SetBits(this Int24 source, Int24 bits)
         {
-            return (source | bits);
+            return source | bits;
         }
 
         /// <summary>
@@ -591,7 +591,7 @@ namespace GSF
         /// <returns><see cref="UInt24"/> value with specified <paramref name="bits"/> set.</returns>
         public static UInt24 SetBits(this UInt24 source, UInt24 bits)
         {
-            return (source | bits);
+            return source | bits;
         }
 
         /// <summary>
@@ -616,7 +616,7 @@ namespace GSF
         /// <returns><see cref="int"/> value with specified <paramref name="bits"/> set.</returns>
         public static int SetBits(this int source, int bits)
         {
-            return (source | bits);
+            return source | bits;
         }
 
         /// <summary>
@@ -641,7 +641,7 @@ namespace GSF
         /// <returns><see cref="uint"/> value with specified <paramref name="bits"/> set.</returns>
         public static uint SetBits(this uint source, uint bits)
         {
-            return (source | bits);
+            return source | bits;
         }
 
         /// <summary>
@@ -666,7 +666,7 @@ namespace GSF
         /// <returns><see cref="long"/> value with specified <paramref name="bits"/> set.</returns>
         public static long SetBits(this long source, long bits)
         {
-            return (source | bits);
+            return source | bits;
         }
 
         /// <summary>
@@ -691,7 +691,7 @@ namespace GSF
         /// <returns><see cref="ulong"/> value with specified <paramref name="bits"/> set.</returns>
         public static ulong SetBits(this ulong source, ulong bits)
         {
-            return (source | bits);
+            return source | bits;
         }
 
         #endregion
@@ -720,7 +720,7 @@ namespace GSF
         /// <returns><see cref="sbyte"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static sbyte ClearBits(this sbyte source, sbyte bits)
         {
-            return ((sbyte)(source & ~bits));
+            return (sbyte)(source & ~bits);
         }
 
         /// <summary>
@@ -745,7 +745,7 @@ namespace GSF
         /// <returns><see cref="byte"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static byte ClearBits(this byte source, byte bits)
         {
-            return ((byte)(source & ~bits));
+            return (byte)(source & ~bits);
         }
 
         /// <summary>
@@ -770,7 +770,7 @@ namespace GSF
         /// <returns><see cref="short"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static short ClearBits(this short source, short bits)
         {
-            return ((short)(source & ~bits));
+            return (short)(source & ~bits);
         }
 
         /// <summary>
@@ -795,7 +795,7 @@ namespace GSF
         /// <returns><see cref="ushort"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static ushort ClearBits(this ushort source, ushort bits)
         {
-            return ((ushort)(source & ~bits));
+            return (ushort)(source & ~bits);
         }
 
         /// <summary>
@@ -820,7 +820,7 @@ namespace GSF
         /// <returns><see cref="Int24"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static Int24 ClearBits(this Int24 source, Int24 bits)
         {
-            return (source & ~bits);
+            return source & ~bits;
         }
 
         /// <summary>
@@ -845,7 +845,7 @@ namespace GSF
         /// <returns><see cref="UInt24"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static UInt24 ClearBits(this UInt24 source, UInt24 bits)
         {
-            return (source & ~bits);
+            return source & ~bits;
         }
 
         /// <summary>
@@ -870,7 +870,7 @@ namespace GSF
         /// <returns><see cref="int"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static int ClearBits(this int source, int bits)
         {
-            return (source & ~bits);
+            return source & ~bits;
         }
 
         /// <summary>
@@ -895,7 +895,7 @@ namespace GSF
         /// <returns><see cref="uint"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static uint ClearBits(this uint source, uint bits)
         {
-            return (source & ~bits);
+            return source & ~bits;
         }
 
         /// <summary>
@@ -920,7 +920,7 @@ namespace GSF
         /// <returns><see cref="long"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static long ClearBits(this long source, long bits)
         {
-            return (source & ~bits);
+            return source & ~bits;
         }
 
         /// <summary>
@@ -945,7 +945,7 @@ namespace GSF
         /// <returns><see cref="ulong"/> value with specified <paramref name="bits"/> cleared.</returns>
         public static ulong ClearBits(this ulong source, ulong bits)
         {
-            return (source & ~bits);
+            return source & ~bits;
         }
 
         #endregion
@@ -1001,7 +1001,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this sbyte source, sbyte bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1053,7 +1053,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this byte source, byte bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1105,7 +1105,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this short source, short bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1157,7 +1157,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this ushort source, ushort bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1209,7 +1209,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this Int24 source, Int24 bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1261,7 +1261,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this UInt24 source, UInt24 bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1313,7 +1313,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this int source, int bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1365,7 +1365,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this uint source, uint bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1417,7 +1417,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this long source, long bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         /// <summary>
@@ -1469,7 +1469,7 @@ namespace GSF
         /// <returns>true if specified <paramref name="bits"/> are set in <paramref name="source"/> value; otherwise false.</returns>
         public static bool CheckBits(this ulong source, ulong bits, bool allBits)
         {
-            return (allBits ? ((source & bits) == bits) : ((source & bits) != 0));
+            return allBits ? (source & bits) == bits : (source & bits) != 0;
         }
 
         #endregion
@@ -1498,7 +1498,7 @@ namespace GSF
         /// <returns><see cref="sbyte"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static sbyte ToggleBits(this sbyte source, sbyte bits)
         {
-            return ((sbyte)(source ^ bits));
+            return (sbyte)(source ^ bits);
         }
 
         /// <summary>
@@ -1523,7 +1523,7 @@ namespace GSF
         /// <returns><see cref="byte"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static byte ToggleBits(this byte source, byte bits)
         {
-            return ((byte)(source ^ bits));
+            return (byte)(source ^ bits);
         }
 
         /// <summary>
@@ -1548,7 +1548,7 @@ namespace GSF
         /// <returns><see cref="short"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static short ToggleBits(this short source, short bits)
         {
-            return ((short)(source ^ bits));
+            return (short)(source ^ bits);
         }
 
         /// <summary>
@@ -1573,7 +1573,7 @@ namespace GSF
         /// <returns><see cref="ushort"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static ushort ToggleBits(this ushort source, ushort bits)
         {
-            return ((ushort)(source ^ bits));
+            return (ushort)(source ^ bits);
         }
 
         /// <summary>
@@ -1598,7 +1598,7 @@ namespace GSF
         /// <returns><see cref="Int24"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static Int24 ToggleBits(this Int24 source, Int24 bits)
         {
-            return (source ^ bits);
+            return source ^ bits;
         }
 
         /// <summary>
@@ -1623,7 +1623,7 @@ namespace GSF
         /// <returns><see cref="UInt24"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static UInt24 ToggleBits(this UInt24 source, UInt24 bits)
         {
-            return (source ^ bits);
+            return source ^ bits;
         }
 
         /// <summary>
@@ -1648,7 +1648,7 @@ namespace GSF
         /// <returns><see cref="int"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static int ToggleBits(this int source, int bits)
         {
-            return (source ^ bits);
+            return source ^ bits;
         }
 
         /// <summary>
@@ -1673,7 +1673,7 @@ namespace GSF
         /// <returns><see cref="uint"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static uint ToggleBits(this uint source, uint bits)
         {
-            return (source ^ bits);
+            return source ^ bits;
         }
 
         /// <summary>
@@ -1698,7 +1698,7 @@ namespace GSF
         /// <returns><see cref="long"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static long ToggleBits(this long source, long bits)
         {
-            return (source ^ bits);
+            return source ^ bits;
         }
 
         /// <summary>
@@ -1723,7 +1723,7 @@ namespace GSF
         /// <returns><see cref="ulong"/> value with specified <paramref name="bits"/> toggled.</returns>
         public static ulong ToggleBits(this ulong source, ulong bits)
         {
-            return (source ^ bits);
+            return source ^ bits;
         }
 
         #endregion
@@ -1752,7 +1752,7 @@ namespace GSF
         /// <returns><see cref="sbyte"/> value.</returns>
         public static sbyte GetMaskedValue(this sbyte source, sbyte bitmask)
         {
-            return ((sbyte)(source & bitmask));
+            return (sbyte)(source & bitmask);
         }
 
         /// <summary>
@@ -1777,7 +1777,7 @@ namespace GSF
         /// <returns><see cref="byte"/> value.</returns>
         public static byte GetMaskedValue(this byte source, byte bitmask)
         {
-            return ((byte)(source & bitmask));
+            return (byte)(source & bitmask);
         }
 
         /// <summary>
@@ -1802,7 +1802,7 @@ namespace GSF
         /// <returns><see cref="short"/> value.</returns>
         public static short GetMaskedValue(this short source, short bitmask)
         {
-            return ((short)(source & bitmask));
+            return (short)(source & bitmask);
         }
 
         /// <summary>
@@ -1827,7 +1827,7 @@ namespace GSF
         /// <returns><see cref="ushort"/> value.</returns>
         public static ushort GetMaskedValue(this ushort source, ushort bitmask)
         {
-            return ((ushort)(source & bitmask));
+            return (ushort)(source & bitmask);
         }
 
         /// <summary>
@@ -1852,7 +1852,7 @@ namespace GSF
         /// <returns><see cref="Int24"/> value.</returns>
         public static Int24 GetMaskedValue(this Int24 source, Int24 bitmask)
         {
-            return (source & bitmask);
+            return source & bitmask;
         }
 
         /// <summary>
@@ -1877,7 +1877,7 @@ namespace GSF
         /// <returns><see cref="UInt24"/> value.</returns>
         public static UInt24 GetMaskedValue(this UInt24 source, UInt24 bitmask)
         {
-            return (source & bitmask);
+            return source & bitmask;
         }
 
         /// <summary>
@@ -1902,7 +1902,7 @@ namespace GSF
         /// <returns><see cref="int"/> value.</returns>
         public static int GetMaskedValue(this int source, int bitmask)
         {
-            return (source & bitmask);
+            return source & bitmask;
         }
 
         /// <summary>
@@ -1927,7 +1927,7 @@ namespace GSF
         /// <returns><see cref="uint"/> value.</returns>
         public static uint GetMaskedValue(this uint source, uint bitmask)
         {
-            return (source & bitmask);
+            return source & bitmask;
         }
 
         /// <summary>
@@ -1952,7 +1952,7 @@ namespace GSF
         /// <returns><see cref="long"/> value.</returns>
         public static long GetMaskedValue(this long source, long bitmask)
         {
-            return (source & bitmask);
+            return source & bitmask;
         }
 
         /// <summary>
@@ -1977,7 +1977,7 @@ namespace GSF
         /// <returns><see cref="ulong"/> value.</returns>
         public static ulong GetMaskedValue(this ulong source, ulong bitmask)
         {
-            return (source & bitmask);
+            return source & bitmask;
         }
 
         #endregion
@@ -2008,7 +2008,7 @@ namespace GSF
         /// <returns><see cref="sbyte"/> value.</returns>
         public static sbyte SetMaskedValue(this sbyte source, sbyte bitmask, sbyte value)
         {
-            return ((sbyte)((sbyte)(source & ~bitmask) | value));
+            return (sbyte)((sbyte)(source & ~bitmask) | value);
         }
 
         /// <summary>
@@ -2035,7 +2035,7 @@ namespace GSF
         /// <returns><see cref="byte"/> value.</returns>
         public static byte SetMaskedValue(this byte source, byte bitmask, byte value)
         {
-            return ((byte)((source & ~bitmask) | value));
+            return (byte)((source & ~bitmask) | value);
         }
 
         /// <summary>
@@ -2062,7 +2062,7 @@ namespace GSF
         /// <returns><see cref="short"/> value.</returns>
         public static short SetMaskedValue(this short source, short bitmask, short value)
         {
-            return ((short)((short)(source & ~bitmask) | value));
+            return (short)((short)(source & ~bitmask) | value);
         }
 
         /// <summary>
@@ -2089,7 +2089,7 @@ namespace GSF
         /// <returns><see cref="ushort"/> value.</returns>
         public static ushort SetMaskedValue(this ushort source, ushort bitmask, ushort value)
         {
-            return ((ushort)((source & ~bitmask) | value));
+            return (ushort)((source & ~bitmask) | value);
         }
 
         /// <summary>
@@ -2116,7 +2116,7 @@ namespace GSF
         /// <returns><see cref="Int24"/> value.</returns>
         public static Int24 SetMaskedValue(this Int24 source, Int24 bitmask, Int24 value)
         {
-            return ((source & ~bitmask) | value);
+            return (source & ~bitmask) | value;
         }
 
         /// <summary>
@@ -2143,7 +2143,7 @@ namespace GSF
         /// <returns><see cref="UInt24"/> value.</returns>
         public static UInt24 SetMaskedValue(this UInt24 source, UInt24 bitmask, UInt24 value)
         {
-            return ((source & ~bitmask) | value);
+            return (source & ~bitmask) | value;
         }
 
         /// <summary>
@@ -2170,7 +2170,7 @@ namespace GSF
         /// <returns><see cref="int"/> value.</returns>
         public static int SetMaskedValue(this int source, int bitmask, int value)
         {
-            return ((source & ~bitmask) | value);
+            return (source & ~bitmask) | value;
         }
 
         /// <summary>
@@ -2197,7 +2197,7 @@ namespace GSF
         /// <returns><see cref="uint"/> value.</returns>
         public static uint SetMaskedValue(this uint source, uint bitmask, uint value)
         {
-            return ((source & ~bitmask) | value);
+            return (source & ~bitmask) | value;
         }
 
         /// <summary>
@@ -2224,7 +2224,7 @@ namespace GSF
         /// <returns><see cref="long"/> value.</returns>
         public static long SetMaskedValue(this long source, long bitmask, long value)
         {
-            return ((source & ~bitmask) | value);
+            return (source & ~bitmask) | value;
         }
 
         /// <summary>
@@ -2251,7 +2251,7 @@ namespace GSF
         /// <returns><see cref="ulong"/> value.</returns>
         public static ulong SetMaskedValue(this ulong source, ulong bitmask, ulong value)
         {
-            return ((source & ~bitmask) | value);
+            return (source & ~bitmask) | value;
         }
 
         #endregion
@@ -2259,7 +2259,7 @@ namespace GSF
         #region [ Bit Rotation Extensions ]
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2271,11 +2271,9 @@ namespace GSF
         /// </remarks>
         public static byte BitRotL(this byte value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 8); x++)
+            for (int x = 1; x <= rotations % 8; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit07);
+                bool hiBitSet = value.CheckBits(Bits.Bit07);
 
                 value <<= 1;
 
@@ -2287,7 +2285,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2299,11 +2297,9 @@ namespace GSF
         /// </remarks>
         public static sbyte BitRotL(this sbyte value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 8); x++)
+            for (int x = 1; x <= rotations % 8; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit07);
+                bool hiBitSet = value.CheckBits(Bits.Bit07);
 
                 value <<= 1;
 
@@ -2315,7 +2311,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2327,11 +2323,9 @@ namespace GSF
         /// </remarks>
         public static short BitRotL(this short value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 16); x++)
+            for (int x = 1; x <= rotations % 16; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit15);
+                bool hiBitSet = value.CheckBits(Bits.Bit15);
 
                 value <<= 1;
 
@@ -2343,7 +2337,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2355,11 +2349,9 @@ namespace GSF
         /// </remarks>
         public static ushort BitRotL(this ushort value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 16); x++)
+            for (int x = 1; x <= rotations % 16; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit15);
+                bool hiBitSet = value.CheckBits(Bits.Bit15);
 
                 value <<= 1;
 
@@ -2371,7 +2363,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2383,11 +2375,9 @@ namespace GSF
         /// </remarks>
         public static Int24 BitRotL(this Int24 value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 24); x++)
+            for (int x = 1; x <= rotations % 24; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit23);
+                bool hiBitSet = value.CheckBits(Bits.Bit23);
 
                 value <<= 1;
 
@@ -2399,7 +2389,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2411,11 +2401,9 @@ namespace GSF
         /// </remarks>
         public static UInt24 BitRotL(this UInt24 value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 24); x++)
+            for (int x = 1; x <= rotations % 24; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit23);
+                bool hiBitSet = value.CheckBits(Bits.Bit23);
 
                 value <<= 1;
 
@@ -2427,7 +2415,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2439,11 +2427,9 @@ namespace GSF
         /// </remarks>
         public static int BitRotL(this int value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 32); x++)
+            for (int x = 1; x <= rotations % 32; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit31);
+                bool hiBitSet = value.CheckBits(Bits.Bit31);
 
                 value <<= 1;
 
@@ -2455,7 +2441,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2467,11 +2453,9 @@ namespace GSF
         /// </remarks>
         public static uint BitRotL(this uint value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 32); x++)
+            for (int x = 1; x <= rotations % 32; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit31);
+                bool hiBitSet = value.CheckBits(Bits.Bit31);
 
                 value <<= 1;
 
@@ -2483,7 +2467,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2495,11 +2479,9 @@ namespace GSF
         /// </remarks>
         public static long BitRotL(this long value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 64); x++)
+            for (int x = 1; x <= rotations % 64; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit63);
+                bool hiBitSet = value.CheckBits(Bits.Bit63);
 
                 value <<= 1;
 
@@ -2511,7 +2493,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2523,11 +2505,9 @@ namespace GSF
         /// </remarks>
         public static ulong BitRotL(this ulong value, int rotations)
         {
-            bool hiBitSet;
-
-            for (int x = 1; x <= (rotations % 64); x++)
+            for (int x = 1; x <= rotations % 64; x++)
             {
-                hiBitSet = value.CheckBits(Bits.Bit63);
+                bool hiBitSet = value.CheckBits(Bits.Bit63);
 
                 value <<= 1;
 
@@ -2539,7 +2519,7 @@ namespace GSF
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2551,25 +2531,20 @@ namespace GSF
         /// </remarks>
         public static byte BitRotR(this byte value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 8); x++)
+            for (int x = 1; x <= rotations % 8; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
-
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit07);
-                else
-                    value = value.ClearBits(Bits.Bit07);
+                
+                value = loBitSet ? value.SetBits(Bits.Bit07) : value.ClearBits(Bits.Bit07);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2581,25 +2556,20 @@ namespace GSF
         /// </remarks>
         public static sbyte BitRotR(this sbyte value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 8); x++)
+            for (int x = 1; x <= rotations % 8; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit07);
-                else
-                    value = value.ClearBits(Bits.Bit07);
+                value = loBitSet ? value.SetBits(Bits.Bit07) : value.ClearBits(Bits.Bit07);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2611,25 +2581,20 @@ namespace GSF
         /// </remarks>
         public static short BitRotR(this short value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 16); x++)
+            for (int x = 1; x <= rotations % 16; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit15);
-                else
-                    value = value.ClearBits(Bits.Bit15);
+                value = loBitSet ? value.SetBits(Bits.Bit15) : value.ClearBits(Bits.Bit15);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2641,25 +2606,20 @@ namespace GSF
         /// </remarks>
         public static ushort BitRotR(this ushort value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 16); x++)
+            for (int x = 1; x <= rotations % 16; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit15);
-                else
-                    value = value.ClearBits(Bits.Bit15);
+                value = loBitSet ? value.SetBits(Bits.Bit15) : value.ClearBits(Bits.Bit15);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2671,25 +2631,20 @@ namespace GSF
         /// </remarks>
         public static Int24 BitRotR(this Int24 value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 24); x++)
+            for (int x = 1; x <= rotations % 24; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit23);
-                else
-                    value = value.ClearBits(Bits.Bit23);
+                value = loBitSet ? value.SetBits(Bits.Bit23) : value.ClearBits(Bits.Bit23);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2701,25 +2656,20 @@ namespace GSF
         /// </remarks>
         public static UInt24 BitRotR(this UInt24 value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 24); x++)
+            for (int x = 1; x <= rotations % 24; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit23);
-                else
-                    value = value.ClearBits(Bits.Bit23);
+                value = loBitSet ? value.SetBits(Bits.Bit23) : value.ClearBits(Bits.Bit23);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2731,25 +2681,20 @@ namespace GSF
         /// </remarks>
         public static int BitRotR(this int value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 32); x++)
+            for (int x = 1; x <= rotations % 32; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit31);
-                else
-                    value = value.ClearBits(Bits.Bit31);
+                value = loBitSet ? value.SetBits(Bits.Bit31) : value.ClearBits(Bits.Bit31);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2761,25 +2706,20 @@ namespace GSF
         /// </remarks>
         public static uint BitRotR(this uint value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 32); x++)
+            for (int x = 1; x <= rotations % 32; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit31);
-                else
-                    value = value.ClearBits(Bits.Bit31);
+                value = loBitSet ? value.SetBits(Bits.Bit31) : value.ClearBits(Bits.Bit31);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2791,25 +2731,20 @@ namespace GSF
         /// </remarks>
         public static long BitRotR(this long value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 64); x++)
+            for (int x = 1; x <= rotations % 64; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit63);
-                else
-                    value = value.ClearBits(Bits.Bit63);
+                value = loBitSet ? value.SetBits(Bits.Bit63) : value.ClearBits(Bits.Bit63);
             }
 
             return value;
         }
 
         /// <summary>
-        /// Performs rightwise bit-rotation for the specified number of rotations.
+        /// Performs right-wise bit-rotation for the specified number of rotations.
         /// </summary>
         /// <param name="value">Value used for bit-rotation.</param>
         /// <param name="rotations">Number of rotations to perform.</param>
@@ -2821,18 +2756,13 @@ namespace GSF
         /// </remarks>
         public static ulong BitRotR(this ulong value, int rotations)
         {
-            bool loBitSet;
-
-            for (int x = 1; x <= (rotations % 64); x++)
+            for (int x = 1; x <= rotations % 64; x++)
             {
-                loBitSet = value.CheckBits(Bits.Bit00);
+                bool loBitSet = value.CheckBits(Bits.Bit00);
 
                 value >>= 1;
 
-                if (loBitSet)
-                    value = value.SetBits(Bits.Bit63);
-                else
-                    value = value.ClearBits(Bits.Bit63);
+                value = loBitSet ? value.SetBits(Bits.Bit63) : value.ClearBits(Bits.Bit63);
             }
 
             return value;
@@ -2842,78 +2772,110 @@ namespace GSF
 
         #region [ ToBinaryString Extensions ]
 
-        private static string RemoveSign(string value) =>
-            value.Length > 0 && value[0] == '-' ? value.Substring(1) : value;
+        private static string RemoveSign(string value)
+        {
+            return value.Length > 0 && value[0] == '-' ? value.Substring(1) : value;
+        }
 
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this sbyte value) => RemoveSign(Radix2.Encode(value)).PadLeft(8, '0');
-        
+        public static string ToBinaryString(this sbyte value)
+        {
+            return RemoveSign(Radix2.Encode(value)).PadLeft(8, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this byte value) => Radix2.Encode((ushort)value).PadLeft(8, '0');
-        
+        public static string ToBinaryString(this byte value)
+        {
+            return Radix2.Encode((ushort)value).PadLeft(8, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this short value) => RemoveSign(Radix2.Encode(value)).PadLeft(16, '0');
-        
+        public static string ToBinaryString(this short value)
+        {
+            return RemoveSign(Radix2.Encode(value)).PadLeft(16, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this ushort value) => Radix2.Encode(value).PadLeft(16, '0');
-        
+        public static string ToBinaryString(this ushort value)
+        {
+            return Radix2.Encode(value).PadLeft(16, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this Int24 value) => RemoveSign(Radix2.Encode(value)).PadLeft(24, '0');
-        
+        public static string ToBinaryString(this Int24 value)
+        {
+            return RemoveSign(Radix2.Encode(value)).PadLeft(24, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this UInt24 value) => Radix2.Encode(value).PadLeft(24, '0');
-        
+        public static string ToBinaryString(this UInt24 value)
+        {
+            return Radix2.Encode(value).PadLeft(24, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this int value) => RemoveSign(Radix2.Encode(value)).PadLeft(32, '0');
-        
+        public static string ToBinaryString(this int value)
+        {
+            return RemoveSign(Radix2.Encode(value)).PadLeft(32, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this uint value) => Radix2.Encode(value).PadLeft(32, '0');
-        
+        public static string ToBinaryString(this uint value)
+        {
+            return Radix2.Encode(value).PadLeft(32, '0');
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this long value) => RemoveSign(Radix2.Encode(value).PadLeft(64, '0'));
-        
+        public static string ToBinaryString(this long value)
+        {
+            return RemoveSign(Radix2.Encode(value).PadLeft(64, '0'));
+        }
+
         /// <summary>
         /// Encodes <paramref name="value"/> as binary, i.e., a string of bit values (0 or 1).
         /// </summary>
         /// <param name="value">Integer value to encode.</param>
         /// <returns>Binary encoding of <paramref name="value"/>.</returns>
-        public static string ToBinaryString(this ulong value) => Radix2.Encode(value).PadLeft(64, '0');
+        public static string ToBinaryString(this ulong value)
+        {
+            return Radix2.Encode(value).PadLeft(64, '0');
+        }
 
         #endregion
     }

--- a/Source/Libraries/GSF.Historian/DataListener.cs
+++ b/Source/Libraries/GSF.Historian/DataListener.cs
@@ -59,1188 +59,1081 @@ using GSF.Historian.Packets;
 using GSF.Parsing;
 using GSF.Units;
 
-namespace GSF.Historian
+// ReSharper disable NonReadonlyMemberInGetHashCode
+// ReSharper disable InconsistentlySynchronizedField
+
+namespace GSF.Historian;
+
+/// <summary>
+/// Represents a listener that can receive time-series data in real-time using <see cref="System.Net.Sockets.Socket"/>s.
+/// </summary>
+/// <seealso cref="IDataPoint"/>
+/// <seealso cref="PacketParser"/>
+[ToolboxBitmap(typeof(DataListener))]
+public class DataListener : Component, ISupportLifecycle, ISupportInitialize, IProvideStatus, IPersistSettings
 {
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a listener that can receive time-series data in real-time using <see cref="System.Net.Sockets.Socket"/>s.
+    /// Specifies the default value for the <see cref="ID"/> property.
     /// </summary>
-    /// <seealso cref="IDataPoint"/>
-    /// <seealso cref="PacketParser"/>
-    [ToolboxBitmap(typeof(DataListener))]
-    public class DataListener : Component, ISupportLifecycle, ISupportInitialize, IProvideStatus, IPersistSettings
+    public const string DefaultID = "Default";
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="Server"/> property.
+    /// </summary>
+    public const string DefaultServer = "localhost";
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="Port"/> property.
+    /// </summary>
+    public const int DefaultPort = 1004;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="Protocol"/> property.
+    /// </summary>
+    public const TransportProtocol DefaultProtocol = TransportProtocol.Udp;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="ConnectToServer"/> property.
+    /// </summary>
+    public const bool DefaultConnectToServer = true;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="CacheData"/> property.
+    /// </summary>
+    public const bool DefaultCacheData = true;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="InitializeData"/> property.
+    /// </summary>
+    public const bool DefaultInitializeData = true;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="InitializeDataTimeout"/> property.
+    /// </summary>
+    public const int DefaultInitializeDataTimeout = 60000;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="PersistSettings"/> property.
+    /// </summary>
+    public const bool DefaultPersistSettings = false;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="SettingsCategory"/> property.
+    /// </summary>
+    public const string DefaultSettingsCategory = nameof(DataListener);
+
+    // Events
+
+    /// <summary>
+    /// Occurs when the <see cref="DataListener"/> is starting up.
+    /// </summary>
+    [Category("Listener")]
+    [Description("Occurs when the DataListener is starting up.")]
+    public event EventHandler ListenerStarting;
+
+    /// <summary>
+    /// Occurs when the <see cref="DataListener"/> has started.
+    /// </summary>
+    [Category("Listener")]
+    [Description("Occurs when the DataListener has started.")]
+    public event EventHandler ListenerStarted;
+
+    /// <summary>
+    /// Occurs when the <see cref="DataListener"/> is being stopped.
+    /// </summary>
+    [Category("Listener")]
+    [Description("Occurs when the DataListener is being stopped.")]
+    public event EventHandler ListenerStopping;
+
+    /// <summary>
+    /// Occurs when <see cref="DataListener"/> has stopped.
+    /// </summary>
+    [Category("Listener")]
+    [Description("Occurs when DataListener has stopped.")]
+    public event EventHandler ListenerStopped;
+
+    /// <summary>
+    /// Occurs when the underlying <see cref="System.Net.Sockets.Socket"/> connection for receiving time-series data is being attempted.
+    /// </summary>
+    [Category("Socket")]
+    [Description("Occurs when the underlying Socket connection for receiving time-series data is being attempted.")]
+    public event EventHandler SocketConnecting;
+
+    /// <summary>
+    /// Occurs when the underlying <see cref="System.Net.Sockets.Socket"/> connection for receiving time-series data is established.
+    /// </summary>
+    [Category("Socket")]
+    [Description("Occurs when the underlying Socket connection for receiving time-series data is established.")]
+    public event EventHandler SocketConnected;
+
+    /// <summary>
+    /// Occurs when the underlying <see cref="System.Net.Sockets.Socket"/> connection for receiving time-series data is terminated.
+    /// </summary>
+    [Category("Socket")]
+    [Description("Occurs when the underlying Socket connection for receiving time-series data is terminated.")]
+    public event EventHandler SocketDisconnected;
+
+    /// <summary>
+    /// Occurs when the <see cref="Data"/> is being populated on <see cref="Start"/>up.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when the Data is being populated on Startup.")]
+    public event EventHandler DataInitStart;
+
+    /// <summary>
+    /// Occurs when the <see cref="Data"/> is populated completely on <see cref="Start"/>up.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when the Data is populated completely on Startup.")]
+    public event EventHandler DataInitComplete;
+
+    /// <summary>
+    /// Occurs when the <see cref="Data"/> cannot be populated completely on <see cref="Start"/>up.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when the Data cannot be populated completely on Startup.")]
+    public event EventHandler DataInitPartial;
+
+    /// <summary>
+    /// Occurs when the <see cref="Data"/> cannot be populated on <see cref="Start"/>up due to the unavailability of the <see cref="Server"/>.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when the Data cannot be populated on Startup due to the unavailability of the Server.")]
+    public event EventHandler DataInitFailure;
+
+    /// <summary>
+    /// Occurs when time-series data is extracted from the received packets.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when time-series data is extracted from the received packets.")]
+    public event EventHandler<EventArgs<IList<IDataPoint>>> DataExtracted;
+
+    /// <summary>
+    /// Occurs when the <see cref="Data"/> has changed.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when the Data has changed.")]
+    public event EventHandler DataChanged;
+
+    // Fields
+    private string m_server;
+    private int m_port;
+    private TransportProtocol m_protocol;
+    private bool m_cacheData;
+    private bool m_initializeData;
+    private int m_initializeDataTimeout;
+    private string m_settingsCategory;
+    private readonly List<IDataPoint> m_data;
+    private readonly ConcurrentDictionary<IClient, Guid> m_clientIDs;
+    private bool m_listenerStopping;
+    private Thread m_startupThread;
+    private readonly AutoResetEvent m_initializeWaitHandle;
+
+    private bool m_initialized;
+    // WithEvents
+    private readonly TcpClient m_tcpClient;
+    private readonly UdpClient m_udpClient;
+    private readonly TcpServer m_tcpServer;
+    private readonly TcpClient m_dataInitClient;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataListener"/> class.
+    /// </summary>
+    public DataListener()
     {
-        #region [ Members ]
+        Name = DefaultID;
+        m_server = DefaultServer;
+        m_port = DefaultPort;
+        m_protocol = DefaultProtocol;
+        ConnectToServer = DefaultConnectToServer;
+        m_cacheData = DefaultCacheData;
+        m_initializeData = DefaultInitializeData;
+        m_initializeDataTimeout = DefaultInitializeDataTimeout;
+        PersistSettings = DefaultPersistSettings;
+        m_settingsCategory = DefaultSettingsCategory;
+        m_data = [];
+        m_clientIDs = new ConcurrentDictionary<IClient, Guid>();
+        m_initializeWaitHandle = new AutoResetEvent(false);
 
-        // Constants
+        Parser = new PacketParser();
+        Parser.DataParsed += PacketParser_DataParsed;
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="ID"/> property.
-        /// </summary>
-        public const string DefaultID = "Default";
+        m_tcpClient = new TcpClient();
+        m_tcpClient.ConnectionAttempt += ClientSocket_ConnectionAttempt;
+        m_tcpClient.ConnectionEstablished += ClientSocket_ConnectionEstablished;
+        m_tcpClient.ConnectionTerminated += ClientSocket_ConnectionTerminated;
+        m_tcpClient.ReceiveDataComplete += ClientSocket_ReceiveDataComplete;
+        m_clientIDs.TryAdd(m_tcpClient, Guid.NewGuid());
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="Server"/> property.
-        /// </summary>
-        public const string DefaultServer = "localhost";
+        m_udpClient = new UdpClient();
+        m_udpClient.ConnectionAttempt += ClientSocket_ConnectionAttempt;
+        m_udpClient.ConnectionEstablished += ClientSocket_ConnectionEstablished;
+        m_udpClient.ConnectionTerminated += ClientSocket_ConnectionTerminated;
+        m_udpClient.ReceiveDataComplete += ClientSocket_ReceiveDataComplete;
+        m_clientIDs.TryAdd(m_udpClient, Guid.NewGuid());
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="Port"/> property.
-        /// </summary>
-        public const int DefaultPort = 1004;
+        m_tcpServer = new TcpServer();
+        m_tcpServer.ServerStarted += ServerSocket_ServerStarted;
+        m_tcpServer.ServerStopped += ServerSocket_ServerStopped;
+        m_tcpServer.ReceiveClientDataComplete += ServerSocket_ReceiveClientDataComplete;
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="Protocol"/> property.
-        /// </summary>
-        public const TransportProtocol DefaultProtocol = TransportProtocol.Udp;
+        m_dataInitClient = new TcpClient();
+        m_dataInitClient.ConnectionString = "Server={0}:1003; interface=0.0.0.0";
+        m_dataInitClient.PayloadAware = true;
+        m_dataInitClient.MaxConnectionAttempts = 10;
+        m_dataInitClient.ReceiveDataComplete += DataInitClient_ReceiveDataComplete;
+    }
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="ConnectToServer"/> property.
-        /// </summary>
-        public const bool DefaultConnectToServer = true;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataListener"/> class.
+    /// </summary>
+    /// <param name="container"><see cref="IContainer"/> object that contains the <see cref="DataListener"/>.</param>
+    public DataListener(IContainer container)
+        : this()
+    {
+        container?.Add(this);
+    }
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="CacheData"/> property.
-        /// </summary>
-        public const bool DefaultCacheData = true;
+    #endregion
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="InitializeData"/> property.
-        /// </summary>
-        public const bool DefaultInitializeData = true;
+    #region [ Properties ]
 
-        /// <summary>
-        /// Specifies the default value for the <see cref="InitializeDataTimeout"/> property.
-        /// </summary>
-        public const int DefaultInitializeDataTimeout = 60000;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="PersistSettings"/> property.
-        /// </summary>
-        public const bool DefaultPersistSettings = false;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="SettingsCategory"/> property.
-        /// </summary>
-        public const string DefaultSettingsCategory = "DataListener";
-
-        // Events
-
-        /// <summary>
-        /// Occurs when the <see cref="DataListener"/> is starting up.
-        /// </summary>
-        [Category("Listener"),
-        Description("Occurs when the DataListener is starting up.")]
-        public event EventHandler ListenerStarting;
-
-        /// <summary>
-        /// Occurs when the <see cref="DataListener"/> has started.
-        /// </summary>
-        [Category("Listener"),
-        Description("Occurs when the DataListener has started.")]
-        public event EventHandler ListenerStarted;
-
-        /// <summary>
-        /// Occurs when the <see cref="DataListener"/> is being stopped.
-        /// </summary>
-        [Category("Listener"),
-        Description("Occurs when the DataListener is being stopped.")]
-        public event EventHandler ListenerStopping;
-
-        /// <summary>
-        /// Occurs when <see cref="DataListener"/> has stopped.
-        /// </summary>
-        [Category("Listener"),
-        Description("Occurs when DataListener has stopped.")]
-        public event EventHandler ListenerStopped;
-
-        /// <summary>
-        /// Occurs when the underlying <see cref="System.Net.Sockets.Socket"/> connection for receiving time-series data is being attempted.
-        /// </summary>
-        [Category("Socket"),
-        Description("Occurs when the underlying Socket connection for receiving time-series data is being attempted.")]
-        public event EventHandler SocketConnecting;
-
-        /// <summary>
-        /// Occurs when the underlying <see cref="System.Net.Sockets.Socket"/> connection for receiving time-series data is established.
-        /// </summary>
-        [Category("Socket"),
-        Description("Occurs when the underlying Socket connection for receiving time-series data is established.")]
-        public event EventHandler SocketConnected;
-
-        /// <summary>
-        /// Occurs when the underlying <see cref="System.Net.Sockets.Socket"/> connection for receiving time-series data is terminated.
-        /// </summary>
-        [Category("Socket"),
-        Description("Occurs when the underlying Socket connection for receiving time-series data is terminated.")]
-        public event EventHandler SocketDisconnected;
-
-        /// <summary>
-        /// Occurs when the <see cref="Data"/> is being populated on <see cref="Start"/>up.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when the Data is being populated on Startup.")]
-        public event EventHandler DataInitStart;
-
-        /// <summary>
-        /// Occurs when the <see cref="Data"/> is populated completely on <see cref="Start"/>up.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when the Data is populated completely on Startup.")]
-        public event EventHandler DataInitComplete;
-
-        /// <summary>
-        /// Occurs when the <see cref="Data"/> cannot be populated completely on <see cref="Start"/>up.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when the Data cannot be populated completely on Startup.")]
-        public event EventHandler DataInitPartial;
-
-        /// <summary>
-        /// Occurs when the <see cref="Data"/> cannot be populated on <see cref="Start"/>up due to the unavailability of the <see cref="Server"/>.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when the Data cannot be populated on Startup due to the unavailability of the Server.")]
-        public event EventHandler DataInitFailure;
-
-        /// <summary>
-        /// Occurs when time-series data is extracted from the received packets.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when time-series data is extracted from the received packets.")]
-        public event EventHandler<EventArgs<IList<IDataPoint>>> DataExtracted;
-
-        /// <summary>
-        /// Occurs when the <see cref="Data"/> has changed.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when the Data has changed.")]
-        public event EventHandler DataChanged;
-
-        // Fields
-        private string m_id;
-        private string m_server;
-        private int m_port;
-        private TransportProtocol m_protocol;
-        private bool m_connectToServer;
-        private bool m_cacheData;
-        private bool m_initializeData;
-        private int m_initializeDataTimeout;
-        private bool m_persistSettings;
-        private string m_settingsCategory;
-        private long m_totalBytesReceived;
-        private long m_totalPacketsReceived;
-        private readonly List<IDataPoint> m_data;
-        private readonly ConcurrentDictionary<IClient, Guid> m_clientIDs;
-        private bool m_listenerStopping;
-        private Thread m_startupThread;
-        private readonly AutoResetEvent m_initializeWaitHandle;
-        private bool m_disposed;
-        private bool m_initialized;
-        // WithEvents
-        private readonly PacketParser m_parser;
-        private readonly TcpClient m_tcpClient;
-        private readonly UdpClient m_udpClient;
-        private readonly TcpServer m_tcpServer;
-        private readonly TcpClient m_dataInitClient;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataListener"/> class.
-        /// </summary>
-        public DataListener()
+    /// <summary>
+    /// Gets or sets the alphanumeric identifier of the <see cref="DataListener"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    [Category(nameof(Identity))]
+    [DefaultValue(DefaultID)]
+    [Description("Alpha-numeric identifier of the DataListener.")]
+    public string ID
+    {
+        get => Name;
+        set
         {
-            m_id = DefaultID;
-            m_server = DefaultServer;
-            m_port = DefaultPort;
-            m_protocol = DefaultProtocol;
-            m_connectToServer = DefaultConnectToServer;
-            m_cacheData = DefaultCacheData;
-            m_initializeData = DefaultInitializeData;
-            m_initializeDataTimeout = DefaultInitializeDataTimeout;
-            m_persistSettings = DefaultPersistSettings;
-            m_settingsCategory = DefaultSettingsCategory;
-            m_data = new List<IDataPoint>();
-            m_clientIDs = new ConcurrentDictionary<IClient, Guid>();
-            m_initializeWaitHandle = new AutoResetEvent(false);
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
 
-            m_parser = new PacketParser();
-            m_parser.DataParsed += PacketParser_DataParsed;
-
-            m_tcpClient = new TcpClient();
-            m_tcpClient.ConnectionAttempt += ClientSocket_ConnectionAttempt;
-            m_tcpClient.ConnectionEstablished += ClientSocket_ConnectionEstablished;
-            m_tcpClient.ConnectionTerminated += ClientSocket_ConnectionTerminated;
-            m_tcpClient.ReceiveDataComplete += ClientSocket_ReceiveDataComplete;
-            m_clientIDs.TryAdd(m_tcpClient, Guid.NewGuid());
-
-            m_udpClient = new UdpClient();
-            m_udpClient.ConnectionAttempt += ClientSocket_ConnectionAttempt;
-            m_udpClient.ConnectionEstablished += ClientSocket_ConnectionEstablished;
-            m_udpClient.ConnectionTerminated += ClientSocket_ConnectionTerminated;
-            m_udpClient.ReceiveDataComplete += ClientSocket_ReceiveDataComplete;
-            m_clientIDs.TryAdd(m_udpClient, Guid.NewGuid());
-
-            m_tcpServer = new TcpServer();
-            m_tcpServer.ServerStarted += ServerSocket_ServerStarted;
-            m_tcpServer.ServerStopped += ServerSocket_ServerStopped;
-            m_tcpServer.ReceiveClientDataComplete += ServerSocket_ReceiveClientDataComplete;
-
-            m_dataInitClient = new TcpClient();
-            m_dataInitClient.ConnectionString = "Server={0}:1003; interface=0.0.0.0";
-            m_dataInitClient.PayloadAware = true;
-            m_dataInitClient.MaxConnectionAttempts = 10;
-            m_dataInitClient.ReceiveDataComplete += DataInitClient_ReceiveDataComplete;
+            Name = value;
         }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataListener"/> class.
-        /// </summary>
-        /// <param name="container"><see cref="IContainer"/> object that contains the <see cref="DataListener"/>.</param>
-        public DataListener(IContainer container)
-            : this()
+    /// <summary>
+    /// Gets or sets the DNS name or IP address of the server from where the <see cref="DataListener"/> will get the time-series data.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    [Category("Connection")]
+    [DefaultValue(DefaultServer)]
+    [Description("DNS name or IP address of the server from where the DataListener will get the time-series data.")]
+    public string Server
+    {
+        get => m_server;
+        set
         {
-            if (container != null)
-                container.Add(this);
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_server = value;
         }
+    }
 
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the alpha-numeric identifier of the <see cref="DataListener"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        [Category("Identity"),
-        DefaultValue(DefaultID),
-        Description("Alpha-numeric identifier of the DataListener.")]
-        public string ID
+    /// <summary>
+    /// Gets or sets the network port of the <see cref="Server"/> where the <see cref="DataListener"/> will connect to get the time-series data.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 0 and 65535.</exception>
+    [Category("Connection")]
+    [DefaultValue(DefaultPort)]
+    [Description("Network port of the Server where the DataListener will connect to get the time-series data.")]
+    public int Port
+    {
+        get => m_port;
+        set
         {
-            get
-            {
-                return m_id;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
+            if (!Transport.IsPortNumberValid(value.ToString()))
+                throw new ArgumentException("Value must be between 0 and 65535");
 
-                m_id = value;
-            }
+            m_port = value;
         }
+    }
 
-        /// <summary>
-        /// Gets or sets the DNS name or IP address of the server from where the <see cref="DataListener"/> will get the time-series data.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        [Category("Connection"),
-        DefaultValue(DefaultServer),
-        Description("DNS name or IP address of the server from where the DataListener will get the time-series data.")]
-        public string Server
+    /// <summary>
+    /// Gets or sets the <see cref="TransportProtocol"/> to be used for receiving time-series data from the <see cref="Server"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not Tcp or Udp.</exception>
+    [Category("Connection")]
+    [DefaultValue(DefaultProtocol)]
+    [Description("Protocol to be used for receiving time-series data from the Server.")]
+    public TransportProtocol Protocol
+    {
+        get => m_protocol;
+        set
         {
-            get
-            {
-                return m_server;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
+            if (value is not (TransportProtocol.Tcp or TransportProtocol.Udp))
+                throw new ArgumentException("Value must be Tcp or Udp");
 
-                m_server = value;
-            }
+            m_protocol = value;
         }
+    }
 
-        /// <summary>
-        /// Gets or sets the network port of the <see cref="Server"/> where the <see cref="DataListener"/> will connect to get the time-series data.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 0 and 65535.</exception>
-        [Category("Connection"),
-        DefaultValue(DefaultPort),
-        Description("Network port of the Server where the DataListener will connect to get the time-series data.")]
-        public int Port
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="DataListener"/> will connect to the <see cref="Server"/> 
+    /// for receiving the time-series data or the <see cref="Server"/> will make a connection to the <see cref="DataListener"/> on 
+    /// the specified <see cref="Port"/> for sending time-series data.
+    /// </summary>
+    [Category("Connection")]
+    [DefaultValue(DefaultConnectToServer)]
+    [Description("Indicates whether the DataListener will connect to the Server for receiving the time-series data or the Server will make a connection to the DataListener on the specified Port for sending time-series data.")]
+    public bool ConnectToServer { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="Data"/> is to be updated with the latest time-series data.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="CacheData"/> is being disabled when <see cref="InitializeData"/> is enabled.</exception>
+    [Category(nameof(Data))]
+    [DefaultValue(DefaultCacheData)]
+    [Description("Indicates whether the Data is to be updated with the latest time-series data.")]
+    public bool CacheData
+    {
+        get => m_cacheData;
+        set
         {
-            get
-            {
-                return m_port;
-            }
-            set
-            {
-                if (!Transport.IsPortNumberValid(value.ToString()))
-                    throw new ArgumentException("Value must be between 0 and 65535");
+            if (!value && m_initializeData)
+                throw new InvalidOperationException("CacheData cannot be disabled when InitializeData is enabled");
 
-                m_port = value;
-            }
+            m_cacheData = value;
         }
+    }
 
-        /// <summary>
-        /// Gets or sets the <see cref="TransportProtocol"/> to be used for receiving time-series data from the <see cref="Server"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not Tcp or Udp.</exception>
-        [Category("Connection"),
-        DefaultValue(DefaultProtocol),
-        Description("Protocol to be used for receiving time-series data from the Server.")]
-        public TransportProtocol Protocol
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="DataListener"/> will initialize the <see cref="Data"/> from the <see cref="Server"/> on startup.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="InitializeData"/> should be enabled only if the <see cref="Server"/> software on port 1003 is programmed to accept <see cref="PacketType11"/>.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException"><see cref="InitializeData"/> is being enabled when <see cref="CacheData"/> is disabled.</exception>
+    [Category(nameof(Data))]
+    [DefaultValue(DefaultInitializeData)]
+    [Description("Indicates whether the DataListener will initialize the Data from the Server on startup.")]
+    public bool InitializeData
+    {
+        get => m_initializeData;
+        set
         {
-            get
-            {
-                return m_protocol;
-            }
-            set
-            {
-                if (!(value == TransportProtocol.Tcp || value == TransportProtocol.Udp))
-                    throw new ArgumentException("Value must be Tcp or Udp");
+            if (value && !m_cacheData)
+                throw new InvalidOperationException("InitializeData cannot be enabled when CacheData is disabled");
 
-                m_protocol = value;
-            }
+            m_initializeData = value;
         }
+    }
 
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="DataListener"/> will connect to the <see cref="Server"/> 
-        /// for receiving the time-series data or the <see cref="Server"/> will make a connection to the <see cref="DataListener"/> on 
-        /// the specified <see cref="Port"/> for sending time-series data.
-        /// </summary>
-        [Category("Connection"),
-        DefaultValue(DefaultConnectToServer),
-        Description("Indicates whether the DataListener will connect to the Server for receiving the time-series data or the Server will make a connection to the DataListener on the specified Port for sending time-series data.")]
-        public bool ConnectToServer
+    /// <summary>
+    /// Gets or sets the time (in milliseconds) to wait for the <see cref="Data"/> to be initialized from the <see cref="Server"/> on <see cref="Start"/>up.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
+    [Category(nameof(Data))]
+    [DefaultValue(DefaultInitializeDataTimeout)]
+    [Description("Time (in milliseconds) to wait for the Data to be initialized from the Server on Startup.")]
+    public int InitializeDataTimeout
+    {
+        get => m_initializeDataTimeout;
+        set
         {
-            get
-            {
-                return m_connectToServer;
-            }
-            set
-            {
-                m_connectToServer = value;
-            }
+            if (value < 1)
+                throw new ArgumentException("Value must be positive");
+
+            m_initializeDataTimeout = value;
         }
+    }
 
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="Data"/> is to be updated with the latest time-series data.
-        /// </summary>
-        /// <exception cref="InvalidOperationException"><see cref="CacheData"/> is being disabled when <see cref="InitializeData"/> is enabled.</exception>
-        [Category("Data"),
-        DefaultValue(DefaultCacheData),
-        Description("Indicates whether the Data is to be updated with the latest time-series data.")]
-        public bool CacheData
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the settings of <see cref="DataListener"/> are to be saved to the config file.
+    /// </summary>
+    [Category("Persistence")]
+    [DefaultValue(DefaultPersistSettings)]
+    [Description("Indicates whether the settings of DataListener are to be saved to the config file.")]
+    public bool PersistSettings { get; set; }
+
+    /// <summary>
+    /// Gets or sets the category under which the settings of <see cref="DataListener"/> are to be saved to the config file if the <see cref="PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    [Category("Persistence")]
+    [DefaultValue(DefaultSettingsCategory)]
+    [Description("Category under which the settings of DataListener are to be saved to the config file if the PersistSettings property is set to true.")]
+    public string SettingsCategory
+    {
+        get => m_settingsCategory;
+        set
         {
-            get
-            {
-                return m_cacheData;
-            }
-            set
-            {
-                if (!value && m_initializeData)
-                    throw new InvalidOperationException("CacheData cannot be disabled when InitializeData is enabled");
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
 
-                m_cacheData = value;
-            }
+            m_settingsCategory = value;
         }
+    }
 
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="DataListener"/> will initialize the <see cref="Data"/> from the <see cref="Server"/> on startup.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="InitializeData"/> should be enabled only if the <see cref="Server"/> software on port 1003 is programmed to accept <see cref="PacketType11"/>.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException"><see cref="InitializeData"/> is being enabled when <see cref="CacheData"/> is disabled.</exception>
-        [Category("Data"),
-        DefaultValue(DefaultInitializeData),
-        Description("Indicates whether the DataListener will initialize the Data from the Server on startup.")]
-        public bool InitializeData
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="DataListener"/> is currently enabled.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Enabled"/> property is not be set by user-code directly.
+    /// </remarks>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool Enabled
+    {
+        get => RunTime != 0.0;
+        set
         {
-            get
-            {
-                return m_initializeData;
-            }
-            set
-            {
-                if (value && !m_cacheData)
-                    throw new InvalidOperationException("InitializeData cannot be enabled when CacheData is disabled");
+            if (value && !Enabled)
+                Start();
+            else if (!value && Enabled)
+                Stop();
+        }
+    }
 
-                m_initializeData = value;
+    /// <summary>
+    /// Gets a flag that indicates whether the object has been disposed.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool IsDisposed { get; private set; }
+
+    /// <summary>
+    /// Gets the newest time-series data received by the <see cref="DataListener"/>.
+    /// </summary>
+    /// <remarks>
+    /// WARNING: <see cref="Data"/> is thread unsafe. Synchronized access is required.
+    /// </remarks>
+    [Browsable(false)]
+    public IList<IDataPoint> Data => m_data.AsReadOnly();
+
+    /// <summary>
+    /// Gets the underlying <see cref="PacketParser"/> used the <see cref="DataListener"/> for extracting the time-series data.
+    /// </summary>
+    [Browsable(false)]
+    public PacketParser Parser { get; }
+
+    /// <summary>
+    /// Gets the up-time (in seconds) of the <see cref="DataListener"/>.
+    /// </summary>
+    [Browsable(false)]
+    public Time RunTime
+    {
+        get
+        {
+            if (m_tcpServer.CurrentState == ServerState.Running)
+                return m_tcpServer.RunTime;
+            
+            if (m_tcpClient.CurrentState == ClientState.Connected)
+                return m_tcpClient.ConnectionTime;
+            
+            if (m_udpClient.CurrentState == ClientState.Connected)
+                return m_udpClient.ConnectionTime;
+            
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Gets the total number of bytes received by the <see cref="DataListener"/> since it was <see cref="Start"/>ed.
+    /// </summary>
+    [Browsable(false)]
+    public long TotalBytesReceived { get; private set; }
+
+    /// <summary>
+    /// Gets the total number of packets received by the <see cref="DataListener"/> since it was <see cref="Start"/>ed.
+    /// </summary>
+    [Browsable(false)]
+    public long TotalPacketsReceived { get; private set; }
+
+    /// <summary>
+    /// Gets the unique identifier of the <see cref="DataListener"/>.
+    /// </summary>
+    [Browsable(false)]
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Gets the descriptive status of the <see cref="DataListener"/>.
+    /// </summary>
+    [Browsable(false)]
+    public string Status
+    {
+        get
+        {
+            StringBuilder status = new();
+            status.AppendLine($"                      Name: {Name}");
+            status.AppendLine($"            Server address: {m_server}");
+            status.AppendLine($"               Server port: {m_port}");
+            status.AppendLine($"        Transport protocol: {m_protocol}");
+            status.AppendLine($"      Total bytes received: {TotalBytesReceived:N0}");
+            status.AppendLine($"    Total packets received: {TotalPacketsReceived:N0}");
+            status.AppendLine($"                  Run time: {RunTime.ToString(3)}");
+
+            return status.ToString();
+        }
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes the <see cref="DataListener"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Initialize()"/> is to be called by user-code directly only if the <see cref="DataListener"/> is not consumed through the designer surface of the IDE.
+    /// </remarks>
+    public void Initialize()
+    {
+        if (m_initialized)
+            return;
+        
+        LoadSettings();         // Load settings from the config file.
+        m_initialized = true;   // Initialize only once.
+    }
+
+    /// <summary>
+    /// Performs necessary operations before the <see cref="DataListener"/> properties are initialized.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BeginInit()"/> should never be called by user-code directly. This method exists solely for use 
+    /// by the designer if the <see cref="DataListener"/> is consumed through the designer surface of the IDE.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void BeginInit()
+    {
+        if (!DesignMode)
+        {
+            try
+            {
+                // Nothing needs to be done before component is initialized.
+            }
+            catch
+            {
+                // Prevent the IDE from crashing when component is in design mode.
             }
         }
+    }
 
-        /// <summary>
-        /// Gets or sets the time (in milliseconds) to wait for the <see cref="Data"/> to be initialized from the <see cref="Server"/> on <see cref="Start"/>up.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
-        [Category("Data"),
-        DefaultValue(DefaultInitializeDataTimeout),
-        Description("Time (in milliseconds) to wait for the Data to be initialized from the Server on Startup.")]
-        public int InitializeDataTimeout
+    /// <summary>
+    /// Performs necessary operations after the <see cref="DataListener"/> properties are initialized.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EndInit()"/> should never be called by user-code directly. This method exists solely for use 
+    /// by the designer if the <see cref="DataListener"/> is consumed through the designer surface of the IDE.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void EndInit()
+    {
+        if (!DesignMode)
         {
-            get
+            try
             {
-                return m_initializeDataTimeout;
+                Initialize();
             }
-            set
+            catch
             {
-                if (value < 1)
-                    throw new ArgumentException("Value must be positive");
-
-                m_initializeDataTimeout = value;
+                // Prevent the IDE from crashing when component is in design mode.
             }
         }
+    }
 
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the settings of <see cref="DataListener"/> are to be saved to the config file.
-        /// </summary>
-        [Category("Persistence"),
-        DefaultValue(DefaultPersistSettings),
-        Description("Indicates whether the settings of DataListener are to be saved to the config file.")]
-        public bool PersistSettings
+    /// <summary>
+    /// Saves settings for the <see cref="DataListener"/> to the config file if the <see cref="PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
+    public void SaveSettings()
+    {
+        if (!PersistSettings)
+            return;
+        
+        // Ensure that settings category is specified.
+        if (string.IsNullOrEmpty(m_settingsCategory))
+            throw new ConfigurationErrorsException("SettingsCategory property has not been set");
+
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[m_settingsCategory];
+        
+        settings[nameof(ID), true].Update(Name);
+        settings[nameof(Server), true].Update(m_server);
+        settings[nameof(Port), true].Update(m_port);
+        settings[nameof(Protocol), true].Update(m_protocol);
+        settings[nameof(ConnectToServer), true].Update(ConnectToServer);
+        settings[nameof(CacheData), true].Update(m_cacheData);
+        settings[nameof(InitializeData), true].Update(m_initializeData);
+        settings[nameof(InitializeDataTimeout), true].Update(m_initializeDataTimeout);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved settings for the <see cref="DataListener"/> from the config file if the <see cref="PersistSettings"/>  property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
+    public void LoadSettings()
+    {
+        if (!PersistSettings)
+            return;
+        
+        // Ensure that settings category is specified.
+        if (string.IsNullOrEmpty(m_settingsCategory))
+            throw new ConfigurationErrorsException("SettingsCategory property has not been set");
+
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[m_settingsCategory];
+        
+        settings.Add(nameof(ID), Name, "Alpha-numeric identifier of the listener.");
+        settings.Add(nameof(Server), m_server, "DNS name or IP address of the server providing the time-series data.");
+        settings.Add(nameof(Port), m_port, "Network port at the server where the time-series data is being server.");
+        settings.Add(nameof(Protocol), m_protocol, "Protocol (Tcp; Udp) to be used for receiving time-series data.");
+        settings.Add(nameof(ConnectToServer), ConnectToServer, "True is the listener to initiate connection to the server; otherwise False;");
+        settings.Add(nameof(CacheData), m_cacheData, "True if newest data is to be cached locally; otherwise False.");
+        settings.Add(nameof(InitializeData), m_initializeData, "True if data is to be initialized from the server on startup; otherwise False.");
+        settings.Add(nameof(InitializeDataTimeout), m_initializeDataTimeout, "Number of milliseconds to wait for data to be initialized from the server on startup.");
+        
+        ID = settings[nameof(ID)].ValueAs(Name);
+        Server = settings[nameof(Server)].ValueAs(m_server);
+        Port = settings[nameof(Port)].ValueAs(m_port);
+        Protocol = settings[nameof(Protocol)].ValueAs(m_protocol);
+        ConnectToServer = settings[nameof(ConnectToServer)].ValueAs(ConnectToServer);
+        CacheData = settings[nameof(CacheData)].ValueAs(m_cacheData);
+        InitializeData = settings[nameof(InitializeData)].ValueAs(m_initializeData);
+        InitializeDataTimeout = settings[nameof(InitializeDataTimeout)].ValueAs(m_initializeDataTimeout);
+    }
+
+    /// <summary>
+    /// Starts the <see cref="DataListener"/> synchronously.
+    /// </summary>
+    public void Start()
+    {
+        if (Enabled)
+            return;
+        
+        m_listenerStopping = false;
+
+        OnListenerStarting();
+
+        if (m_initializeData)
         {
-            get
-            {
-                return m_persistSettings;
-            }
-            set
-            {
-                m_persistSettings = value;
-            }
-        }
+            // Attempt to initialize data from the server.
+            OnDataInitStart();
+            
+            m_dataInitClient.ConnectionString = string.Format(m_dataInitClient.ConnectionString, Server);
+            m_dataInitClient.Connect();
 
-        /// <summary>
-        /// Gets or sets the category under which the settings of <see cref="DataListener"/> are to be saved to the config file if the <see cref="PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        [Category("Persistence"),
-        DefaultValue(DefaultSettingsCategory),
-        Description("Category under which the settings of DataListener are to be saved to the config file if the PersistSettings property is set to true.")]
-        public string SettingsCategory
-        {
-            get
+            if (m_dataInitClient.CurrentState == ClientState.Connected)
             {
-                return m_settingsCategory;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
+                // Wait enough for the handshaking to complete.
+                Thread.Sleep(1000);
 
-                m_settingsCategory = value;
-            }
-        }
+                // We'll request current data for all points.
+                PacketType11 request = new();
+                request.RequestIDs.Add(-1);
+                m_dataInitClient.Send(request.BinaryImage());
 
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="DataListener"/> is currently enabled.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Enabled"/> property is not be set by user-code directly.
-        /// </remarks>
-        [Browsable(false),
-        EditorBrowsable(EditorBrowsableState.Never),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool Enabled
-        {
-            get
-            {
-                return (RunTime != 0.0);
-            }
-            set
-            {
-                if (value && !Enabled)
-                    Start();
-                else if (!value && Enabled)
-                    Stop();
-            }
-        }
-
-        /// <summary>
-        /// Gets a flag that indicates whether the object has been disposed.
-        /// </summary>
-        [Browsable(false),
-        EditorBrowsable(EditorBrowsableState.Never),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool IsDisposed
-        {
-            get
-            {
-                return m_disposed;
-            }
-        }
-
-        /// <summary>
-        /// Gets the newest time-series data received by the <see cref="DataListener"/>.
-        /// </summary>
-        /// <remarks>
-        /// WARNING: <see cref="Data"/> is thread unsafe. Synchronized access is required.
-        /// </remarks>
-        [Browsable(false)]
-        public IList<IDataPoint> Data
-        {
-            get
-            {
-                return m_data.AsReadOnly();
-            }
-        }
-
-        /// <summary>
-        /// Gets the underlying <see cref="PacketParser"/> used the <see cref="DataListener"/> for extracting the time-series data.
-        /// </summary>
-        [Browsable(false)]
-        public PacketParser Parser
-        {
-            get
-            {
-                return m_parser;
-            }
-        }
-
-        /// <summary>
-        /// Gets the up-time (in seconds) of the <see cref="DataListener"/>.
-        /// </summary>
-        [Browsable(false)]
-        public Time RunTime
-        {
-            get
-            {
-                if (m_tcpServer.CurrentState == ServerState.Running)
-                    return m_tcpServer.RunTime;
-                else if (m_tcpClient.CurrentState == ClientState.Connected)
-                    return m_tcpClient.ConnectionTime;
-                else if (m_udpClient.CurrentState == ClientState.Connected)
-                    return m_udpClient.ConnectionTime;
+                // Wait for the data to be initialized and timeout if it takes too long.
+                if (!m_initializeWaitHandle.WaitOne(m_initializeDataTimeout, false))
+                    OnDataInitPartial();
                 else
-                    return 0;
+                    OnDataInitComplete();
+            
+                m_dataInitClient.Disconnect();
             }
-        }
-
-        /// <summary>
-        /// Gets the total number of bytes received by the <see cref="DataListener"/> since it was <see cref="Start"/>ed.
-        /// </summary>
-        [Browsable(false)]
-        public long TotalBytesReceived
-        {
-            get
+            else
             {
-                return m_totalBytesReceived;
+                // Archiver is either not running, or is running but is a legacy Archiver.
+                OnDataInitFailure();
             }
         }
 
-        /// <summary>
-        /// Gets the total number of packets received by the <see cref="DataListener"/> since it was <see cref="Start"/>ed.
-        /// </summary>
-        [Browsable(false)]
-        public long TotalPacketsReceived
+        // Start-up the appropriate communication component that'll get the raw data.
+        if (Protocol == TransportProtocol.Udp)
         {
-            get
+            m_udpClient.ConnectionString = $"Port={Port}; interface=0.0.0.0";
+            m_udpClient.Connect(); // Start the connection cycle - try indefinitely.
+        }
+        else
+        {
+            if (ConnectToServer)
             {
-                return m_totalPacketsReceived;
+                // TCP connection - going out to the server for connection.
+                m_tcpClient.ConnectionString = $"Server={Server}:{Port}; interface=0.0.0.0";
+                m_tcpClient.Connect(); // Start the connection cycle - try indefinitely.
             }
-        }
-
-        /// <summary>
-        /// Gets the unique identifier of the <see cref="DataListener"/>.
-        /// </summary>
-        [Browsable(false)]
-        public string Name
-        {
-            get
+            else
             {
-                return m_id;
+                // TCP connection - client coming in for connection.
+                m_tcpServer.ConfigurationString = $"Port={Port}; interface=0.0.0.0";
+                m_tcpServer.Start(); // Start the connection cycle - try indefinitely.
+                OnSocketConnecting();
             }
         }
 
-        /// <summary>
-        /// Gets the descriptive status of the <see cref="DataListener"/>.
-        /// </summary>
-        [Browsable(false)]
-        public string Status
-        {
-            get
-            {
-                StringBuilder status = new StringBuilder();
-                status.AppendFormat("                      Name: {0}", m_id);
-                status.AppendLine();
-                status.AppendFormat("            Server address: {0}", m_server);
-                status.AppendLine();
-                status.AppendFormat("               Server port: {0}", m_port);
-                status.AppendLine();
-                status.AppendFormat("        Transport protocol: {0}", m_protocol);
-                status.AppendLine();
-                status.AppendFormat("      Total bytes received: {0}", m_totalBytesReceived);
-                status.AppendLine();
-                status.AppendFormat("    Total packets received: {0}", m_totalPacketsReceived);
-                status.AppendLine();
-                status.AppendFormat("                  Run time: {0}", RunTime.ToString(3));
-                status.AppendLine();
+        // Start the parser that'll parse the raw data.
+        Parser.Start();
+    }
 
-                return status.ToString();
-            }
+    /// <summary>
+    /// Starts the <see cref="DataListener"/> asynchronously.
+    /// </summary>
+    public void StartAsync()
+    {
+        // Only allow one async startup attempt.
+        if (m_startupThread is not null && m_startupThread.IsAlive)
+            return;
+
+        m_startupThread = new Thread(Start);
+        m_startupThread.Start();
+    }
+
+    /// <summary>
+    /// Stops the <see cref="DataListener"/>.
+    /// </summary>
+    public void Stop()
+    {
+        OnListenerStopping();
+
+        // Abort async startup process if it is running.
+        m_startupThread?.Abort();
+
+        // Prevent communication clients from reconnecting.
+        m_listenerStopping = true;
+
+        m_tcpServer.Stop();
+        m_tcpClient.Disconnect();
+        m_udpClient.Disconnect();
+        Parser.Stop();
+        
+        TotalBytesReceived = 0L;
+        TotalPacketsReceived = 0L;
+
+        OnListenerStopped();
+    }
+
+    /// <summary>
+    /// Gets the current data for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier whose current data is to be retrieved.</param>
+    /// <returns><see cref="IDataPoint"/> if a match is found; otherwise null.</returns>
+    public IDataPoint FindData(int historianID)
+    {
+        IDataPoint currentData = null;
+        
+        lock (m_data)
+        {
+            // If valid ID is specified, lookup it's current data.
+            if (historianID > 0 && historianID <= m_data.Count)
+                currentData = m_data[historianID - 1];
         }
 
-        #endregion
+        return currentData;
+    }
 
-        #region [ Methods ]
+    /// <summary>
+    /// Determines whether the current <see cref="DataListener"/> object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="DataListener"/> object is to be compared for equality.</param>
+    /// <returns>true if the current <see cref="DataListener"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        if (obj is not DataListener other)
+            return false;
+        
+        return string.Compare(Name, other.ID, StringComparison.OrdinalIgnoreCase) == 0;
+    }
 
-        /// <summary>
-        /// Initializes the <see cref="DataListener"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Initialize()"/> is to be called by user-code directly only if the <see cref="DataListener"/> is not consumed through the designer surface of the IDE.
-        /// </remarks>
-        public void Initialize()
+    /// <summary>
+    /// Returns the hash code for the current <see cref="DataListener"/> object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        return Name.GetHashCode();
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ListenerStarting"/> event.
+    /// </summary>
+    protected virtual void OnListenerStarting()
+    {
+        ListenerStarting?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ListenerStarted"/> event.
+    /// </summary>
+    protected virtual void OnListenerStarted()
+    {
+        ListenerStarted?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ListenerStopping"/> event.
+    /// </summary>
+    protected virtual void OnListenerStopping()
+    {
+        ListenerStopping?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ListenerStopped"/> event.
+    /// </summary>
+    protected virtual void OnListenerStopped()
+    {
+        ListenerStopped?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="SocketConnecting"/> event.
+    /// </summary>
+    protected virtual void OnSocketConnecting()
+    {
+        SocketConnecting?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="SocketConnected"/> event.
+    /// </summary>
+    protected virtual void OnSocketConnected()
+    {
+        SocketConnected?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="SocketDisconnected"/> event.
+    /// </summary>
+    protected virtual void OnSocketDisconnected()
+    {
+        SocketDisconnected?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataInitStart"/> event.
+    /// </summary>
+    protected virtual void OnDataInitStart()
+    {
+        DataInitStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataInitComplete"/> event.
+    /// </summary>
+    protected virtual void OnDataInitComplete()
+    {
+        DataInitComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataInitPartial"/> event.
+    /// </summary>
+    protected virtual void OnDataInitPartial()
+    {
+        DataInitPartial?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataInitFailure"/> event.
+    /// </summary>
+    protected virtual void OnDataInitFailure()
+    {
+        DataInitFailure?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataExtracted"/> event.
+    /// </summary>
+    /// <param name="data">Extracted time-series data to send to <see cref="DataExtracted"/> event.</param>
+    protected virtual void OnDataExtracted(IList<IDataPoint> data)
+    {
+        DataExtracted?.Invoke(this, new EventArgs<IList<IDataPoint>>(data));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataChanged"/> event.
+    /// </summary>
+    protected virtual void OnDataChanged()
+    {
+        DataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the <see cref="DataListener"/> and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (IsDisposed)
+            return;
+        
+        try
         {
-            if (!m_initialized)
-            {
-                LoadSettings();         // Load settings from the config file.
-                m_initialized = true;   // Initialize only once.
-            }
-        }
-
-        /// <summary>
-        /// Performs necessary operations before the <see cref="DataListener"/> properties are initialized.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="BeginInit()"/> should never be called by user-code directly. This method exists solely for use 
-        /// by the designer if the <see cref="DataListener"/> is consumed through the designer surface of the IDE.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void BeginInit()
-        {
-            if (!DesignMode)
-            {
-                try
-                {
-                    // Nothing needs to be done before component is initialized.
-                }
-                catch
-                {
-                    // Prevent the IDE from crashing when component is in design mode.
-                }
-            }
-        }
-
-        /// <summary>
-        /// Performs necessary operations after the <see cref="DataListener"/> properties are initialized.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EndInit()"/> should never be called by user-code directly. This method exists solely for use 
-        /// by the designer if the <see cref="DataListener"/> is consumed through the designer surface of the IDE.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void EndInit()
-        {
-            if (!DesignMode)
-            {
-                try
-                {
-                    Initialize();
-                }
-                catch
-                {
-                    // Prevent the IDE from crashing when component is in design mode.
-                }
-            }
-        }
-
-        /// <summary>
-        /// Saves settings for the <see cref="DataListener"/> to the config file if the <see cref="PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
-        public void SaveSettings()
-        {
-            if (m_persistSettings)
-            {
-                // Ensure that settings category is specified.
-                if (string.IsNullOrEmpty(m_settingsCategory))
-                    throw new ConfigurationErrorsException("SettingsCategory property has not been set");
-
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[m_settingsCategory];
-                settings["ID", true].Update(m_id);
-                settings["Server", true].Update(m_server);
-                settings["Port", true].Update(m_port);
-                settings["Protocol", true].Update(m_protocol);
-                settings["ConnectToServer", true].Update(m_connectToServer);
-                settings["CacheData", true].Update(m_cacheData);
-                settings["InitializeData", true].Update(m_initializeData);
-                settings["InitializeDataTimeout", true].Update(m_initializeDataTimeout);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved settings for the <see cref="DataListener"/> from the config file if the <see cref="PersistSettings"/>  property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
-        public void LoadSettings()
-        {
-            if (m_persistSettings)
-            {
-                // Ensure that settings category is specified.
-                if (string.IsNullOrEmpty(m_settingsCategory))
-                    throw new ConfigurationErrorsException("SettingsCategory property has not been set");
-
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[m_settingsCategory];
-                settings.Add("ID", m_id, "Alpha-numeric identifier of the listener.");
-                settings.Add("Server", m_server, "DNS name or IP address of the server providing the time-series data.");
-                settings.Add("Port", m_port, "Network port at the server where the time-series data is being server.");
-                settings.Add("Protocol", m_protocol, "Protocol (Tcp; Udp) to be used for receiving time-series data.");
-                settings.Add("ConnectToServer", m_connectToServer, "True is the listener to initiate connection to the server; otherwise False;");
-                settings.Add("CacheData", m_cacheData, "True if newest data is to be cached locally; otherwise False.");
-                settings.Add("InitializeData", m_initializeData, "True if data is to be initialized from the server on startup; otherwise False.");
-                settings.Add("InitializeDataTimeout", m_initializeDataTimeout, "Number of milliseconds to wait for data to be initialized from the server on startup.");
-                ID = settings["ID"].ValueAs(m_id);
-                Server = settings["Server"].ValueAs(m_server);
-                Port = settings["Port"].ValueAs(m_port);
-                Protocol = settings["Protocol"].ValueAs(m_protocol);
-                ConnectToServer = settings["ConnectToServer"].ValueAs(m_connectToServer);
-                CacheData = settings["CacheData"].ValueAs(m_cacheData);
-                InitializeData = settings["InitializeData"].ValueAs(m_initializeData);
-                InitializeDataTimeout = settings["InitializeDataTimeout"].ValueAs(m_initializeDataTimeout);
-            }
-        }
-
-        /// <summary>
-        /// Starts the <see cref="DataListener"/> synchronously.
-        /// </summary>
-        public void Start()
-        {
-            if (!Enabled)
-            {
-                m_listenerStopping = false;
-
-                OnListenerStarting();
-
-                if (m_initializeData)
-                {
-                    // Attempt to initialize data from the server.
-                    OnDataInitStart();
-                    m_dataInitClient.ConnectionString = string.Format(m_dataInitClient.ConnectionString, Server);
-                    m_dataInitClient.Connect();
-                    if (m_dataInitClient.CurrentState == ClientState.Connected)
-                    {
-                        // Wait enough for the handshaking to complete.
-                        Thread.Sleep(1000);
-
-                        // We'll request current data for all points.
-                        PacketType11 request = new PacketType11();
-                        request.RequestIDs.Add(-1);
-                        m_dataInitClient.Send(request.BinaryImage());
-
-                        // Wait for the data to be initialized and timeout if it takes too long.
-                        if (!m_initializeWaitHandle.WaitOne(m_initializeDataTimeout, false))
-                            OnDataInitPartial();
-                        else
-                            OnDataInitComplete();
-                        m_dataInitClient.Disconnect();
-                    }
-                    else
-                    {
-                        // Archiver is either not running, or is running but is a legacy Archiver.
-                        OnDataInitFailure();
-                    }
-                }
-
-                // Start-up the appropriate communication component that'll get the raw data.
-                if (Protocol == TransportProtocol.Udp)
-                {
-                    m_udpClient.ConnectionString = string.Format("Port={0}; interface=0.0.0.0", Port);
-                    m_udpClient.Connect(); // Start the connection cycle - try indefinitely.
-                }
-                else
-                {
-                    if (m_connectToServer)
-                    {
-                        // TCP connection - going out to the server for connection.
-                        m_tcpClient.ConnectionString = string.Format("Server={0}:{1}; interface=0.0.0.0", Server, Port);
-                        m_tcpClient.Connect(); // Start the connection cycle - try indefinitely.
-                    }
-                    else
-                    {
-                        // TCP connection - client coming in for connection.
-                        m_tcpServer.ConfigurationString = string.Format("Port={0}; interface=0.0.0.0", Port);
-                        m_tcpServer.Start(); // Start the connection cycle - try indefinitely.
-                        OnSocketConnecting();
-                    }
-                }
-
-                // Start the parser that'll parse the raw data.
-                m_parser.Start();
-            }
-        }
-
-        /// <summary>
-        /// Starts the <see cref="DataListener"/> asynchronously.
-        /// </summary>
-        public void StartAsync()
-        {
-            // Only allow one async startup attempt.
-            if (m_startupThread != null && m_startupThread.IsAlive)
+            // This will be done regardless of whether the object is finalized or disposed.
+            if (!disposing)
                 return;
 
-            m_startupThread = new Thread(Start);
-            m_startupThread.Start();
-        }
+            // This will be done only when the object is disposed by calling Dispose().
+            Stop();
+            SaveSettings();
 
-        /// <summary>
-        /// Stops the <see cref="DataListener"/>.
-        /// </summary>
-        public void @Stop()
-        {
-            OnListenerStopping();
+            m_data?.Clear();
 
-            // Abort async startup process if it is running.
-            if (m_startupThread != null)
-                m_startupThread.Abort();
-
-            // Prevent communication clients from reconnecting.
-            m_listenerStopping = true;
-
-            m_tcpServer.Stop();
-            m_tcpClient.Disconnect();
-            m_udpClient.Disconnect();
-            m_parser.Stop();
-            m_totalBytesReceived = 0;
-            m_totalPacketsReceived = 0;
-
-            OnListenerStopped();
-        }
-
-        /// <summary>
-        /// Gets the current data for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier whose current data is to be retrieved.</param>
-        /// <returns><see cref="IDataPoint"/> if a match is found; otherwise null.</returns>
-        public IDataPoint FindData(int historianID)
-        {
-            IDataPoint currentData = null;
-            lock (m_data)
+            if (Parser is not null)
             {
-                if (historianID > 0 && historianID <= m_data.Count)
-                {
-                    // Valid id is specified, so we'll lookup it's current data.
-                    currentData = m_data[historianID - 1];
-                }
+                Parser.DataParsed -= PacketParser_DataParsed;
+                Parser.Dispose();
             }
-            return currentData;
-        }
 
-        /// <summary>
-        /// Determines whether the current <see cref="DataListener"/> object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="DataListener"/> object is to be compared for equality.</param>
-        /// <returns>true if the current <see cref="DataListener"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            DataListener other = obj as DataListener;
-            if (other == null)
-                return false;
-            else
-                return string.Compare(m_id, other.ID, true) == 0;
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current <see cref="DataListener"/> object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return m_id.GetHashCode();
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ListenerStarting"/> event.
-        /// </summary>
-        protected virtual void OnListenerStarting()
-        {
-            if (ListenerStarting != null)
-                ListenerStarting(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ListenerStarted"/> event.
-        /// </summary>
-        protected virtual void OnListenerStarted()
-        {
-            if (ListenerStarted != null)
-                ListenerStarted(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ListenerStopping"/> event.
-        /// </summary>
-        protected virtual void OnListenerStopping()
-        {
-            if (ListenerStopping != null)
-                ListenerStopping(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ListenerStopped"/> event.
-        /// </summary>
-        protected virtual void OnListenerStopped()
-        {
-            if (ListenerStopped != null)
-                ListenerStopped(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="SocketConnecting"/> event.
-        /// </summary>
-        protected virtual void OnSocketConnecting()
-        {
-            if (SocketConnecting != null)
-                SocketConnecting(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="SocketConnected"/> event.
-        /// </summary>
-        protected virtual void OnSocketConnected()
-        {
-            if (SocketConnected != null)
-                SocketConnected(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="SocketDisconnected"/> event.
-        /// </summary>
-        protected virtual void OnSocketDisconnected()
-        {
-            if (SocketDisconnected != null)
-                SocketDisconnected(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataInitStart"/> event.
-        /// </summary>
-        protected virtual void OnDataInitStart()
-        {
-            if (DataInitStart != null)
-                DataInitStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataInitComplete"/> event.
-        /// </summary>
-        protected virtual void OnDataInitComplete()
-        {
-            if (DataInitComplete != null)
-                DataInitComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataInitPartial"/> event.
-        /// </summary>
-        protected virtual void OnDataInitPartial()
-        {
-            if (DataInitPartial != null)
-                DataInitPartial(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataInitFailure"/> event.
-        /// </summary>
-        protected virtual void OnDataInitFailure()
-        {
-            if (DataInitFailure != null)
-                DataInitFailure(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataExtracted"/> event.
-        /// </summary>
-        /// <param name="data">Extracted time-series data to send to <see cref="DataExtracted"/> event.</param>
-        protected virtual void OnDataExtracted(IList<IDataPoint> data)
-        {
-            if (DataExtracted != null)
-                DataExtracted(this, new EventArgs<IList<IDataPoint>>(data));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataChanged"/> event.
-        /// </summary>
-        protected virtual void OnDataChanged()
-        {
-            if (DataChanged != null)
-                DataChanged(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="DataListener"/> and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (!m_disposed)
+            if (m_tcpServer is not null)
             {
-                try
-                {
-                    // This will be done regardless of whether the object is finalized or disposed.
-
-                    if (disposing)
-                    {
-                        // This will be done only when the object is disposed by calling Dispose().
-                        Stop();
-                        SaveSettings();
-
-                        if (m_data != null)
-                            m_data.Clear();
-
-                        if (m_parser != null)
-                        {
-                            m_parser.DataParsed -= PacketParser_DataParsed;
-                            m_parser.Dispose();
-                        }
-
-                        if (m_tcpServer != null)
-                        {
-                            m_tcpServer.ServerStarted -= ServerSocket_ServerStarted;
-                            m_tcpServer.ServerStopped -= ServerSocket_ServerStopped;
-                            m_tcpServer.ReceiveClientDataComplete -= ServerSocket_ReceiveClientDataComplete;
-                            m_tcpServer.Dispose();
-                        }
-
-                        if (m_tcpClient != null)
-                        {
-                            m_tcpClient.ConnectionAttempt -= ClientSocket_ConnectionAttempt;
-                            m_tcpClient.ConnectionEstablished -= ClientSocket_ConnectionEstablished;
-                            m_tcpClient.ConnectionTerminated -= ClientSocket_ConnectionTerminated;
-                            m_tcpClient.ReceiveDataComplete -= ClientSocket_ReceiveDataComplete;
-                            m_tcpClient.Dispose();
-                        }
-
-                        if (m_udpClient != null)
-                        {
-                            m_udpClient.ConnectionAttempt -= ClientSocket_ConnectionAttempt;
-                            m_udpClient.ConnectionEstablished -= ClientSocket_ConnectionEstablished;
-                            m_udpClient.ConnectionTerminated -= ClientSocket_ConnectionTerminated;
-                            m_udpClient.ReceiveDataComplete -= ClientSocket_ReceiveDataComplete;
-                            m_udpClient.Dispose();
-                        }
-
-                        if (m_dataInitClient != null)
-                        {
-                            m_dataInitClient.ReceiveDataComplete -= DataInitClient_ReceiveDataComplete;
-                            m_dataInitClient.Dispose();
-                        }
-
-                        if (m_initializeWaitHandle != null)
-                            m_initializeWaitHandle.Close();
-                    }
-                }
-                finally
-                {
-                    m_disposed = true;          // Prevent duplicate dispose.
-                    base.Dispose(disposing);    // Call base class Dispose().
-                }
+                m_tcpServer.ServerStarted -= ServerSocket_ServerStarted;
+                m_tcpServer.ServerStopped -= ServerSocket_ServerStopped;
+                m_tcpServer.ReceiveClientDataComplete -= ServerSocket_ReceiveClientDataComplete;
+                m_tcpServer.Dispose();
             }
-        }
 
-        private void DataInitClient_ReceiveDataComplete(object sender, EventArgs<byte[], int> e)
-        {
-            StateRecordSummary state = new StateRecordSummary(e.Argument1, 0, e.Argument2);
-            if (state.HistorianID > 0)
+            if (m_tcpClient is not null)
             {
-                lock (m_data)
-                {
-                    m_data.Add(new ArchiveDataPoint(state.HistorianID, state.CurrentData.Time, state.CurrentData.Value, state.CurrentData.Quality));
-                }
+                m_tcpClient.ConnectionAttempt -= ClientSocket_ConnectionAttempt;
+                m_tcpClient.ConnectionEstablished -= ClientSocket_ConnectionEstablished;
+                m_tcpClient.ConnectionTerminated -= ClientSocket_ConnectionTerminated;
+                m_tcpClient.ReceiveDataComplete -= ClientSocket_ReceiveDataComplete;
+                m_tcpClient.Dispose();
             }
-            else
+
+            if (m_udpClient is not null)
             {
-                // This is the end-of-transmission to our request for current data from the server.
-                m_initializeWaitHandle.Set();
+                m_udpClient.ConnectionAttempt -= ClientSocket_ConnectionAttempt;
+                m_udpClient.ConnectionEstablished -= ClientSocket_ConnectionEstablished;
+                m_udpClient.ConnectionTerminated -= ClientSocket_ConnectionTerminated;
+                m_udpClient.ReceiveDataComplete -= ClientSocket_ReceiveDataComplete;
+                m_udpClient.Dispose();
             }
-        }
 
-        private void ServerSocket_ServerStarted(object sender, EventArgs e)
-        {
-            OnSocketConnected();
-            OnListenerStarted();
-        }
-
-        private void ServerSocket_ServerStopped(object sender, EventArgs e)
-        {
-            OnSocketDisconnected();
-        }
-
-        private void ServerSocket_ReceiveClientDataComplete(object sender, EventArgs<Guid, byte[], int> e)
-        {
-            m_totalPacketsReceived++;
-            m_totalBytesReceived += e.Argument3;
-            m_parser.Parse(e.Argument1, e.Argument2, 0, e.Argument3);
-        }
-
-        private void ClientSocket_ConnectionAttempt(object sender, EventArgs e)
-        {
-            OnSocketConnecting();
-        }
-
-        private void ClientSocket_ConnectionEstablished(object sender, EventArgs e)
-        {
-            OnSocketConnected();
-            OnListenerStarted();
-        }
-
-        private void ClientSocket_ConnectionTerminated(object sender, EventArgs e)
-        {
-            OnSocketDisconnected();
-
-            // Re-attempt connection to the server if the disconnect was not deliberate.
-            if (!m_listenerStopping)
-                ((IClient)sender).Connect();
-        }
-
-        private void ClientSocket_ReceiveDataComplete(object sender, EventArgs<byte[], int> e)
-        {
-            m_totalPacketsReceived++;
-            m_totalBytesReceived += e.Argument2;
-            m_parser.Parse(m_clientIDs[(IClient)sender], e.Argument1, 0, e.Argument2);
-        }
-
-        private void PacketParser_DataParsed(object sender, EventArgs<IPacket> e)
-        {
-            // Extract data from the packets.
-            IEnumerable<IDataPoint> extractedData;
-            List<IDataPoint> dataPoints = new List<IDataPoint>();
-
-            extractedData = e.Argument.ExtractTimeSeriesData();
-
-            if (extractedData != null)
-                dataPoints.AddRange(extractedData);
-
-            if (dataPoints.Count > 0)
+            if (m_dataInitClient is not null)
             {
-                // Published the extracted data.
-                OnDataExtracted(dataPoints);
-
-                // Cache extracted data for reuse.
-                if (m_cacheData)
-                {
-                    lock (m_data)
-                    {
-                        foreach (IDataPoint dataPoint in dataPoints)
-                        {
-                            if (dataPoint.HistorianID > m_data.Count)
-                            {
-                                // No data exists for the id, so add one for it and others in-between.
-                                for (int i = m_data.Count + 1; i <= dataPoint.HistorianID; i++)
-                                {
-                                    m_data.Add(new ArchiveDataPoint(i));
-                                }
-                            }
-
-                            // Replace existing data with the new data.
-                            m_data[dataPoint.HistorianID - 1] = dataPoint;
-                        }
-                    }
-                    OnDataChanged();
-                }
+                m_dataInitClient.ReceiveDataComplete -= DataInitClient_ReceiveDataComplete;
+                m_dataInitClient.Dispose();
             }
-        }
 
-        #endregion
+            m_initializeWaitHandle?.Close();
+        }
+        finally
+        {
+            IsDisposed = true;          // Prevent duplicate dispose.
+            base.Dispose(disposing);    // Call base class Dispose().
+        }
     }
+
+    private void DataInitClient_ReceiveDataComplete(object sender, EventArgs<byte[], int> e)
+    {
+        StateRecordSummary state = new(e.Argument1, 0, e.Argument2);
+
+        if (state.HistorianID > 0)
+        {
+            lock (m_data)
+                m_data.Add(new ArchiveDataPoint(state.HistorianID, state.CurrentData.Time, state.CurrentData.Value, state.CurrentData.Quality));
+        }
+        else
+        {
+            // This is the end-of-transmission to our request for current data from the server.
+            m_initializeWaitHandle.Set();
+        }
+    }
+
+    private void ServerSocket_ServerStarted(object sender, EventArgs e)
+    {
+        OnSocketConnected();
+        OnListenerStarted();
+    }
+
+    private void ServerSocket_ServerStopped(object sender, EventArgs e)
+    {
+        OnSocketDisconnected();
+    }
+
+    private void ServerSocket_ReceiveClientDataComplete(object sender, EventArgs<Guid, byte[], int> e)
+    {
+        TotalPacketsReceived++;
+        TotalBytesReceived += e.Argument3;
+        Parser.Parse(e.Argument1, e.Argument2, 0, e.Argument3);
+    }
+
+    private void ClientSocket_ConnectionAttempt(object sender, EventArgs e)
+    {
+        OnSocketConnecting();
+    }
+
+    private void ClientSocket_ConnectionEstablished(object sender, EventArgs e)
+    {
+        OnSocketConnected();
+        OnListenerStarted();
+    }
+
+    private void ClientSocket_ConnectionTerminated(object sender, EventArgs e)
+    {
+        OnSocketDisconnected();
+
+        // Re-attempt connection to the server if the disconnect was not deliberate.
+        if (!m_listenerStopping)
+            ((IClient)sender).Connect();
+    }
+
+    private void ClientSocket_ReceiveDataComplete(object sender, EventArgs<byte[], int> e)
+    {
+        TotalPacketsReceived++;
+        TotalBytesReceived += e.Argument2;
+        Parser.Parse(m_clientIDs[(IClient)sender], e.Argument1, 0, e.Argument2);
+    }
+
+    private void PacketParser_DataParsed(object sender, EventArgs<IPacket> e)
+    {
+        // Extract data from the packets.
+        List<IDataPoint> dataPoints = [];
+        IEnumerable<IDataPoint> extractedData = e.Argument.ExtractTimeSeriesData();
+
+        if (extractedData is not null)
+            dataPoints.AddRange(extractedData);
+
+        if (dataPoints.Count <= 0)
+            return;
+        
+        // Published the extracted data.
+        OnDataExtracted(dataPoints);
+
+        // Cache extracted data for reuse.
+        if (!m_cacheData)
+            return;
+        
+        lock (m_data)
+        {
+            foreach (IDataPoint dataPoint in dataPoints)
+            {
+                if (dataPoint.HistorianID > m_data.Count)
+                {
+                    // No data exists for the id, so add one for it and others in-between.
+                    for (int i = m_data.Count + 1; i <= dataPoint.HistorianID; i++)
+                        m_data.Add(new ArchiveDataPoint(i));
+                }
+
+                // Replace existing data with the new data.
+                m_data[dataPoint.HistorianID - 1] = dataPoint;
+            }
+        }
+        
+        OnDataChanged();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/DataService.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/DataService.cs
@@ -44,137 +44,115 @@ using System.ServiceModel.Description;
 using GSF.Configuration;
 using GSF.ServiceModel;
 
-namespace GSF.Historian.DataServices
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// A base class for web service that can send and receive historian data over REST (Representational State Transfer) interface.
+/// </summary>
+[SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly")]
+public class DataService : SelfHostingService, IDataService
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// A base class for web service that can send and receive historian data over REST (Representational State Transfer) interface.
+    /// Initializes a new instance of historian data web service.
     /// </summary>
-    [SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly")]
-    public class DataService : SelfHostingService, IDataService
+    protected DataService()
     {
-        #region [ Members ]
+        Singleton = true;
+        PublishMetadata = true;
+        PersistSettings = true;
 
-        // Fields
-        private IArchive m_archive;
-        private TimeSpan m_closeTimeout;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of historian data web service.
-        /// </summary>
-        protected DataService()
-        {
-            Singleton = true;
-            PublishMetadata = true;
-            PersistSettings = true;
-
-            // We set the default close timeout to 2 minutes
-            m_closeTimeout = TimeSpan.Parse("00:02:00");
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the <see cref="IArchive"/> used by the web service for its data.
-        /// </summary>
-        public virtual IArchive Archive
-        {
-            get
-            {
-                return m_archive;
-            }
-            set
-            {
-                m_archive = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the desired <see cref="System.ServiceModel.Channels.Binding.CloseTimeout"/> used as
-        /// the interval of time provided for a connection to close before the transport raises an exception.
-        /// </summary>
-        public TimeSpan CloseTimeout
-        {
-            get
-            {
-                return m_closeTimeout;
-            }
-            set
-            {
-                m_closeTimeout = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Loads saved web service settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("CloseTimeout", m_closeTimeout, "Maximum time allowed for a connection to close before raising a timeout exception.");
-                CloseTimeout = settings["CloseTimeout"].ValueAs(m_closeTimeout);
-            }
-        }
-
-        /// <summary>
-        /// Saves web service settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["CloseTimeout", true].Update(m_closeTimeout);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Raises the <see cref="SelfHostingService.ServiceHostCreated"/> event.
-        /// </summary>
-        /// <remarks>
-        /// We override default behavior to update the default close timeout and to make sure the
-        /// maximum number of items are allowed in the returned graph.
-        /// </remarks>
-        protected override void OnServiceHostCreated()
-        {
-            base.OnServiceHostCreated();
-
-            foreach (ServiceEndpoint endpoint in ServiceHost.Description.Endpoints)
-            {
-                // Update the close timeout based on customizable setting
-                endpoint.Binding.CloseTimeout = m_closeTimeout;
-
-                // Verify that max items allowed in object graphs are set to maximum possible
-                foreach (OperationDescription description in endpoint.Contract.Operations)
-                {
-                    DataContractSerializerOperationBehavior behavior = description.Behaviors.Find<DataContractSerializerOperationBehavior>();
-                    
-                    if (behavior != null)
-                        behavior.MaxItemsInObjectGraph = int.MaxValue;
-                }
-            }
-        }
-
-        #endregion
+        // We set the default close timeout to 2 minutes
+        CloseTimeout = TimeSpan.Parse("00:02:00");
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the <see cref="IArchive"/> used by the web service for its data.
+    /// </summary>
+    public virtual IArchive Archive { get; set; }
+
+    /// <summary>
+    /// Gets or sets the desired <see cref="System.ServiceModel.Channels.Binding.CloseTimeout"/> used as
+    /// the interval of time provided for a connection to close before the transport raises an exception.
+    /// </summary>
+    public TimeSpan CloseTimeout { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Loads saved web service settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(CloseTimeout), CloseTimeout, "Maximum time allowed for a connection to close before raising a timeout exception.");
+        
+        CloseTimeout = settings[nameof(CloseTimeout)].ValueAs(CloseTimeout);
+    }
+
+    /// <summary>
+    /// Saves web service settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(CloseTimeout), true].Update(CloseTimeout);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Raises the <see cref="SelfHostingService.ServiceHostCreated"/> event.
+    /// </summary>
+    /// <remarks>
+    /// We override default behavior to update the default close timeout and to make sure the
+    /// maximum number of items are allowed in the returned graph.
+    /// </remarks>
+    protected override void OnServiceHostCreated()
+    {
+        base.OnServiceHostCreated();
+
+        foreach (ServiceEndpoint endpoint in ServiceHost.Description.Endpoints)
+        {
+            // Update the close timeout based on customizable setting
+            if (endpoint.Binding is not null)
+                endpoint.Binding.CloseTimeout = CloseTimeout;
+
+            // Verify that max items allowed in object graphs are set to maximum possible
+            foreach (OperationDescription description in endpoint.Contract.Operations)
+            {
+                DataContractSerializerOperationBehavior behavior = description.Behaviors.Find<DataContractSerializerOperationBehavior>();
+                    
+                if (behavior is not null)
+                    behavior.MaxItemsInObjectGraph = int.MaxValue;
+            }
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/DataServices.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/DataServices.cs
@@ -29,12 +29,11 @@
 
 using GSF.Adapters;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// A class that loads all of the <see cref="IDataService">data web services</see>.
+/// </summary>
+public class DataServices : AdapterLoader<IDataService>
 {
-    /// <summary>
-    /// A class that loads all of the <see cref="IDataService">data web services</see>.
-    /// </summary>
-    public class DataServices : AdapterLoader<IDataService>
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/DataServices/IDataService.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/IDataService.cs
@@ -29,43 +29,42 @@
 
 using GSF.ServiceModel;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+#region [ Enumerations ]
+
+/// <summary>
+/// Indicates the direction in which data will be flowing from a web service.
+/// </summary>
+public enum DataFlowDirection
 {
-    #region [ Enumerations ]
+    /// <summary>
+    /// Data will be flowing in to the web service.
+    /// </summary>
+    Incoming,
+    /// <summary>
+    /// Data will be flowing out from the web service.
+    /// </summary>
+    Outgoing,
+    /// <summary>
+    /// Data will be flowing both in and out from the web service.
+    /// </summary>
+    BothWays
+}
+
+#endregion
+
+/// <summary>
+/// Defines a web service that can send and receive historian data over REST (Representational State Transfer) interface.
+/// </summary>
+public interface IDataService : ISelfHostingService
+{
+    #region [ Properties ]
 
     /// <summary>
-    /// Indicates the direction in which data will be flowing from a web service.
+    /// Gets or sets the <see cref="IArchive"/> used by the web service for its data.
     /// </summary>
-    public enum DataFlowDirection
-    {
-        /// <summary>
-        /// Data will be flowing in to the web service.
-        /// </summary>
-        Incoming,
-        /// <summary>
-        /// Data will be flowing out from the web service.
-        /// </summary>
-        Outgoing,
-        /// <summary>
-        /// Data will be flowing both in and out from the web service.
-        /// </summary>
-        BothWays
-    }
+    IArchive Archive { get; set; }
 
     #endregion
-
-    /// <summary>
-    /// Defines a web service that can send and receive historian data over REST (Representational State Transfer) interface.
-    /// </summary>
-    public interface IDataService : ISelfHostingService
-    {
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the <see cref="IArchive"/> used by the web service for its data.
-        /// </summary>
-        IArchive Archive { get; set; }
-
-        #endregion
-    }
 }

--- a/Source/Libraries/GSF.Historian/DataServices/IMetadataService.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/IMetadataService.cs
@@ -30,87 +30,86 @@
 using System.ServiceModel;
 using System.ServiceModel.Web;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Defines a REST web service for historian metadata.
+/// </summary>
+/// <seealso cref="SerializableMetadata"/>
+[ServiceContract]
+public interface IMetadataService
 {
+    #region [ Methods ]
+
     /// <summary>
-    /// Defines a REST web service for historian metadata.
+    /// Writes <paramref name="metadata"/> received in <see cref="WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
     /// </summary>
-    /// <seealso cref="SerializableMetadata"/>
-    [ServiceContract]
-    public interface IMetadataService
-    {
-        #region [ Methods ]
+    /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
+    [OperationContract]
+    [WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/write/xml")]
+    void WriteMetadataAsXml(SerializableMetadata metadata);
 
-        /// <summary>
-        /// Writes <paramref name="metadata"/> received in <see cref="WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
-        [OperationContract, 
-        WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/write/xml")]
-        void WriteMetadataAsXml(SerializableMetadata metadata);
+    /// <summary>
+    /// Writes <paramref name="metadata"/> received in <see cref="WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
+    /// </summary>
+    /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
+    [OperationContract]
+    [WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Json, UriTemplate = "/metadata/write/json")]
+    void WriteMetadataAsJson(SerializableMetadata metadata);
 
-        /// <summary>
-        /// Writes <paramref name="metadata"/> received in <see cref="WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
-        [OperationContract, 
-        WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Json, UriTemplate = "/metadata/write/json")]
-        void WriteMetadataAsJson(SerializableMetadata metadata);
+    /// <summary>
+    /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/read/xml")]
+    SerializableMetadata ReadAllMetadataAsXml();
 
-        /// <summary>
-        /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        [OperationContract, 
-        WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/read/xml")]
-        SerializableMetadata ReadAllMetadataAsXml();
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/read/{idList}/xml")]
+    SerializableMetadata ReadSelectMetadataAsXml(string idList);
 
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        [OperationContract, 
-        WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/read/{idList}/xml")]
-        SerializableMetadata ReadSelectMetadataAsXml(string idList);
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/read/{fromID}-{toID}/xml")]
+    SerializableMetadata ReadRangeMetadataAsXml(string fromID, string toID);
 
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        [OperationContract, 
-        WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/metadata/read/{fromID}-{toID}/xml")]
-        SerializableMetadata ReadRangeMetadataAsXml(string fromID, string toID);
+    /// <summary>
+    /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/metadata/read/json")]
+    SerializableMetadata ReadAllMetadataAsJson();
 
-        /// <summary>
-        /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        [OperationContract, 
-        WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/metadata/read/json")]
-        SerializableMetadata ReadAllMetadataAsJson();
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/metadata/read/{idList}/json")]
+    SerializableMetadata ReadSelectMetadataAsJson(string idList);
 
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        [OperationContract, 
-        WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/metadata/read/{idList}/json")]
-        SerializableMetadata ReadSelectMetadataAsJson(string idList);
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/metadata/read/{fromID}-{toID}/json")]
+    SerializableMetadata ReadRangeMetadataAsJson(string fromID, string toID);
 
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        [OperationContract, 
-        WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/metadata/read/{fromID}-{toID}/json")]
-        SerializableMetadata ReadRangeMetadataAsJson(string fromID, string toID);
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/ITimeSeriesDataService.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/ITimeSeriesDataService.cs
@@ -30,126 +30,125 @@
 using System.ServiceModel;
 using System.ServiceModel.Web;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Defines a REST web service for time-series data.
+/// </summary>
+/// <seealso cref="SerializableTimeSeriesData"/>
+[ServiceContract]
+public interface ITimeSeriesDataService
 {
+    #region [ Methods ]
+
     /// <summary>
-    /// Defines a REST web service for time-series data.
+    /// Writes <paramref name="data"/> received in <see cref="WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
     /// </summary>
-    /// <seealso cref="SerializableTimeSeriesData"/>
-    [ServiceContract]
-    public interface ITimeSeriesDataService
-    {
-        #region [ Methods ]
+    /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
+    [OperationContract]
+    [WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/write/xml")]
+    void WriteTimeSeriesDataAsXml(SerializableTimeSeriesData data);
 
-        /// <summary>
-        /// Writes <paramref name="data"/> received in <see cref="WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
-        [OperationContract,
-        WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/write/xml")]
-        void WriteTimeSeriesDataAsXml(SerializableTimeSeriesData data);
+    /// <summary>
+    /// Writes <paramref name="data"/> received in <see cref="WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
+    /// </summary>
+    /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
+    [OperationContract]
+    [WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/write/json")]
+    void WriteTimeSeriesDataAsJson(SerializableTimeSeriesData data);
 
-        /// <summary>
-        /// Writes <paramref name="data"/> received in <see cref="WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
-        [OperationContract,
-        WebInvoke(Method = "POST", RequestFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/write/json")]
-        void WriteTimeSeriesDataAsJson(SerializableTimeSeriesData data);
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/current/{idList}/xml")]
+    SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsXml(string idList);
 
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/current/{idList}/xml")]
-        SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsXml(string idList);
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/current/{fromID}-{toID}/xml")]
+    SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsXml(string fromID, string toID);
 
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/current/{fromID}-{toID}/xml")]
-        SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsXml(string fromID, string toID);
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/current/{idList}/json")]
+    SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsJson(string idList);
 
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/current/{idList}/json")]
-        SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsJson(string idList);
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/current/{fromID}-{toID}/json")]
+    SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsJson(string fromID, string toID);
 
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/current/{fromID}-{toID}/json")]
-        SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsJson(string fromID, string toID);
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/historic/{idList}/{startTime}/{endTime}/xml")]
+    SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsXml(string idList, string startTime, string endTime);
 
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/historic/{idList}/{startTime}/{endTime}/xml")]
-        SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsXml(string idList, string startTime, string endTime);
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/historic/{fromID}-{toID}/{startTime}/{endTime}/xml")]
+    SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsXml(string fromID, string toID, string startTime, string endTime);
 
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Xml, UriTemplate = "/timeseriesdata/read/historic/{fromID}-{toID}/{startTime}/{endTime}/xml")]
-        SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsXml(string fromID, string toID, string startTime, string endTime);
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/historic/{idList}/{startTime}/{endTime}/json")]
+    SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJson(string idList, string startTime, string endTime);
 
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/historic/{idList}/{startTime}/{endTime}/json")]
-        SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJson(string idList, string startTime, string endTime);
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/historic/{fromID}-{toID}/{startTime}/{endTime}/json")]
+    SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsJson(string fromID, string toID, string startTime, string endTime);
 
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="System.String"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/historic/{fromID}-{toID}/{startTime}/{endTime}/json")]
-        SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsJson(string fromID, string toID, string startTime, string endTime);
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="data">JSON serialized post request.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    [OperationContract]
+    [WebInvoke(Method = "POST", ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/historic/json")]
+    SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJsonPost(SerializableReadRequestData data);
 
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="data">JSON serialized post request.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        [OperationContract,
-        WebInvoke(Method = "POST", ResponseFormat = WebMessageFormat.Json, UriTemplate = "/timeseriesdata/read/historic/json")]
-        SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJsonPost(SerializableReadRequestData data);
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/MetadataService.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/MetadataService.cs
@@ -41,246 +41,249 @@ using System.ServiceModel;
 using GSF.Historian.Files;
 using GSF.Parsing;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Represents a REST web service for historian metadata.
+/// </summary>
+/// <seealso cref="SerializableMetadata"/>
+[ServiceBehavior(InstanceContextMode = InstanceContextMode.Single, ConcurrencyMode = ConcurrencyMode.Multiple)]
+public class MetadataService : DataService, IMetadataService
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a REST web service for historian metadata.
+    /// Initializes a new instance of the <see cref="MetadataService"/> class.
     /// </summary>
-    /// <seealso cref="SerializableMetadata"/>
-    [ServiceBehavior(InstanceContextMode = InstanceContextMode.Single, ConcurrencyMode = ConcurrencyMode.Multiple)]
-    public class MetadataService : DataService, IMetadataService
+    public MetadataService()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataService"/> class.
-        /// </summary>
-        public MetadataService()
-        {
-            Endpoints = "http.rest://localhost:6151/historian";
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Writes <paramref name="metadata"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
-        public void WriteMetadataAsXml(SerializableMetadata metadata)
-        {
-            WriteMetadata(metadata);
-        }
-
-        /// <summary>
-        /// Writes <paramref name="metadata"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
-        public void WriteMetadataAsJson(SerializableMetadata metadata)
-        {
-            WriteMetadata(metadata);
-        }
-
-        /// <summary>
-        /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        public SerializableMetadata ReadAllMetadataAsXml()
-        {
-            return ReadMetadata();
-        }
-
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        public SerializableMetadata ReadSelectMetadataAsXml(string idList)
-        {
-            return ReadMetadata(idList);
-        }
-
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        public SerializableMetadata ReadRangeMetadataAsXml(string fromID, string toID)
-        {
-            return ReadMetadata(fromID, toID);
-        }
-
-        /// <summary>
-        /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        public SerializableMetadata ReadAllMetadataAsJson()
-        {
-            return ReadMetadata();
-        }
-
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        public SerializableMetadata ReadSelectMetadataAsJson(string idList)
-        {
-            return ReadMetadata(idList);
-        }
-
-        /// <summary>
-        /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
-        /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
-        public SerializableMetadata ReadRangeMetadataAsJson(string fromID, string toID)
-        {
-            return ReadMetadata(fromID, toID);
-        }
-
-        private void WriteMetadata(SerializableMetadata metadata)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new NullReferenceException("Archive");
-
-                // Write all metadata records to the archive.
-                foreach (SerializableMetadataRecord record in metadata.MetadataRecords)
-                {
-                    Archive.WriteMetaData(record.HistorianID, record.Deflate().BinaryImage());
-                }
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        private SerializableMetadata ReadMetadata()
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return null;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new NullReferenceException("Archive");
-
-                // Read all metadata records from the archive.
-                int id = 0;
-                byte[] buffer;
-                SerializableMetadata metadata = new SerializableMetadata();
-                List<SerializableMetadataRecord> records = new List<SerializableMetadataRecord>();
-                while (true)
-                {
-                    buffer = Archive.ReadMetaData(++id);
-                    if ((object)buffer == null)
-                        // No more records.
-                        break;
-
-                    records.Add(new SerializableMetadataRecord(new MetadataRecord(id, MetadataFileLegacyMode.Enabled, buffer, 0, buffer.Length)));
-                }
-                metadata.MetadataRecords = records.ToArray();
-
-                return metadata;
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        private SerializableMetadata ReadMetadata(string idList)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return null;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new NullReferenceException("Archive");
-
-                // Read specified metadata records from the archive.
-                int id;
-                byte[] buffer;
-                SerializableMetadata metadata = new SerializableMetadata();
-                List<SerializableMetadataRecord> records = new List<SerializableMetadataRecord>();
-                foreach (string singleID in idList.Split(',', ';'))
-                {
-                    buffer = Archive.ReadMetaData(id = int.Parse(singleID));
-                    if ((object)buffer == null)
-                        // ID is invalid.
-                        continue;
-
-                    records.Add(new SerializableMetadataRecord(new MetadataRecord(id, MetadataFileLegacyMode.Enabled, buffer, 0, buffer.Length)));
-                }
-                metadata.MetadataRecords = records.ToArray();
-
-                return metadata;
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        private SerializableMetadata ReadMetadata(string fromID, string toID)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return null;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new NullReferenceException("Archive");
-
-                // Read specified metadata records from the archive.
-                byte[] buffer;
-                SerializableMetadata metadata = new SerializableMetadata();
-                List<SerializableMetadataRecord> records = new List<SerializableMetadataRecord>();
-                for (int id = int.Parse(fromID); id <= int.Parse(toID); id++)
-                {
-                    buffer = Archive.ReadMetaData(id);
-                    if ((object)buffer == null)
-                        // ID is invalid.
-                        continue;
-
-                    records.Add(new SerializableMetadataRecord(new MetadataRecord(id, MetadataFileLegacyMode.Enabled, buffer, 0, buffer.Length)));
-                }
-                metadata.MetadataRecords = records.ToArray();
-
-                return metadata;
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        #endregion
+        Endpoints = "http.rest://localhost:6151/historian";
     }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Writes <paramref name="metadata"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
+    /// </summary>
+    /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
+    public void WriteMetadataAsXml(SerializableMetadata metadata)
+    {
+        WriteMetadata(metadata);
+    }
+
+    /// <summary>
+    /// Writes <paramref name="metadata"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
+    /// </summary>
+    /// <param name="metadata">An <see cref="SerializableMetadata"/> object.</param>
+    public void WriteMetadataAsJson(SerializableMetadata metadata)
+    {
+        WriteMetadata(metadata);
+    }
+
+    /// <summary>
+    /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    public SerializableMetadata ReadAllMetadataAsXml()
+    {
+        return ReadMetadata();
+    }
+
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    public SerializableMetadata ReadSelectMetadataAsXml(string idList)
+    {
+        return ReadMetadata(idList);
+    }
+
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    public SerializableMetadata ReadRangeMetadataAsXml(string fromID, string toID)
+    {
+        return ReadMetadata(fromID, toID);
+    }
+
+    /// <summary>
+    /// Reads all metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    public SerializableMetadata ReadAllMetadataAsJson()
+    {
+        return ReadMetadata();
+    }
+
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    public SerializableMetadata ReadSelectMetadataAsJson(string idList)
+    {
+        return ReadMetadata(idList);
+    }
+
+    /// <summary>
+    /// Reads a subset of metadata from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which metadata is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which metadata is to be read.</param>
+    /// <returns>An <see cref="SerializableMetadata"/> object.</returns>
+    public SerializableMetadata ReadRangeMetadataAsJson(string fromID, string toID)
+    {
+        return ReadMetadata(fromID, toID);
+    }
+
+    private void WriteMetadata(SerializableMetadata metadata)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new NullReferenceException(nameof(Archive));
+
+            // Write all metadata records to the archive.
+            foreach (SerializableMetadataRecord record in metadata.MetadataRecords)
+                Archive.WriteMetaData(record.HistorianID, record.Deflate().BinaryImage());
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    private SerializableMetadata ReadMetadata()
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return null;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new NullReferenceException(nameof(Archive));
+
+            // Read all metadata records from the archive.
+            int id = 0;
+            byte[] buffer;
+            SerializableMetadata metadata = new();
+            List<SerializableMetadataRecord> records = [];
+
+            while (true)
+            {
+                buffer = Archive.ReadMetaData(++id);
+
+                if (buffer is null)
+                    break; // No more records.
+
+                records.Add(new SerializableMetadataRecord(new MetadataRecord(id, MetadataFileLegacyMode.Enabled, buffer, 0, buffer.Length)));
+            }
+
+            metadata.MetadataRecords = records.ToArray();
+
+            return metadata;
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    private SerializableMetadata ReadMetadata(string idList)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return null;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new NullReferenceException(nameof(Archive));
+
+            // Read specified metadata records from the archive.
+            int id;
+            byte[] buffer;
+            SerializableMetadata metadata = new();
+            List<SerializableMetadataRecord> records = [];
+
+            foreach (string singleID in idList.Split(',', ';'))
+            {
+                buffer = Archive.ReadMetaData(id = int.Parse(singleID));
+                
+                if (buffer is null)
+                    continue; // ID is invalid.
+
+                records.Add(new SerializableMetadataRecord(new MetadataRecord(id, MetadataFileLegacyMode.Enabled, buffer, 0, buffer.Length)));
+            }
+
+            metadata.MetadataRecords = records.ToArray();
+
+            return metadata;
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    private SerializableMetadata ReadMetadata(string fromID, string toID)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return null;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new NullReferenceException(nameof(Archive));
+
+            // Read specified metadata records from the archive.
+            byte[] buffer;
+            SerializableMetadata metadata = new();
+            List<SerializableMetadataRecord> records = [];
+
+            for (int id = int.Parse(fromID); id <= int.Parse(toID); id++)
+            {
+                buffer = Archive.ReadMetaData(id);
+
+                if (buffer is null)
+                    continue; // ID is invalid.
+
+                records.Add(new SerializableMetadataRecord(new MetadataRecord(id, MetadataFileLegacyMode.Enabled, buffer, 0, buffer.Length)));
+            }
+            
+            metadata.MetadataRecords = records.ToArray();
+
+            return metadata;
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Contains classes that define the fundamental data web services for a historian.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains classes that define the fundamental data web services for a historian.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/DataServices/SerializableMetadata.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/SerializableMetadata.cs
@@ -33,188 +33,185 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Represents a container for <see cref="SerializableMetadataRecord"/>s that can be serialized using <see cref="XmlSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+/// </summary>
+/// <example>
+/// This is the output for <see cref="SerializableMetadata"/> serialized using <see cref="XmlSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-8" ?> 
+/// <Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <MetadataRecords>
+///     <MetadataRecord HistorianID="1" DataType="0" Name="TVA_CORD-BUS2:ABBV" Synonym1="4-PM1" Synonym2="VPHM" Synonym3="" 
+///       Description="Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude" HardwareInfo="ABB RES521" Remarks="" 
+///       PlantCode="P1" UnitNumber="1" SystemName="CORD" SourceID="3" Enabled="true" ScanRate="0.0333333351" CompressionMinTime="0" 
+///       CompressionMaxTime="0" EngineeringUnits="Volts" LowWarning="475000" HighWarning="525000" LowAlarm="450000" HighAlarm="550000" 
+///       LowRange="475000" HighRange="525000" CompressionLimit="0" ExceptionLimit="0" DisplayDigits="7" SetDescription="" ClearDescription="" 
+///       AlarmState="0" ChangeSecurity="5" AccessSecurity="0" StepCheck="false" AlarmEnabled="false" AlarmFlags="0" AlarmDelay="0" AlarmToFile="false" 
+///       AlarmByEmail="false" AlarmByPager="false" AlarmByPhone="false" AlarmEmails="" AlarmPagers="" AlarmPhones="" /> 
+///   </MetadataRecords>
+/// </Metadata>
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableMetadata"/> serialized using <see cref="DataContractSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <Metadata xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+///   <MetadataRecords>
+///     <MetadataRecord>
+///       <HistorianID>1</HistorianID> 
+///       <DataType>0</DataType> 
+///       <Name>TVA_CORD-BUS2:ABBV</Name> 
+///       <Synonym1>4-PM1</Synonym1> 
+///       <Synonym2>VPHM</Synonym2> 
+///       <Synonym3 /> 
+///       <Description>Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude</Description> 
+///       <HardwareInfo>ABB RES521</HardwareInfo> 
+///       <Remarks /> 
+///       <PlantCode>P1</PlantCode> 
+///       <UnitNumber>1</UnitNumber> 
+///       <SystemName>CORD</SystemName> 
+///       <SourceID>3</SourceID> 
+///       <Enabled>true</Enabled> 
+///       <ScanRate>0.0333333351</ScanRate> 
+///       <CompressionMinTime>0</CompressionMinTime> 
+///       <CompressionMaxTime>0</CompressionMaxTime> 
+///       <EngineeringUnits>Volts</EngineeringUnits> 
+///       <LowWarning>475000</LowWarning> 
+///       <HighWarning>525000</HighWarning> 
+///       <LowAlarm>450000</LowAlarm> 
+///       <HighAlarm>550000</HighAlarm> 
+///       <LowRange>475000</LowRange> 
+///       <HighRange>525000</HighRange> 
+///       <CompressionLimit>0</CompressionLimit> 
+///       <ExceptionLimit>0</ExceptionLimit> 
+///       <DisplayDigits>7</DisplayDigits> 
+///       <SetDescription /> 
+///       <ClearDescription /> 
+///       <AlarmState>0</AlarmState> 
+///       <ChangeSecurity>5</ChangeSecurity> 
+///       <AccessSecurity>0</AccessSecurity> 
+///       <StepCheck>false</StepCheck> 
+///       <AlarmEnabled>false</AlarmEnabled> 
+///       <AlarmFlags>0</AlarmFlags> 
+///       <AlarmDelay>0</AlarmDelay> 
+///       <AlarmToFile>false</AlarmToFile> 
+///       <AlarmByEmail>false</AlarmByEmail> 
+///       <AlarmByPager>false</AlarmByPager> 
+///       <AlarmByPhone>false</AlarmByPhone> 
+///       <AlarmEmails /> 
+///       <AlarmPagers /> 
+///       <AlarmPhones /> 
+///     </MetadataRecord>
+///   </MetadataRecords>
+/// </Metadata>
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableMetadata"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
+/// <code>
+/// {
+///   "MetadataRecords":
+///     [{"HistorianID":1,
+///       "DataType":0,
+///       "Name":"TVA_CORD-BUS2:ABBV",
+///       "Synonym1":"4-PM1",
+///       "Synonym2":"VPHM",
+///       "Synonym3":"",
+///       "Description":"Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude",
+///       "HardwareInfo":"ABB RES521",
+///       "Remarks":"",
+///       "PlantCode":"P1",
+///       "UnitNumber":1,
+///       "SystemName":"CORD",
+///       "SourceID":3,
+///       "Enabled":true,
+///       "ScanRate":0.0333333351,
+///       "CompressionMinTime":0,
+///       "CompressionMaxTime":0,
+///       "EngineeringUnits":"Volts",
+///       "LowWarning":475000,
+///       "HighWarning":525000,
+///       "LowAlarm":450000,
+///       "HighAlarm":550000,
+///       "LowRange":475000,
+///       "HighRange":525000,
+///       "CompressionLimit":0,
+///       "ExceptionLimit":0,
+///       "DisplayDigits":7,
+///       "SetDescription":"",
+///       "ClearDescription":"",
+///       "AlarmState":0,
+///       "ChangeSecurity":5,
+///       "AccessSecurity":0,
+///       "StepCheck":false,
+///       "AlarmEnabled":false,
+///       "AlarmFlags":0,
+///       "AlarmDelay":0,
+///       "AlarmToFile":false,
+///       "AlarmByEmail":false,
+///       "AlarmByPager":false,
+///       "AlarmByPhone":false,
+///       "AlarmEmails":"",
+///       "AlarmPagers":"",
+///       "AlarmPhones":""}]
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="MetadataFile"/>
+/// <seealso cref="SerializableMetadataRecord"/>
+/// <seealso cref="XmlSerializer"/>
+/// <seealso cref="DataContractSerializer"/>
+/// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
+[XmlType("Metadata")]
+[DataContract(Name = "Metadata", Namespace = "")]
+public class SerializableMetadata
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a container for <see cref="SerializableMetadataRecord"/>s that can be serialized using <see cref="XmlSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+    /// Initializes a new instance of the <see cref="SerializableMetadata"/> class.
     /// </summary>
-    /// <example>
-    /// This is the output for <see cref="SerializableMetadata"/> serialized using <see cref="XmlSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-8" ?> 
-    /// <Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <MetadataRecords>
-    ///     <MetadataRecord HistorianID="1" DataType="0" Name="TVA_CORD-BUS2:ABBV" Synonym1="4-PM1" Synonym2="VPHM" Synonym3="" 
-    ///       Description="Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude" HardwareInfo="ABB RES521" Remarks="" 
-    ///       PlantCode="P1" UnitNumber="1" SystemName="CORD" SourceID="3" Enabled="true" ScanRate="0.0333333351" CompressionMinTime="0" 
-    ///       CompressionMaxTime="0" EngineeringUnits="Volts" LowWarning="475000" HighWarning="525000" LowAlarm="450000" HighAlarm="550000" 
-    ///       LowRange="475000" HighRange="525000" CompressionLimit="0" ExceptionLimit="0" DisplayDigits="7" SetDescription="" ClearDescription="" 
-    ///       AlarmState="0" ChangeSecurity="5" AccessSecurity="0" StepCheck="false" AlarmEnabled="false" AlarmFlags="0" AlarmDelay="0" AlarmToFile="false" 
-    ///       AlarmByEmail="false" AlarmByPager="false" AlarmByPhone="false" AlarmEmails="" AlarmPagers="" AlarmPhones="" /> 
-    ///   </MetadataRecords>
-    /// </Metadata>
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableMetadata"/> serialized using <see cref="DataContractSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <Metadata xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-    ///   <MetadataRecords>
-    ///     <MetadataRecord>
-    ///       <HistorianID>1</HistorianID> 
-    ///       <DataType>0</DataType> 
-    ///       <Name>TVA_CORD-BUS2:ABBV</Name> 
-    ///       <Synonym1>4-PM1</Synonym1> 
-    ///       <Synonym2>VPHM</Synonym2> 
-    ///       <Synonym3 /> 
-    ///       <Description>Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude</Description> 
-    ///       <HardwareInfo>ABB RES521</HardwareInfo> 
-    ///       <Remarks /> 
-    ///       <PlantCode>P1</PlantCode> 
-    ///       <UnitNumber>1</UnitNumber> 
-    ///       <SystemName>CORD</SystemName> 
-    ///       <SourceID>3</SourceID> 
-    ///       <Enabled>true</Enabled> 
-    ///       <ScanRate>0.0333333351</ScanRate> 
-    ///       <CompressionMinTime>0</CompressionMinTime> 
-    ///       <CompressionMaxTime>0</CompressionMaxTime> 
-    ///       <EngineeringUnits>Volts</EngineeringUnits> 
-    ///       <LowWarning>475000</LowWarning> 
-    ///       <HighWarning>525000</HighWarning> 
-    ///       <LowAlarm>450000</LowAlarm> 
-    ///       <HighAlarm>550000</HighAlarm> 
-    ///       <LowRange>475000</LowRange> 
-    ///       <HighRange>525000</HighRange> 
-    ///       <CompressionLimit>0</CompressionLimit> 
-    ///       <ExceptionLimit>0</ExceptionLimit> 
-    ///       <DisplayDigits>7</DisplayDigits> 
-    ///       <SetDescription /> 
-    ///       <ClearDescription /> 
-    ///       <AlarmState>0</AlarmState> 
-    ///       <ChangeSecurity>5</ChangeSecurity> 
-    ///       <AccessSecurity>0</AccessSecurity> 
-    ///       <StepCheck>false</StepCheck> 
-    ///       <AlarmEnabled>false</AlarmEnabled> 
-    ///       <AlarmFlags>0</AlarmFlags> 
-    ///       <AlarmDelay>0</AlarmDelay> 
-    ///       <AlarmToFile>false</AlarmToFile> 
-    ///       <AlarmByEmail>false</AlarmByEmail> 
-    ///       <AlarmByPager>false</AlarmByPager> 
-    ///       <AlarmByPhone>false</AlarmByPhone> 
-    ///       <AlarmEmails /> 
-    ///       <AlarmPagers /> 
-    ///       <AlarmPhones /> 
-    ///     </MetadataRecord>
-    ///   </MetadataRecords>
-    /// </Metadata>
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableMetadata"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
-    /// <code>
-    /// {
-    ///   "MetadataRecords":
-    ///     [{"HistorianID":1,
-    ///       "DataType":0,
-    ///       "Name":"TVA_CORD-BUS2:ABBV",
-    ///       "Synonym1":"4-PM1",
-    ///       "Synonym2":"VPHM",
-    ///       "Synonym3":"",
-    ///       "Description":"Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude",
-    ///       "HardwareInfo":"ABB RES521",
-    ///       "Remarks":"",
-    ///       "PlantCode":"P1",
-    ///       "UnitNumber":1,
-    ///       "SystemName":"CORD",
-    ///       "SourceID":3,
-    ///       "Enabled":true,
-    ///       "ScanRate":0.0333333351,
-    ///       "CompressionMinTime":0,
-    ///       "CompressionMaxTime":0,
-    ///       "EngineeringUnits":"Volts",
-    ///       "LowWarning":475000,
-    ///       "HighWarning":525000,
-    ///       "LowAlarm":450000,
-    ///       "HighAlarm":550000,
-    ///       "LowRange":475000,
-    ///       "HighRange":525000,
-    ///       "CompressionLimit":0,
-    ///       "ExceptionLimit":0,
-    ///       "DisplayDigits":7,
-    ///       "SetDescription":"",
-    ///       "ClearDescription":"",
-    ///       "AlarmState":0,
-    ///       "ChangeSecurity":5,
-    ///       "AccessSecurity":0,
-    ///       "StepCheck":false,
-    ///       "AlarmEnabled":false,
-    ///       "AlarmFlags":0,
-    ///       "AlarmDelay":0,
-    ///       "AlarmToFile":false,
-    ///       "AlarmByEmail":false,
-    ///       "AlarmByPager":false,
-    ///       "AlarmByPhone":false,
-    ///       "AlarmEmails":"",
-    ///       "AlarmPagers":"",
-    ///       "AlarmPhones":""}]
-    /// }
-    /// </code>
-    /// </example>
-    /// <seealso cref="MetadataFile"/>
-    /// <seealso cref="SerializableMetadataRecord"/>
-    /// <seealso cref="XmlSerializer"/>
-    /// <seealso cref="DataContractSerializer"/>
-    /// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
-    [XmlType("Metadata"), DataContract(Name = "Metadata", Namespace = "")]
-    public class SerializableMetadata
+    public SerializableMetadata()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableMetadata"/> class.
-        /// </summary>
-        public SerializableMetadata()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableMetadata"/> class.
-        /// </summary>
-        /// <param name="metadataFile"><see cref="MetadataFile"/> object from which <see cref="SerializableMetadata"/> is to be initialized.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="metadataFile"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="metadataFile"/> is closed.</exception>
-        public SerializableMetadata(MetadataFile metadataFile)
-            : this()
-        {
-            if (metadataFile == null)
-                throw new ArgumentNullException(nameof(metadataFile));
-
-            if (!metadataFile.IsOpen)
-                throw new ArgumentException("metadataFile is closed");
-
-            // Process all records in the metadata file.
-            List<SerializableMetadataRecord> serializableMetadataRecords = new List<SerializableMetadataRecord>();
-            foreach (MetadataRecord metadataRecord in metadataFile.Read())
-            {
-                serializableMetadataRecords.Add(new SerializableMetadataRecord(metadataRecord));
-            }
-            MetadataRecords = serializableMetadataRecords.ToArray();
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the <see cref="SerializableMetadataRecord"/>s contained in the <see cref="SerializableMetadata"/>.
-        /// </summary>
-        [XmlArray, DataMember]
-        public SerializableMetadataRecord[] MetadataRecords { get; set; }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializableMetadata"/> class.
+    /// </summary>
+    /// <param name="metadataFile"><see cref="MetadataFile"/> object from which <see cref="SerializableMetadata"/> is to be initialized.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="metadataFile"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="metadataFile"/> is closed.</exception>
+    public SerializableMetadata(MetadataFile metadataFile)
+        : this()
+    {
+        if (metadataFile is null)
+            throw new ArgumentNullException(nameof(metadataFile));
+
+        if (!metadataFile.IsOpen)
+            throw new ArgumentException("metadataFile is closed");
+
+        // Process all records in the metadata file.
+        MetadataRecords = metadataFile.Read().Select(metadataRecord => new SerializableMetadataRecord(metadataRecord)).ToArray();
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the <see cref="SerializableMetadataRecord"/>s contained in the <see cref="SerializableMetadata"/>.
+    /// </summary>
+    [XmlArray]
+    [DataMember]
+    public SerializableMetadataRecord[] MetadataRecords { get; set; }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/SerializableMetadataRecord.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/SerializableMetadataRecord.cs
@@ -36,718 +36,592 @@ using System.Runtime.Serialization;
 using System.Xml.Serialization;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Represents a flattened <see cref="MetadataRecord"/> that can be serialized using <see cref="XmlSerializer"/>, <see cref="DataContractSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+/// </summary>
+/// <example>
+/// This is the output for <see cref="SerializableMetadataRecord"/> serialized using <see cref="XmlSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-8" ?> 
+/// <MetadataRecord HistorianID="1" DataType="0" Name="TVA_CORD-BUS2:ABBV" Synonym1="4-PM1" Synonym2="VPHM" Synonym3="" Description="Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude" HardwareInfo="ABB RES521" 
+///   Remarks="" PlantCode="P1" UnitNumber="1" SystemName="CORD" SourceID="3" Enabled="true" ScanRate="0.0333333351" CompressionMinTime="0" CompressionMaxTime="0" EngineeringUnits="Volts" LowWarning="475000" HighWarning="525000" 
+///   LowAlarm="450000" HighAlarm="550000" LowRange="475000" HighRange="525000" CompressionLimit="0" ExceptionLimit="0" DisplayDigits="7" SetDescription="" ClearDescription="" AlarmState="0" ChangeSecurity="5" AccessSecurity="0" 
+///   StepCheck="false" AlarmEnabled="false" AlarmFlags="0" AlarmDelay="0" AlarmToFile="false" AlarmByEmail="false" AlarmByPager="false" AlarmByPhone="false" AlarmEmails="" AlarmPagers="" AlarmPhones="" 
+///   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /> 
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableMetadataRecord"/> serialized using <see cref="DataContractSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <MetadataRecord xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+///   <HistorianID>1</HistorianID> 
+///   <DataType>0</DataType> 
+///   <Name>TVA_CORD-BUS2:ABBV</Name> 
+///   <Synonym1>4-PM1</Synonym1> 
+///   <Synonym2>VPHM</Synonym2> 
+///   <Synonym3 /> 
+///   <Description>Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude</Description> 
+///   <HardwareInfo>ABB RES521</HardwareInfo> 
+///   <Remarks /> 
+///   <PlantCode>P1</PlantCode> 
+///   <UnitNumber>1</UnitNumber> 
+///   <SystemName>CORD</SystemName> 
+///   <SourceID>3</SourceID> 
+///   <Enabled>true</Enabled> 
+///   <ScanRate>0.0333333351</ScanRate> 
+///   <CompressionMinTime>0</CompressionMinTime> 
+///   <CompressionMaxTime>0</CompressionMaxTime> 
+///   <EngineeringUnits>Volts</EngineeringUnits> 
+///   <LowWarning>475000</LowWarning> 
+///   <HighWarning>525000</HighWarning> 
+///   <LowAlarm>450000</LowAlarm> 
+///   <HighAlarm>550000</HighAlarm> 
+///   <LowRange>475000</LowRange> 
+///   <HighRange>525000</HighRange> 
+///   <CompressionLimit>0</CompressionLimit> 
+///   <ExceptionLimit>0</ExceptionLimit> 
+///   <DisplayDigits>7</DisplayDigits> 
+///   <SetDescription /> 
+///   <ClearDescription /> 
+///   <AlarmState>0</AlarmState> 
+///   <ChangeSecurity>5</ChangeSecurity> 
+///   <AccessSecurity>0</AccessSecurity> 
+///   <StepCheck>false</StepCheck> 
+///   <AlarmEnabled>false</AlarmEnabled> 
+///   <AlarmFlags>0</AlarmFlags> 
+///   <AlarmDelay>0</AlarmDelay> 
+///   <AlarmToFile>false</AlarmToFile> 
+///   <AlarmByEmail>false</AlarmByEmail> 
+///   <AlarmByPager>false</AlarmByPager> 
+///   <AlarmByPhone>false</AlarmByPhone> 
+///   <AlarmEmails /> 
+///   <AlarmPagers /> 
+///   <AlarmPhones /> 
+/// </MetadataRecord>
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableMetadataRecord"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
+/// <code>
+/// {
+///   "HistorianID":1,
+///   "DataType":0,
+///   "Name":"TVA_CORD-BUS2:ABBV",
+///   "Synonym1":"4-PM1",
+///   "Synonym2":"VPHM",
+///   "Synonym3":"",
+///   "Description":"Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude",
+///   "HardwareInfo":"ABB RES521",
+///   "Remarks":"",
+///   "PlantCode":"P1",
+///   "UnitNumber":1,
+///   "SystemName":"CORD",
+///   "SourceID":3,
+///   "Enabled":true,
+///   "ScanRate":0.0333333351,
+///   "CompressionMinTime":0,
+///   "CompressionMaxTime":0,
+///   "EngineeringUnits":"Volts",
+///   "LowWarning":475000,
+///   "HighWarning":525000,
+///   "LowAlarm":450000,
+///   "HighAlarm":550000,
+///   "LowRange":475000,
+///   "HighRange":525000,
+///   "CompressionLimit":0,
+///   "ExceptionLimit":0,
+///   "DisplayDigits":7,
+///   "SetDescription":"",
+///   "ClearDescription":"",
+///   "AlarmState":0,
+///   "ChangeSecurity":5,
+///   "AccessSecurity":0,
+///   "StepCheck":false,
+///   "AlarmEnabled":false,
+///   "AlarmFlags":0,
+///   "AlarmDelay":0,
+///   "AlarmToFile":false,
+///   "AlarmByEmail":false,
+///   "AlarmByPager":false,
+///   "AlarmByPhone":false,
+///   "AlarmEmails":"",
+///   "AlarmPagers":"",
+///   "AlarmPhones":""
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="MetadataRecord"/>
+/// <seealso cref="XmlSerializer"/>
+/// <seealso cref="DataContractSerializer"/>
+/// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
+[XmlType(nameof(MetadataRecord))]
+[DataContract(Name = nameof(MetadataRecord), Namespace = "")]
+public class SerializableMetadataRecord
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a flattened <see cref="MetadataRecord"/> that can be serialized using <see cref="XmlSerializer"/>, <see cref="DataContractSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+    /// Initializes a new instance of the <see cref="SerializableMetadataRecord"/> class.
     /// </summary>
-    /// <example>
-    /// This is the output for <see cref="SerializableMetadataRecord"/> serialized using <see cref="XmlSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-8" ?> 
-    /// <MetadataRecord HistorianID="1" DataType="0" Name="TVA_CORD-BUS2:ABBV" Synonym1="4-PM1" Synonym2="VPHM" Synonym3="" Description="Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude" HardwareInfo="ABB RES521" 
-    ///   Remarks="" PlantCode="P1" UnitNumber="1" SystemName="CORD" SourceID="3" Enabled="true" ScanRate="0.0333333351" CompressionMinTime="0" CompressionMaxTime="0" EngineeringUnits="Volts" LowWarning="475000" HighWarning="525000" 
-    ///   LowAlarm="450000" HighAlarm="550000" LowRange="475000" HighRange="525000" CompressionLimit="0" ExceptionLimit="0" DisplayDigits="7" SetDescription="" ClearDescription="" AlarmState="0" ChangeSecurity="5" AccessSecurity="0" 
-    ///   StepCheck="false" AlarmEnabled="false" AlarmFlags="0" AlarmDelay="0" AlarmToFile="false" AlarmByEmail="false" AlarmByPager="false" AlarmByPhone="false" AlarmEmails="" AlarmPagers="" AlarmPhones="" 
-    ///   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /> 
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableMetadataRecord"/> serialized using <see cref="DataContractSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <MetadataRecord xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-    ///   <HistorianID>1</HistorianID> 
-    ///   <DataType>0</DataType> 
-    ///   <Name>TVA_CORD-BUS2:ABBV</Name> 
-    ///   <Synonym1>4-PM1</Synonym1> 
-    ///   <Synonym2>VPHM</Synonym2> 
-    ///   <Synonym3 /> 
-    ///   <Description>Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude</Description> 
-    ///   <HardwareInfo>ABB RES521</HardwareInfo> 
-    ///   <Remarks /> 
-    ///   <PlantCode>P1</PlantCode> 
-    ///   <UnitNumber>1</UnitNumber> 
-    ///   <SystemName>CORD</SystemName> 
-    ///   <SourceID>3</SourceID> 
-    ///   <Enabled>true</Enabled> 
-    ///   <ScanRate>0.0333333351</ScanRate> 
-    ///   <CompressionMinTime>0</CompressionMinTime> 
-    ///   <CompressionMaxTime>0</CompressionMaxTime> 
-    ///   <EngineeringUnits>Volts</EngineeringUnits> 
-    ///   <LowWarning>475000</LowWarning> 
-    ///   <HighWarning>525000</HighWarning> 
-    ///   <LowAlarm>450000</LowAlarm> 
-    ///   <HighAlarm>550000</HighAlarm> 
-    ///   <LowRange>475000</LowRange> 
-    ///   <HighRange>525000</HighRange> 
-    ///   <CompressionLimit>0</CompressionLimit> 
-    ///   <ExceptionLimit>0</ExceptionLimit> 
-    ///   <DisplayDigits>7</DisplayDigits> 
-    ///   <SetDescription /> 
-    ///   <ClearDescription /> 
-    ///   <AlarmState>0</AlarmState> 
-    ///   <ChangeSecurity>5</ChangeSecurity> 
-    ///   <AccessSecurity>0</AccessSecurity> 
-    ///   <StepCheck>false</StepCheck> 
-    ///   <AlarmEnabled>false</AlarmEnabled> 
-    ///   <AlarmFlags>0</AlarmFlags> 
-    ///   <AlarmDelay>0</AlarmDelay> 
-    ///   <AlarmToFile>false</AlarmToFile> 
-    ///   <AlarmByEmail>false</AlarmByEmail> 
-    ///   <AlarmByPager>false</AlarmByPager> 
-    ///   <AlarmByPhone>false</AlarmByPhone> 
-    ///   <AlarmEmails /> 
-    ///   <AlarmPagers /> 
-    ///   <AlarmPhones /> 
-    /// </MetadataRecord>
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableMetadataRecord"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
-    /// <code>
-    /// {
-    ///   "HistorianID":1,
-    ///   "DataType":0,
-    ///   "Name":"TVA_CORD-BUS2:ABBV",
-    ///   "Synonym1":"4-PM1",
-    ///   "Synonym2":"VPHM",
-    ///   "Synonym3":"",
-    ///   "Description":"Cordova ABB-521 500 kV Bus 2 Positive Sequence Voltage Magnitude",
-    ///   "HardwareInfo":"ABB RES521",
-    ///   "Remarks":"",
-    ///   "PlantCode":"P1",
-    ///   "UnitNumber":1,
-    ///   "SystemName":"CORD",
-    ///   "SourceID":3,
-    ///   "Enabled":true,
-    ///   "ScanRate":0.0333333351,
-    ///   "CompressionMinTime":0,
-    ///   "CompressionMaxTime":0,
-    ///   "EngineeringUnits":"Volts",
-    ///   "LowWarning":475000,
-    ///   "HighWarning":525000,
-    ///   "LowAlarm":450000,
-    ///   "HighAlarm":550000,
-    ///   "LowRange":475000,
-    ///   "HighRange":525000,
-    ///   "CompressionLimit":0,
-    ///   "ExceptionLimit":0,
-    ///   "DisplayDigits":7,
-    ///   "SetDescription":"",
-    ///   "ClearDescription":"",
-    ///   "AlarmState":0,
-    ///   "ChangeSecurity":5,
-    ///   "AccessSecurity":0,
-    ///   "StepCheck":false,
-    ///   "AlarmEnabled":false,
-    ///   "AlarmFlags":0,
-    ///   "AlarmDelay":0,
-    ///   "AlarmToFile":false,
-    ///   "AlarmByEmail":false,
-    ///   "AlarmByPager":false,
-    ///   "AlarmByPhone":false,
-    ///   "AlarmEmails":"",
-    ///   "AlarmPagers":"",
-    ///   "AlarmPhones":""
-    /// }
-    /// </code>
-    /// </example>
-    /// <seealso cref="MetadataRecord"/>
-    /// <seealso cref="XmlSerializer"/>
-    /// <seealso cref="DataContractSerializer"/>
-    /// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
-    [XmlType("MetadataRecord"), DataContract(Name = "MetadataRecord", Namespace = "")]
-    public class SerializableMetadataRecord
+    public SerializableMetadataRecord()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableMetadataRecord"/> class.
-        /// </summary>
-        public SerializableMetadataRecord()
-        {
-            Name = string.Empty;
-            Synonym1 = string.Empty;
-            Synonym2 = string.Empty;
-            Synonym3 = string.Empty;
-            Description = string.Empty;
-            HardwareInfo = string.Empty;
-            Remarks = string.Empty;
-            PlantCode = string.Empty;
-            SystemName = string.Empty;
-            EngineeringUnits = string.Empty;
-            SetDescription = string.Empty;
-            ClearDescription = string.Empty;
-            AlarmEmails = string.Empty;
-            AlarmPagers = string.Empty;
-            AlarmPhones = string.Empty;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableMetadataRecord"/> class.
-        /// </summary>
-        /// <param name="metadataRecord"><see cref="MetadataRecord"/> from which <see cref="SerializableMetadataRecord"/> is to be initialized.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="metadataRecord"/> is null.</exception>
-        public SerializableMetadataRecord(MetadataRecord metadataRecord)
-            : this()
-        {
-            if (metadataRecord == null)
-                throw new ArgumentNullException(nameof(metadataRecord));
-
-            HistorianID = metadataRecord.HistorianID;
-            DataType = (int)metadataRecord.GeneralFlags.DataType;
-            Name = metadataRecord.Name;
-            Synonym1 = metadataRecord.Synonym1;
-            Synonym2 = metadataRecord.Synonym2;
-            Synonym3 = metadataRecord.Synonym3;
-            Description = metadataRecord.Description;
-            HardwareInfo = metadataRecord.HardwareInfo;
-            Remarks = metadataRecord.Remarks;
-            PlantCode = metadataRecord.PlantCode;
-            UnitNumber = metadataRecord.UnitNumber;
-            SystemName = metadataRecord.SystemName;
-            SourceID = metadataRecord.SourceID;
-            Enabled = metadataRecord.GeneralFlags.Enabled;
-            ScanRate = metadataRecord.ScanRate;
-            CompressionMinTime = metadataRecord.CompressionMinTime;
-            CompressionMaxTime = metadataRecord.CompressionMaxTime;
-            ChangeSecurity = metadataRecord.SecurityFlags.ChangeSecurity;
-            AccessSecurity = metadataRecord.SecurityFlags.AccessSecurity;
-            StepCheck = metadataRecord.GeneralFlags.StepCheck;
-            AlarmEnabled = metadataRecord.GeneralFlags.AlarmEnabled;
-            AlarmFlags = metadataRecord.AlarmFlags.Value;
-            AlarmToFile = metadataRecord.GeneralFlags.AlarmToFile;
-            AlarmByEmail = metadataRecord.GeneralFlags.AlarmByEmail;
-            AlarmByPager = metadataRecord.GeneralFlags.AlarmByPager;
-            AlarmByPhone = metadataRecord.GeneralFlags.AlarmByPhone;
-            AlarmEmails = metadataRecord.AlarmEmails;
-            AlarmPagers = metadataRecord.AlarmPagers;
-            AlarmPhones = metadataRecord.AlarmPhones;
-            if (DataType == 0)
-            {
-                // Analog properties.
-                EngineeringUnits = metadataRecord.AnalogFields.EngineeringUnits;
-                LowWarning = metadataRecord.AnalogFields.LowWarning;
-                HighWarning = metadataRecord.AnalogFields.HighWarning;
-                LowAlarm = metadataRecord.AnalogFields.LowAlarm;
-                HighAlarm = metadataRecord.AnalogFields.HighAlarm;
-                LowRange = metadataRecord.AnalogFields.LowRange;
-                HighRange = metadataRecord.AnalogFields.HighRange;
-                CompressionLimit = metadataRecord.AnalogFields.CompressionLimit;
-                ExceptionLimit = metadataRecord.AnalogFields.ExceptionLimit;
-                DisplayDigits = metadataRecord.AnalogFields.DisplayDigits;
-                AlarmDelay = metadataRecord.AnalogFields.AlarmDelay;
-            }
-            else if (DataType == 1)
-            {
-                // Digital properties.
-                SetDescription = metadataRecord.DigitalFields.SetDescription;
-                ClearDescription = metadataRecord.DigitalFields.ClearDescription;
-                AlarmState = metadataRecord.DigitalFields.AlarmState;
-                AlarmDelay = metadataRecord.DigitalFields.AlarmDelay;
-            }
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.HistorianID"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 0)]
-        public int HistorianID
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.DataType"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 1)]
-        public int DataType
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.Name"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 2)]
-        public string Name
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.Synonym1"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 3)]
-        public string Synonym1
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.Synonym2"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 4)]
-        public string Synonym2
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.Synonym3"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 5)]
-        public string Synonym3
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.Description"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 6)]
-        public string Description
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.HardwareInfo"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 7)]
-        public string HardwareInfo
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.Remarks"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 8)]
-        public string Remarks
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.PlantCode"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 9)]
-        public string PlantCode
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.UnitNumber"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 10)]
-        public int UnitNumber
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.SystemName"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 11)]
-        public string SystemName
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.SourceID"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 12)]
-        public int SourceID
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.Enabled"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 13)]
-        public bool Enabled
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.ScanRate"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 14)]
-        public float ScanRate
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.CompressionMinTime"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 15)]
-        public int CompressionMinTime
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.CompressionMaxTime"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 16)]
-        public int CompressionMaxTime
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.EngineeringUnits"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 17)]
-        public string EngineeringUnits
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.LowWarning"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 18)]
-        public float LowWarning
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.HighWarning"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 19)]
-        public float HighWarning
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.LowAlarm"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 20)]
-        public float LowAlarm
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.HighAlarm"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 21)]
-        public float HighAlarm
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.LowRange"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 22)]
-        public float LowRange
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.HighRange"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 23)]
-        public float HighRange
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.CompressionLimit"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 24)]
-        public float CompressionLimit
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.ExceptionLimit"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 25)]
-        public float ExceptionLimit
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.DisplayDigits"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 26)]
-        public int DisplayDigits
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordDigitalFields.SetDescription"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 27)]
-        public string SetDescription
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordDigitalFields.ClearDescription"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 28)]
-        public string ClearDescription
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordDigitalFields.AlarmState"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 29)]
-        public int AlarmState
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordSecurityFlags.ChangeSecurity"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 30)]
-        public int ChangeSecurity
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordSecurityFlags.AccessSecurity"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 31)]
-        public int AccessSecurity
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.StepCheck"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 32)]
-        public bool StepCheck
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmEnabled"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 33)]
-        public bool AlarmEnabled
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAlarmFlags.Value"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 33)]
-        public int AlarmFlags
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields.AlarmDelay"/> or <see cref="MetadataRecordDigitalFields.AlarmDelay"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 34)]
-        public float AlarmDelay
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmToFile"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 35)]
-        public bool AlarmToFile
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmByEmail"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 36)]
-        public bool AlarmByEmail
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmByPager"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 37)]
-        public bool AlarmByPager
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmByPhone"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 38)]
-        public bool AlarmByPhone
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.AlarmEmails"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 39)]
-        public string AlarmEmails
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.AlarmPagers"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 40)]
-        public string AlarmPagers
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecord.AlarmPhones"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 41)]
-        public string AlarmPhones
-        {
-            get;
-            set;
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Returns an <see cref="MetadataRecord"/> object for this <see cref="SerializableMetadataRecord"/>.
-        /// </summary>
-        /// <returns>An <see cref="MetadataRecord"/> object.</returns>
-        public MetadataRecord Deflate()
-        {
-            MetadataRecord metadataRecord = new MetadataRecord(HistorianID, MetadataFileLegacyMode.Enabled);
-            metadataRecord.GeneralFlags.DataType = (DataType)DataType;
-            metadataRecord.Name = Name;
-            metadataRecord.Synonym1 = Synonym1;
-            metadataRecord.Synonym2 = Synonym2;
-            metadataRecord.Synonym3 = Synonym3;
-            metadataRecord.Description = Description;
-            metadataRecord.HardwareInfo = HardwareInfo;
-            metadataRecord.Remarks = Remarks;
-            metadataRecord.PlantCode = PlantCode;
-            metadataRecord.UnitNumber = UnitNumber;
-            metadataRecord.SystemName = SystemName;
-            metadataRecord.SourceID = SourceID;
-            metadataRecord.GeneralFlags.Enabled = Enabled;
-            metadataRecord.ScanRate = ScanRate;
-            metadataRecord.CompressionMinTime = CompressionMinTime;
-            metadataRecord.CompressionMaxTime = CompressionMaxTime;
-            metadataRecord.SecurityFlags.ChangeSecurity = ChangeSecurity;
-            metadataRecord.SecurityFlags.AccessSecurity = AccessSecurity;
-            metadataRecord.GeneralFlags.StepCheck = StepCheck;
-            metadataRecord.GeneralFlags.AlarmEnabled = AlarmEnabled;
-            metadataRecord.AlarmFlags.Value = AlarmFlags;
-            metadataRecord.GeneralFlags.AlarmToFile = AlarmToFile;
-            metadataRecord.GeneralFlags.AlarmByEmail = AlarmByEmail;
-            metadataRecord.GeneralFlags.AlarmByPager = AlarmByPager;
-            metadataRecord.GeneralFlags.AlarmByPhone = AlarmByPhone;
-            metadataRecord.AlarmEmails = AlarmEmails;
-            metadataRecord.AlarmPagers = AlarmPagers;
-            metadataRecord.AlarmPhones = AlarmPhones;
-            if (DataType == 0)
-            {
-                // Analog properties.
-                metadataRecord.AnalogFields.EngineeringUnits = EngineeringUnits;
-                metadataRecord.AnalogFields.LowWarning = LowWarning;
-                metadataRecord.AnalogFields.HighWarning = HighWarning;
-                metadataRecord.AnalogFields.LowAlarm = LowAlarm;
-                metadataRecord.AnalogFields.HighAlarm = HighAlarm;
-                metadataRecord.AnalogFields.LowRange = LowRange;
-                metadataRecord.AnalogFields.HighRange = HighRange;
-                metadataRecord.AnalogFields.CompressionLimit = CompressionLimit;
-                metadataRecord.AnalogFields.ExceptionLimit = ExceptionLimit;
-                metadataRecord.AnalogFields.DisplayDigits = DisplayDigits;
-                metadataRecord.AnalogFields.AlarmDelay = AlarmDelay;
-            }
-            else if (DataType == 1)
-            {
-                // Digital properties.
-                metadataRecord.DigitalFields.SetDescription = SetDescription;
-                metadataRecord.DigitalFields.ClearDescription = ClearDescription;
-                metadataRecord.DigitalFields.AlarmState = AlarmState;
-                metadataRecord.DigitalFields.AlarmDelay = AlarmDelay;
-            }
-
-            return metadataRecord;
-        }
-
-        #endregion
+        Name = string.Empty;
+        Synonym1 = string.Empty;
+        Synonym2 = string.Empty;
+        Synonym3 = string.Empty;
+        Description = string.Empty;
+        HardwareInfo = string.Empty;
+        Remarks = string.Empty;
+        PlantCode = string.Empty;
+        SystemName = string.Empty;
+        EngineeringUnits = string.Empty;
+        SetDescription = string.Empty;
+        ClearDescription = string.Empty;
+        AlarmEmails = string.Empty;
+        AlarmPagers = string.Empty;
+        AlarmPhones = string.Empty;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializableMetadataRecord"/> class.
+    /// </summary>
+    /// <param name="metadataRecord"><see cref="MetadataRecord"/> from which <see cref="SerializableMetadataRecord"/> is to be initialized.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="metadataRecord"/> is null.</exception>
+    public SerializableMetadataRecord(MetadataRecord metadataRecord)
+        : this()
+    {
+        if (metadataRecord is null)
+            throw new ArgumentNullException(nameof(metadataRecord));
+
+        HistorianID = metadataRecord.HistorianID;
+        DataType = (int)metadataRecord.GeneralFlags.DataType;
+        Name = metadataRecord.Name;
+        Synonym1 = metadataRecord.Synonym1;
+        Synonym2 = metadataRecord.Synonym2;
+        Synonym3 = metadataRecord.Synonym3;
+        Description = metadataRecord.Description;
+        HardwareInfo = metadataRecord.HardwareInfo;
+        Remarks = metadataRecord.Remarks;
+        PlantCode = metadataRecord.PlantCode;
+        UnitNumber = metadataRecord.UnitNumber;
+        SystemName = metadataRecord.SystemName;
+        SourceID = metadataRecord.SourceID;
+        Enabled = metadataRecord.GeneralFlags.Enabled;
+        ScanRate = metadataRecord.ScanRate;
+        CompressionMinTime = metadataRecord.CompressionMinTime;
+        CompressionMaxTime = metadataRecord.CompressionMaxTime;
+        ChangeSecurity = metadataRecord.SecurityFlags.ChangeSecurity;
+        AccessSecurity = metadataRecord.SecurityFlags.AccessSecurity;
+        StepCheck = metadataRecord.GeneralFlags.StepCheck;
+        AlarmEnabled = metadataRecord.GeneralFlags.AlarmEnabled;
+        AlarmFlags = metadataRecord.AlarmFlags.Value;
+        AlarmToFile = metadataRecord.GeneralFlags.AlarmToFile;
+        AlarmByEmail = metadataRecord.GeneralFlags.AlarmByEmail;
+        AlarmByPager = metadataRecord.GeneralFlags.AlarmByPager;
+        AlarmByPhone = metadataRecord.GeneralFlags.AlarmByPhone;
+        AlarmEmails = metadataRecord.AlarmEmails;
+        AlarmPagers = metadataRecord.AlarmPagers;
+        AlarmPhones = metadataRecord.AlarmPhones;
+
+        if (DataType == 0)
+        {
+            // Analog properties.
+            EngineeringUnits = metadataRecord.AnalogFields.EngineeringUnits;
+            LowWarning = metadataRecord.AnalogFields.LowWarning;
+            HighWarning = metadataRecord.AnalogFields.HighWarning;
+            LowAlarm = metadataRecord.AnalogFields.LowAlarm;
+            HighAlarm = metadataRecord.AnalogFields.HighAlarm;
+            LowRange = metadataRecord.AnalogFields.LowRange;
+            HighRange = metadataRecord.AnalogFields.HighRange;
+            CompressionLimit = metadataRecord.AnalogFields.CompressionLimit;
+            ExceptionLimit = metadataRecord.AnalogFields.ExceptionLimit;
+            DisplayDigits = metadataRecord.AnalogFields.DisplayDigits;
+            AlarmDelay = metadataRecord.AnalogFields.AlarmDelay;
+        }
+        else if (DataType == 1)
+        {
+            // Digital properties.
+            SetDescription = metadataRecord.DigitalFields.SetDescription;
+            ClearDescription = metadataRecord.DigitalFields.ClearDescription;
+            AlarmState = metadataRecord.DigitalFields.AlarmState;
+            AlarmDelay = metadataRecord.DigitalFields.AlarmDelay;
+        }
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.HistorianID"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 0)]
+    public int HistorianID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.DataType"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 1)]
+    public int DataType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.Name"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 2)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.Synonym1"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 3)]
+    public string Synonym1 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.Synonym2"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 4)]
+    public string Synonym2 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.Synonym3"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 5)]
+    public string Synonym3 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.Description"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 6)]
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.HardwareInfo"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 7)]
+    public string HardwareInfo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.Remarks"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 8)]
+    public string Remarks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.PlantCode"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 9)]
+    public string PlantCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.UnitNumber"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 10)]
+    public int UnitNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.SystemName"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 11)]
+    public string SystemName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.SourceID"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 12)]
+    public int SourceID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.Enabled"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 13)]
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.ScanRate"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 14)]
+    public float ScanRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.CompressionMinTime"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 15)]
+    public int CompressionMinTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.CompressionMaxTime"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 16)]
+    public int CompressionMaxTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.EngineeringUnits"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 17)]
+    public string EngineeringUnits { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.LowWarning"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 18)]
+    public float LowWarning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.HighWarning"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 19)]
+    public float HighWarning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.LowAlarm"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 20)]
+    public float LowAlarm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.HighAlarm"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 21)]
+    public float HighAlarm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.LowRange"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 22)]
+    public float LowRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.HighRange"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 23)]
+    public float HighRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.CompressionLimit"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 24)]
+    public float CompressionLimit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.ExceptionLimit"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 25)]
+    public float ExceptionLimit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.DisplayDigits"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 26)]
+    public int DisplayDigits { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordDigitalFields.SetDescription"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 27)]
+    public string SetDescription { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordDigitalFields.ClearDescription"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 28)]
+    public string ClearDescription { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordDigitalFields.AlarmState"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 29)]
+    public int AlarmState { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordSecurityFlags.ChangeSecurity"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 30)]
+    public int ChangeSecurity { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordSecurityFlags.AccessSecurity"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 31)]
+    public int AccessSecurity { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.StepCheck"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 32)]
+    public bool StepCheck { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmEnabled"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 33)]
+    public bool AlarmEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAlarmFlags.Value"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 33)]
+    public int AlarmFlags { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields.AlarmDelay"/> or <see cref="MetadataRecordDigitalFields.AlarmDelay"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 34)]
+    public float AlarmDelay { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmToFile"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 35)]
+    public bool AlarmToFile { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmByEmail"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 36)]
+    public bool AlarmByEmail { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmByPager"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 37)]
+    public bool AlarmByPager { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags.AlarmByPhone"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 38)]
+    public bool AlarmByPhone { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.AlarmEmails"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 39)]
+    public string AlarmEmails { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.AlarmPagers"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 40)]
+    public string AlarmPagers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecord.AlarmPhones"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 41)]
+    public string AlarmPhones { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Returns an <see cref="MetadataRecord"/> object for this <see cref="SerializableMetadataRecord"/>.
+    /// </summary>
+    /// <returns>An <see cref="MetadataRecord"/> object.</returns>
+    public MetadataRecord Deflate()
+    {
+        MetadataRecord metadataRecord = new(HistorianID, MetadataFileLegacyMode.Enabled);
+
+        metadataRecord.GeneralFlags.DataType = (DataType)DataType;
+        metadataRecord.Name = Name;
+        metadataRecord.Synonym1 = Synonym1;
+        metadataRecord.Synonym2 = Synonym2;
+        metadataRecord.Synonym3 = Synonym3;
+        metadataRecord.Description = Description;
+        metadataRecord.HardwareInfo = HardwareInfo;
+        metadataRecord.Remarks = Remarks;
+        metadataRecord.PlantCode = PlantCode;
+        metadataRecord.UnitNumber = UnitNumber;
+        metadataRecord.SystemName = SystemName;
+        metadataRecord.SourceID = SourceID;
+        metadataRecord.GeneralFlags.Enabled = Enabled;
+        metadataRecord.ScanRate = ScanRate;
+        metadataRecord.CompressionMinTime = CompressionMinTime;
+        metadataRecord.CompressionMaxTime = CompressionMaxTime;
+        metadataRecord.SecurityFlags.ChangeSecurity = ChangeSecurity;
+        metadataRecord.SecurityFlags.AccessSecurity = AccessSecurity;
+        metadataRecord.GeneralFlags.StepCheck = StepCheck;
+        metadataRecord.GeneralFlags.AlarmEnabled = AlarmEnabled;
+        metadataRecord.AlarmFlags.Value = AlarmFlags;
+        metadataRecord.GeneralFlags.AlarmToFile = AlarmToFile;
+        metadataRecord.GeneralFlags.AlarmByEmail = AlarmByEmail;
+        metadataRecord.GeneralFlags.AlarmByPager = AlarmByPager;
+        metadataRecord.GeneralFlags.AlarmByPhone = AlarmByPhone;
+        metadataRecord.AlarmEmails = AlarmEmails;
+        metadataRecord.AlarmPagers = AlarmPagers;
+        metadataRecord.AlarmPhones = AlarmPhones;
+        
+        if (DataType == 0)
+        {
+            // Analog properties.
+            metadataRecord.AnalogFields.EngineeringUnits = EngineeringUnits;
+            metadataRecord.AnalogFields.LowWarning = LowWarning;
+            metadataRecord.AnalogFields.HighWarning = HighWarning;
+            metadataRecord.AnalogFields.LowAlarm = LowAlarm;
+            metadataRecord.AnalogFields.HighAlarm = HighAlarm;
+            metadataRecord.AnalogFields.LowRange = LowRange;
+            metadataRecord.AnalogFields.HighRange = HighRange;
+            metadataRecord.AnalogFields.CompressionLimit = CompressionLimit;
+            metadataRecord.AnalogFields.ExceptionLimit = ExceptionLimit;
+            metadataRecord.AnalogFields.DisplayDigits = DisplayDigits;
+            metadataRecord.AnalogFields.AlarmDelay = AlarmDelay;
+        }
+        else if (DataType == 1)
+        {
+            // Digital properties.
+            metadataRecord.DigitalFields.SetDescription = SetDescription;
+            metadataRecord.DigitalFields.ClearDescription = ClearDescription;
+            metadataRecord.DigitalFields.AlarmState = AlarmState;
+            metadataRecord.DigitalFields.AlarmDelay = AlarmDelay;
+        }
+
+        return metadataRecord;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/SerializableReadRequestData.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/SerializableReadRequestData.cs
@@ -26,50 +26,37 @@
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Represents a container for JSON serialized time-series data read request.
+/// </summary>
+[XmlType("ReadRequestData")]
+[DataContract(Name = "ReadRequestData")]
+public class SerializableReadRequestData
 {
+    #region [ Properties ]
+
     /// <summary>
-    /// Represents a container for JSON serialized time-series data read request.
+    /// XML array of integer historian ID's.
     /// </summary>
-    [XmlType("ReadRequestData"), DataContract(Name = "ReadRequestData")]
-    public class SerializableReadRequestData
-    {
-        #region [ Constructors ]
+    [XmlArray]
+    [DataMember(Order = 0)]
+    public int[] idArray { get; set; }
 
-        #endregion
+    /// <summary>
+    /// Start time.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 1)]
+    public string startTime { get; set; }
 
-        #region [ Properties ]
+    /// <summary>
+    /// End time.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 2)]
+    public string endTime { get; set; }
 
-        /// <summary>
-        /// XML array of integer historian ID's.
-        /// </summary>
-        [XmlArray, DataMember(Order = 0)]
-        public int[] idArray
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Start time.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 1)]
-        public string startTime
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// End time.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 2)]
-        public string endTime
-        {
-            get;
-            set;
-        }
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/SerializableTimeSeriesData.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/SerializableTimeSeriesData.cs
@@ -33,141 +33,138 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml.Serialization;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Represents a container for <see cref="SerializableTimeSeriesDataPoint"/>s that can be serialized using <see cref="XmlSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+/// </summary>
+/// <example>
+/// This is the output for <see cref="SerializableTimeSeriesData"/> serialized using <see cref="XmlSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-8" ?> 
+/// <TimeSeriesData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <TimeSeriesDataPoints>
+///     <TimeSeriesDataPoint HistorianID="1" Time="21-Aug-2009 14:29:52.634" Value="59.9537773" Quality="Good" /> 
+///     <TimeSeriesDataPoint HistorianID="2" Time="21-Aug-2009 14:29:52.668" Value="60.0351028" Quality="Good" /> 
+///     <TimeSeriesDataPoint HistorianID="3" Time="21-Aug-2009 14:29:52.702" Value="59.99268" Quality="Good" /> 
+///     <TimeSeriesDataPoint HistorianID="4" Time="21-Aug-2009 14:29:52.736" Value="59.99003" Quality="Good" /> 
+///     <TimeSeriesDataPoint HistorianID="5" Time="21-Aug-2009 14:29:52.770" Value="59.9532661" Quality="Good" /> 
+///   </TimeSeriesDataPoints>
+/// </TimeSeriesData>
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableTimeSeriesData"/> serialized using <see cref="DataContractSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <TimeSeriesData xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+///   <TimeSeriesDataPoints>
+///     <TimeSeriesDataPoint>
+///       <HistorianID>1</HistorianID> 
+///       <Time>21-Aug-2009 14:31:56.176</Time> 
+///       <Value>60.0272522</Value> 
+///       <Quality>Good</Quality> 
+///     </TimeSeriesDataPoint>
+///     <TimeSeriesDataPoint>
+///       <HistorianID>2</HistorianID> 
+///       <Time>21-Aug-2009 14:31:56.210</Time> 
+///       <Value>60.0283241</Value> 
+///       <Quality>Good</Quality> 
+///     </TimeSeriesDataPoint>
+///     <TimeSeriesDataPoint>
+///       <HistorianID>3</HistorianID> 
+///       <Time>21-Aug-2009 14:31:56.244</Time> 
+///       <Value>60.0418167</Value> 
+///       <Quality>Good</Quality> 
+///     </TimeSeriesDataPoint>
+///     <TimeSeriesDataPoint>
+///       <HistorianID>4</HistorianID> 
+///       <Time>21-Aug-2009 14:31:56.278</Time> 
+///       <Value>60.0049438</Value> 
+///       <Quality>Good</Quality> 
+///     </TimeSeriesDataPoint>
+///     <TimeSeriesDataPoint>
+///       <HistorianID>5</HistorianID> 
+///       <Time>21-Aug-2009 14:31:56.312</Time> 
+///       <Value>59.9982834</Value> 
+///       <Quality>Good</Quality> 
+///     </TimeSeriesDataPoint>
+///   </TimeSeriesDataPoints>
+/// </TimeSeriesData>
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableTimeSeriesData"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
+/// <code>
+/// {
+///   "TimeSeriesDataPoints":
+///     [{"HistorianID":1,
+///       "Time":"21-Aug-2009 14:37:04.804",
+///       "Value":59.9637527,
+///       "Quality":29},
+///      {"HistorianID":2,
+///       "Time":"21-Aug-2009 14:37:04.838",
+///       "Value":60.0154762,
+///       "Quality":29},
+///      {"HistorianID":3,
+///       "Time":"21-Aug-2009 14:37:04.872",
+///       "Value":59.977684,
+///       "Quality":29},
+///      {"HistorianID":3,
+///       "Time":"21-Aug-2009 14:37:04.906",
+///       "Value":59.97335,
+///       "Quality":29},
+///      {"HistorianID":5,
+///       "Time":"21-Aug-2009 14:37:04.940",
+///       "Value":59.974678,
+///       "Quality":29}]
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="SerializableTimeSeriesDataPoint"/>
+/// <seealso cref="XmlSerializer"/>
+/// <seealso cref="DataContractSerializer"/>
+/// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
+[XmlType("TimeSeriesData")]
+[DataContract(Name = "TimeSeriesData", Namespace = "")]
+public class SerializableTimeSeriesData
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a container for <see cref="SerializableTimeSeriesDataPoint"/>s that can be serialized using <see cref="XmlSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+    /// Initializes a new instance of the <see cref="SerializableTimeSeriesData"/> class.
     /// </summary>
-    /// <example>
-    /// This is the output for <see cref="SerializableTimeSeriesData"/> serialized using <see cref="XmlSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-8" ?> 
-    /// <TimeSeriesData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <TimeSeriesDataPoints>
-    ///     <TimeSeriesDataPoint HistorianID="1" Time="21-Aug-2009 14:29:52.634" Value="59.9537773" Quality="Good" /> 
-    ///     <TimeSeriesDataPoint HistorianID="2" Time="21-Aug-2009 14:29:52.668" Value="60.0351028" Quality="Good" /> 
-    ///     <TimeSeriesDataPoint HistorianID="3" Time="21-Aug-2009 14:29:52.702" Value="59.99268" Quality="Good" /> 
-    ///     <TimeSeriesDataPoint HistorianID="4" Time="21-Aug-2009 14:29:52.736" Value="59.99003" Quality="Good" /> 
-    ///     <TimeSeriesDataPoint HistorianID="5" Time="21-Aug-2009 14:29:52.770" Value="59.9532661" Quality="Good" /> 
-    ///   </TimeSeriesDataPoints>
-    /// </TimeSeriesData>
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableTimeSeriesData"/> serialized using <see cref="DataContractSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <TimeSeriesData xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-    ///   <TimeSeriesDataPoints>
-    ///     <TimeSeriesDataPoint>
-    ///       <HistorianID>1</HistorianID> 
-    ///       <Time>21-Aug-2009 14:31:56.176</Time> 
-    ///       <Value>60.0272522</Value> 
-    ///       <Quality>Good</Quality> 
-    ///     </TimeSeriesDataPoint>
-    ///     <TimeSeriesDataPoint>
-    ///       <HistorianID>2</HistorianID> 
-    ///       <Time>21-Aug-2009 14:31:56.210</Time> 
-    ///       <Value>60.0283241</Value> 
-    ///       <Quality>Good</Quality> 
-    ///     </TimeSeriesDataPoint>
-    ///     <TimeSeriesDataPoint>
-    ///       <HistorianID>3</HistorianID> 
-    ///       <Time>21-Aug-2009 14:31:56.244</Time> 
-    ///       <Value>60.0418167</Value> 
-    ///       <Quality>Good</Quality> 
-    ///     </TimeSeriesDataPoint>
-    ///     <TimeSeriesDataPoint>
-    ///       <HistorianID>4</HistorianID> 
-    ///       <Time>21-Aug-2009 14:31:56.278</Time> 
-    ///       <Value>60.0049438</Value> 
-    ///       <Quality>Good</Quality> 
-    ///     </TimeSeriesDataPoint>
-    ///     <TimeSeriesDataPoint>
-    ///       <HistorianID>5</HistorianID> 
-    ///       <Time>21-Aug-2009 14:31:56.312</Time> 
-    ///       <Value>59.9982834</Value> 
-    ///       <Quality>Good</Quality> 
-    ///     </TimeSeriesDataPoint>
-    ///   </TimeSeriesDataPoints>
-    /// </TimeSeriesData>
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableTimeSeriesData"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
-    /// <code>
-    /// {
-    ///   "TimeSeriesDataPoints":
-    ///     [{"HistorianID":1,
-    ///       "Time":"21-Aug-2009 14:37:04.804",
-    ///       "Value":59.9637527,
-    ///       "Quality":29},
-    ///      {"HistorianID":2,
-    ///       "Time":"21-Aug-2009 14:37:04.838",
-    ///       "Value":60.0154762,
-    ///       "Quality":29},
-    ///      {"HistorianID":3,
-    ///       "Time":"21-Aug-2009 14:37:04.872",
-    ///       "Value":59.977684,
-    ///       "Quality":29},
-    ///      {"HistorianID":3,
-    ///       "Time":"21-Aug-2009 14:37:04.906",
-    ///       "Value":59.97335,
-    ///       "Quality":29},
-    ///      {"HistorianID":5,
-    ///       "Time":"21-Aug-2009 14:37:04.940",
-    ///       "Value":59.974678,
-    ///       "Quality":29}]
-    /// }
-    /// </code>
-    /// </example>
-    /// <seealso cref="SerializableTimeSeriesDataPoint"/>
-    /// <seealso cref="XmlSerializer"/>
-    /// <seealso cref="DataContractSerializer"/>
-    /// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
-    [XmlType("TimeSeriesData"), DataContract(Name = "TimeSeriesData", Namespace = "")]
-    public class SerializableTimeSeriesData
+    public SerializableTimeSeriesData()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableTimeSeriesData"/> class.
-        /// </summary>
-        public SerializableTimeSeriesData()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableTimeSeriesData"/> class.
-        /// </summary>
-        /// <param name="dataPoints">List of <see cref="IDataPoint"/> from which <see cref="SerializableTimeSeriesData"/> is to be initialized.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="dataPoints"/> is null.</exception>
-        public SerializableTimeSeriesData(IEnumerable<IDataPoint> dataPoints)
-            : this()
-        {
-            if (dataPoints == null)
-                throw new ArgumentNullException(nameof(dataPoints));
-
-            List<SerializableTimeSeriesDataPoint> serializableDataPoints = new List<SerializableTimeSeriesDataPoint>();
-            foreach (IDataPoint dataPoint in dataPoints)
-            {
-                serializableDataPoints.Add(new SerializableTimeSeriesDataPoint(dataPoint));
-            }
-            TimeSeriesDataPoints = serializableDataPoints.ToArray();
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the <see cref="SerializableTimeSeriesDataPoint"/>s contained in the <see cref="SerializableTimeSeriesData"/>.
-        /// </summary>
-        [XmlArray, DataMember]
-        public SerializableTimeSeriesDataPoint[] TimeSeriesDataPoints { get; set; }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializableTimeSeriesData"/> class.
+    /// </summary>
+    /// <param name="dataPoints">List of <see cref="IDataPoint"/> from which <see cref="SerializableTimeSeriesData"/> is to be initialized.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dataPoints"/> is null.</exception>
+    public SerializableTimeSeriesData(IEnumerable<IDataPoint> dataPoints)
+        : this()
+    {
+        if (dataPoints is null)
+            throw new ArgumentNullException(nameof(dataPoints));
+
+        TimeSeriesDataPoints = dataPoints.Select(dataPoint => new SerializableTimeSeriesDataPoint(dataPoint)).ToArray();
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the <see cref="SerializableTimeSeriesDataPoint"/>s contained in the <see cref="SerializableTimeSeriesData"/>.
+    /// </summary>
+    [XmlArray]
+    [DataMember]
+    public SerializableTimeSeriesDataPoint[] TimeSeriesDataPoints { get; set; }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/SerializableTimeSeriesDataPoint.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/SerializableTimeSeriesDataPoint.cs
@@ -36,115 +36,119 @@ using System.Runtime.Serialization;
 using System.Xml.Serialization;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Represents a time-series data-point that can be serialized using <see cref="XmlSerializer"/>, <see cref="DataContractSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+/// </summary>
+/// <example>
+/// This is the output for <see cref="SerializableTimeSeriesDataPoint"/> serialized using <see cref="XmlSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0"?>
+/// <TimeSeriesDataPoint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+///   HistorianID="1" Time="2009-08-21 14:21:23.236" Value="60.0419579" Quality="Good" />
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableTimeSeriesDataPoint"/> serialized using <see cref="DataContractSerializer"/>:
+/// <code>
+/// <![CDATA[
+/// <TimeSeriesDataPoint xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+///   <HistorianID>1</HistorianID>
+///   <Time>2009-08-21 14:21:54.612</Time>
+///   <Value>60.025547</Value>
+///   <Quality>Good</Quality>
+/// </TimeSeriesDataPoint>
+/// ]]>
+/// </code>
+/// This is the output for <see cref="SerializableTimeSeriesDataPoint"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
+/// <code>
+/// {
+///   "HistorianID":1,
+///   "Time":"2009-08-21 14:22:26.971",
+///   "Value":59.9974136,
+///   "Quality":29
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="IDataPoint"/>
+/// <seealso cref="XmlSerializer"/>
+/// <seealso cref="DataContractSerializer"/>
+/// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
+[XmlType("TimeSeriesDataPoint")]
+[DataContract(Name = "TimeSeriesDataPoint", Namespace = "")]
+public class SerializableTimeSeriesDataPoint
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a time-series data-point that can be serialized using <see cref="XmlSerializer"/>, <see cref="DataContractSerializer"/> or <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>.
+    /// Initializes a new instance of the <see cref="SerializableTimeSeriesDataPoint"/> class.
     /// </summary>
-    /// <example>
-    /// This is the output for <see cref="SerializableTimeSeriesDataPoint"/> serialized using <see cref="XmlSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0"?>
-    /// <TimeSeriesDataPoint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-    ///   HistorianID="1" Time="2009-08-21 14:21:23.236" Value="60.0419579" Quality="Good" />
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableTimeSeriesDataPoint"/> serialized using <see cref="DataContractSerializer"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <TimeSeriesDataPoint xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-    ///   <HistorianID>1</HistorianID>
-    ///   <Time>2009-08-21 14:21:54.612</Time>
-    ///   <Value>60.025547</Value>
-    ///   <Quality>Good</Quality>
-    /// </TimeSeriesDataPoint>
-    /// ]]>
-    /// </code>
-    /// This is the output for <see cref="SerializableTimeSeriesDataPoint"/> serialized using <see cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>:
-    /// <code>
-    /// {
-    ///   "HistorianID":1,
-    ///   "Time":"2009-08-21 14:22:26.971",
-    ///   "Value":59.9974136,
-    ///   "Quality":29
-    /// }
-    /// </code>
-    /// </example>
-    /// <seealso cref="IDataPoint"/>
-    /// <seealso cref="XmlSerializer"/>
-    /// <seealso cref="DataContractSerializer"/>
-    /// <seealso cref="System.Runtime.Serialization.Json.DataContractJsonSerializer"/>
-    [XmlType("TimeSeriesDataPoint"), DataContract(Name = "TimeSeriesDataPoint", Namespace = "")]
-    public class SerializableTimeSeriesDataPoint
+    public SerializableTimeSeriesDataPoint()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableTimeSeriesDataPoint"/> class.
-        /// </summary>
-        public SerializableTimeSeriesDataPoint()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SerializableTimeSeriesDataPoint"/> class.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> from which <see cref="SerializableTimeSeriesDataPoint"/> is to be initialized.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="dataPoint"/> is null.</exception>
-        public SerializableTimeSeriesDataPoint(IDataPoint dataPoint)
-        {
-            if (dataPoint == null)
-                throw new ArgumentNullException(nameof(dataPoint));
-
-            HistorianID = dataPoint.HistorianID;
-            Time = dataPoint.Time.ToString("yyyy-MM-dd HH:mm:ss.fff");
-            Value = dataPoint.Value;
-            Quality = dataPoint.Quality;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the <see cref="IDataPoint.HistorianID"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 0)]
-        public int HistorianID { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="String"/> representation of <see cref="IDataPoint.Time"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 1)]
-        public string Time { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IDataPoint.Value"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 2)]
-        public float Value { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IDataPoint.Quality"/>.
-        /// </summary>
-        [XmlAttribute, DataMember(Order = 3)]
-        public Quality Quality { get; set; }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Returns an <see cref="IDataPoint"/> object for this <see cref="SerializableTimeSeriesDataPoint"/>.
-        /// </summary>
-        /// <returns>An <see cref="IDataPoint"/> object.</returns>
-        public IDataPoint Deflate()
-        {
-            // TODO: Eliminate the need for this by modifying ArchiveFile to use IDataPoint internally.
-            return new ArchiveDataPoint(HistorianID, TimeTag.Parse(Time), Value, Quality);
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializableTimeSeriesDataPoint"/> class.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> from which <see cref="SerializableTimeSeriesDataPoint"/> is to be initialized.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dataPoint"/> is null.</exception>
+    public SerializableTimeSeriesDataPoint(IDataPoint dataPoint)
+    {
+        if (dataPoint is null)
+            throw new ArgumentNullException(nameof(dataPoint));
+
+        HistorianID = dataPoint.HistorianID;
+        Time = dataPoint.Time.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        Value = dataPoint.Value;
+        Quality = dataPoint.Quality;
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the <see cref="IDataPoint.HistorianID"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 0)]
+    public int HistorianID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="String"/> representation of <see cref="IDataPoint.Time"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 1)]
+    public string Time { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="IDataPoint.Value"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 2)]
+    public float Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="IDataPoint.Quality"/>.
+    /// </summary>
+    [XmlAttribute]
+    [DataMember(Order = 3)]
+    public Quality Quality { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Returns an <see cref="IDataPoint"/> object for this <see cref="SerializableTimeSeriesDataPoint"/>.
+    /// </summary>
+    /// <returns>An <see cref="IDataPoint"/> object.</returns>
+    public IDataPoint Deflate()
+    {
+        // TODO: Eliminate the need for this by modifying ArchiveFile to use IDataPoint internally.
+        return new ArchiveDataPoint(HistorianID, TimeTag.Parse(Time), Value, Quality);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/DataServices/TimeSeriesDataService.cs
+++ b/Source/Libraries/GSF.Historian/DataServices/TimeSeriesDataService.cs
@@ -38,358 +38,333 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.ServiceModel;
 using System.Text;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.DataServices
+namespace GSF.Historian.DataServices;
+
+/// <summary>
+/// Represents a REST web service for time-series data.
+/// </summary>
+/// <seealso cref="SerializableTimeSeriesData"/>
+[ServiceBehavior(InstanceContextMode = InstanceContextMode.Single, ConcurrencyMode = ConcurrencyMode.Multiple)]
+public class TimeSeriesDataService : DataService, ITimeSeriesDataService
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a REST web service for time-series data.
+    /// Initializes a new instance of the <see cref="TimeSeriesDataService"/> class.
     /// </summary>
-    /// <seealso cref="SerializableTimeSeriesData"/>
-    [ServiceBehavior(InstanceContextMode = InstanceContextMode.Single, ConcurrencyMode = ConcurrencyMode.Multiple)]
-    public class TimeSeriesDataService : DataService, ITimeSeriesDataService
+    public TimeSeriesDataService()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeSeriesDataService"/> class.
-        /// </summary>
-        public TimeSeriesDataService()
-        {
-            Endpoints = "http.rest://localhost:6152/historian";
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Writes <paramref name="data"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
-        public void WriteTimeSeriesDataAsXml(SerializableTimeSeriesData data)
-        {
-            WriteTimeSeriesData(data);
-        }
-
-        /// <summary>
-        /// Writes <paramref name="data"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
-        /// </summary>
-        /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
-        public void WriteTimeSeriesDataAsJson(SerializableTimeSeriesData data)
-        {
-            WriteTimeSeriesData(data);
-        }
-
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsXml(string idList)
-        {
-            return ReadCurrentTimeSeriesData(idList);
-        }
-
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsXml(string fromID, string toID)
-        {
-            return ReadCurrentTimeSeriesData(fromID, toID);
-        }
-
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsJson(string idList)
-        {
-            return ReadCurrentTimeSeriesData(idList);
-        }
-
-        /// <summary>
-        /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsJson(string fromID, string toID)
-        {
-            return ReadCurrentTimeSeriesData(fromID, toID);
-        }
-
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsXml(string idList, string startTime, string endTime)
-        {
-            return ReadHistoricTimeSeriesData(idList, startTime, endTime);
-        }
-
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsXml(string fromID, string toID, string startTime, string endTime)
-        {
-            return ReadHistoricTimeSeriesData(fromID, toID, startTime, endTime);
-        }
-
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="idList">A comma or semi-colon delimited list of IDs for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJson(string idList, string startTime, string endTime)
-        {
-            return ReadHistoricTimeSeriesData(idList, startTime, endTime);
-        }
-
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
-        /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsJson(string fromID, string toID, string startTime, string endTime)
-        {
-            return ReadHistoricTimeSeriesData(fromID, toID, startTime, endTime);
-        }
-
-        /// <summary>
-        /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
-        /// </summary>
-        /// <param name="data">JSON serialized post request.</param>
-        /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
-        public SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJsonPost(SerializableReadRequestData data)
-        {
-            StringBuilder idList = new StringBuilder();
-
-            foreach (int id in data.idArray)
-            {
-                if (idList.Length > 0)
-                    idList.Append(',');
-
-                idList.Append(id);
-            }
-
-            return ReadHistoricTimeSeriesData(idList.ToString(), data.startTime, data.endTime);
-        }
-
-        private void WriteTimeSeriesData(SerializableTimeSeriesData data)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new ArgumentNullException("Archive");
-
-                // Write all time-series data to the archive.
-                foreach (SerializableTimeSeriesDataPoint point in data.TimeSeriesDataPoints)
-                {
-                    Archive.WriteData(point.Deflate());
-                }
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        private SerializableTimeSeriesData ReadCurrentTimeSeriesData(string idList)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return null;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new ArgumentNullException("Archive");
-
-                // Read current time-series data from the archive.
-                int id = 0;
-                byte[] buffer = null;
-                StateRecord state = null;
-                SerializableTimeSeriesData data = new SerializableTimeSeriesData();
-                List<SerializableTimeSeriesDataPoint> points = new List<SerializableTimeSeriesDataPoint>();
-                foreach (string singleID in idList.Split(',', ';'))
-                {
-                    buffer = Archive.ReadStateData(id = int.Parse(singleID));
-                    if ((object)buffer == null)
-                    {
-                        // ID is invalid.
-                        continue;
-                    }
-                    else
-                    {
-                        // Add to resultset.
-                        state = new StateRecord(id, buffer, 0, buffer.Length);
-                        points.Add(new SerializableTimeSeriesDataPoint(state.CurrentData));
-                    }
-                }
-                data.TimeSeriesDataPoints = points.ToArray();
-
-                return data;
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        private SerializableTimeSeriesData ReadCurrentTimeSeriesData(string fromID, string toID)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return null;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new ArgumentNullException("Archive");
-
-                // Read current time-series data from the archive.
-                byte[] buffer = null;
-                StateRecord state = null;
-                SerializableTimeSeriesData data = new SerializableTimeSeriesData();
-                List<SerializableTimeSeriesDataPoint> points = new List<SerializableTimeSeriesDataPoint>();
-                for (int id = int.Parse(fromID); id <= int.Parse(toID); id++)
-                {
-                    buffer = Archive.ReadStateData(id);
-                    if ((object)buffer == null)
-                    {
-                        // ID is invalid.
-                        continue;
-                    }
-                    else
-                    {
-                        // Add to resultset.
-                        state = new StateRecord(id, buffer, 0, buffer.Length);
-                        points.Add(new SerializableTimeSeriesDataPoint(state.CurrentData));
-                    }
-                }
-                data.TimeSeriesDataPoints = points.ToArray();
-
-                return data;
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        private SerializableTimeSeriesData ReadHistoricTimeSeriesData(string idList, string startTime, string endTime)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return null;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new ArgumentNullException("Archive");
-
-                // Read historic time-series data from the archive.
-                int id = 0;
-                SerializableTimeSeriesData data = new SerializableTimeSeriesData();
-                List<SerializableTimeSeriesDataPoint> points = new List<SerializableTimeSeriesDataPoint>();
-                List<int> historianIDs = new List<int>();
-
-                foreach (string singleID in idList.Split(',', ';'))
-                {
-                    if (int.TryParse(singleID, out id))
-                        historianIDs.Add(id);
-                }
-
-                foreach (IDataPoint point in Archive.ReadData(historianIDs, startTime, endTime))
-                {
-                    points.Add(new SerializableTimeSeriesDataPoint(point));
-                }
-
-                data.TimeSeriesDataPoints = points.ToArray();
-
-                return data;
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        private SerializableTimeSeriesData ReadHistoricTimeSeriesData(string fromID, string toID, string startTime, string endTime)
-        {
-            try
-            {
-                // Abort if services is not enabled.
-                if (!Enabled)
-                    return null;
-
-                // Ensure that data archive is available.
-                if (Archive == null)
-                    throw new ArgumentNullException("Archive");
-
-                // Read historic time-series data from the archive.
-                SerializableTimeSeriesData data = new SerializableTimeSeriesData();
-                List<SerializableTimeSeriesDataPoint> points = new List<SerializableTimeSeriesDataPoint>();
-                List<int> historianIDs = new List<int>();
-
-                for (int id = int.Parse(fromID); id <= int.Parse(toID); id++)
-                {
-                    historianIDs.Add(id);
-                }
-
-                foreach (IDataPoint point in Archive.ReadData(historianIDs, startTime, endTime))
-                {
-                    points.Add(new SerializableTimeSeriesDataPoint(point));
-                }
-
-                data.TimeSeriesDataPoints = points.ToArray();
-
-                return data;
-            }
-            catch (Exception ex)
-            {
-                // Notify about the encountered processing exception.
-                OnServiceProcessException(ex);
-                throw;
-            }
-        }
-
-        #endregion
+        Endpoints = "http.rest://localhost:6152/historian";
     }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Writes <paramref name="data"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format to the <see cref="DataService.Archive"/>.
+    /// </summary>
+    /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
+    public void WriteTimeSeriesDataAsXml(SerializableTimeSeriesData data)
+    {
+        WriteTimeSeriesData(data);
+    }
+
+    /// <summary>
+    /// Writes <paramref name="data"/> received in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format to the <see cref="DataService.Archive"/>.
+    /// </summary>
+    /// <param name="data">An <see cref="SerializableTimeSeriesData"/> object.</param>
+    public void WriteTimeSeriesDataAsJson(SerializableTimeSeriesData data)
+    {
+        WriteTimeSeriesData(data);
+    }
+
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsXml(string idList)
+    {
+        return ReadCurrentTimeSeriesData(idList);
+    }
+
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsXml(string fromID, string toID)
+    {
+        return ReadCurrentTimeSeriesData(fromID, toID);
+    }
+
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadSelectCurrentTimeSeriesDataAsJson(string idList)
+    {
+        return ReadCurrentTimeSeriesData(idList);
+    }
+
+    /// <summary>
+    /// Reads current time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which current time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which current time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadRangeCurrentTimeSeriesDataAsJson(string fromID, string toID)
+    {
+        return ReadCurrentTimeSeriesData(fromID, toID);
+    }
+
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsXml(string idList, string startTime, string endTime)
+    {
+        return ReadHistoricTimeSeriesData(idList, startTime, endTime);
+    }
+
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Xml"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsXml(string fromID, string toID, string startTime, string endTime)
+    {
+        return ReadHistoricTimeSeriesData(fromID, toID, startTime, endTime);
+    }
+
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="idList">A comma or semicolon delimited list of IDs for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJson(string idList, string startTime, string endTime)
+    {
+        return ReadHistoricTimeSeriesData(idList, startTime, endTime);
+    }
+
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="fromID">Starting ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="toID">Ending ID in the ID range for which historic time-series data is to be read.</param>
+    /// <param name="startTime">Start time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <param name="endTime">End time in <see cref="string"/> format of the timespan for which historic time-series data is to be read.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadRangeHistoricTimeSeriesDataAsJson(string fromID, string toID, string startTime, string endTime)
+    {
+        return ReadHistoricTimeSeriesData(fromID, toID, startTime, endTime);
+    }
+
+    /// <summary>
+    /// Reads historic time-series data from the <see cref="DataService.Archive"/> and sends it in <see cref="System.ServiceModel.Web.WebMessageFormat.Json"/> format.
+    /// </summary>
+    /// <param name="data">JSON serialized post request.</param>
+    /// <returns>An <see cref="SerializableTimeSeriesData"/> object.</returns>
+    public SerializableTimeSeriesData ReadSelectHistoricTimeSeriesDataAsJsonPost(SerializableReadRequestData data)
+    {
+        StringBuilder idList = new();
+
+        foreach (int id in data.idArray)
+        {
+            if (idList.Length > 0)
+                idList.Append(',');
+
+            idList.Append(id);
+        }
+
+        return ReadHistoricTimeSeriesData(idList.ToString(), data.startTime, data.endTime);
+    }
+
+    private void WriteTimeSeriesData(SerializableTimeSeriesData data)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new ArgumentNullException(nameof(Archive));
+
+            // Write all time-series data to the archive.
+            foreach (SerializableTimeSeriesDataPoint point in data.TimeSeriesDataPoints)
+                Archive.WriteData(point.Deflate());
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    private SerializableTimeSeriesData ReadCurrentTimeSeriesData(string idList)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return null;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new ArgumentNullException(nameof(Archive));
+
+            // Read current time-series data from the archive.
+            SerializableTimeSeriesData data = new();
+            List<SerializableTimeSeriesDataPoint> points = [];
+
+            foreach (string singleID in idList.Split(',', ';'))
+            {
+                int id = 0;
+                byte[] buffer = Archive.ReadStateData(id = int.Parse(singleID));
+            
+                if (buffer is null)
+                    continue; // ID is invalid.
+
+                // Add to result set.
+                StateRecord state = new StateRecord(id, buffer, 0, buffer.Length);
+                points.Add(new SerializableTimeSeriesDataPoint(state.CurrentData));
+            }
+
+            data.TimeSeriesDataPoints = points.ToArray();
+
+            return data;
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    private SerializableTimeSeriesData ReadCurrentTimeSeriesData(string fromID, string toID)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return null;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new ArgumentNullException(nameof(Archive));
+
+            // Read current time-series data from the archive.
+            SerializableTimeSeriesData data = new();
+            List<SerializableTimeSeriesDataPoint> points = [];
+
+            for (int id = int.Parse(fromID); id <= int.Parse(toID); id++)
+            {
+                byte[] buffer = Archive.ReadStateData(id);
+
+                if (buffer is null)
+                    continue; // ID is invalid.
+
+                // Add to result set.
+                StateRecord state = new StateRecord(id, buffer, 0, buffer.Length);
+                points.Add(new SerializableTimeSeriesDataPoint(state.CurrentData));
+            }
+
+            data.TimeSeriesDataPoints = points.ToArray();
+
+            return data;
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    private SerializableTimeSeriesData ReadHistoricTimeSeriesData(string idList, string startTime, string endTime)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return null;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new ArgumentNullException(nameof(Archive));
+
+            // Read historic time-series data from the archive.
+            SerializableTimeSeriesData data = new();
+            List<int> historianIDs = [];
+
+            foreach (string singleID in idList.Split(',', ';'))
+            {
+                if (int.TryParse(singleID, out int id))
+                    historianIDs.Add(id);
+            }
+
+            data.TimeSeriesDataPoints = Archive.ReadData(historianIDs, startTime, endTime).Select(point => new SerializableTimeSeriesDataPoint(point)).ToArray();
+
+            return data;
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    private SerializableTimeSeriesData ReadHistoricTimeSeriesData(string fromID, string toID, string startTime, string endTime)
+    {
+        try
+        {
+            // Abort if services is not enabled.
+            if (!Enabled)
+                return null;
+
+            // Ensure that data archive is available.
+            if (Archive is null)
+                throw new ArgumentNullException(nameof(Archive));
+
+            // Read historic time-series data from the archive.
+            SerializableTimeSeriesData data = new();
+            List<int> historianIDs = [];
+
+            for (int id = int.Parse(fromID); id <= int.Parse(toID); id++)
+                historianIDs.Add(id);
+
+            data.TimeSeriesDataPoints = Archive.ReadData(historianIDs, startTime, endTime).Select(point => new SerializableTimeSeriesDataPoint(point)).ToArray();
+
+            return data;
+        }
+        catch (Exception ex)
+        {
+            // Notify about the encountered processing exception.
+            OnServiceProcessException(ex);
+            throw;
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/CsvExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/CsvExporter.cs
@@ -33,109 +33,109 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Represents an exporter that can export the current time-series data in CSV format to a file.
+/// </summary>
+/// <example>
+/// Definition of a sample <see cref="Export"/> that can be processed by <see cref="CsvExporter"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-16"?>
+/// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <Name>CsvExport</Name>
+///   <Type>Intervaled</Type>
+///   <Interval>60</Interval>
+///   <Exporter>CsvExporter</Exporter>
+///   <Settings>
+///     <ExportSetting>
+///       <Name>OutputFile</Name>
+///       <Value>c:\CsvExportOutput.csv</Value>
+///     </ExportSetting>
+///   </Settings>
+///   <Records>
+///     <ExportRecord>
+///       <Instance>P2</Instance>
+///       <Identifier>1885</Identifier>
+///     </ExportRecord>  
+///     <ExportRecord>
+///       <Instance>P2</Instance>
+///       <Identifier>2711</Identifier>
+///     </ExportRecord>      
+///   </Records>
+/// </Export>
+/// ]]>
+/// </code>
+/// <para>
+/// Description of custom settings required by <see cref="CsvExporter"/> in an <see cref="Export"/>:
+/// <list type="table">
+///     <listheader>
+///         <term>Setting Name</term>
+///         <description>Setting Description</description>
+///     </listheader>
+///     <item>
+///         <term>OutputFile</term>
+///         <description>Name of the CSV file (including path) where export data is to be written.</description>
+///     </item>
+/// </list>
+/// </para>
+/// </example>
+/// <seealso cref="Export"/>
+public class CsvExporter : ExporterBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents an exporter that can export the current time-series data in CSV format to a file.
+    /// Initializes a new instance of the <see cref="CsvExporter"/> class.
     /// </summary>
-    /// <example>
-    /// Definition of a sample <see cref="Export"/> that can be processed by <see cref="CsvExporter"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-16"?>
-    /// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <Name>CsvExport</Name>
-    ///   <Type>Intervaled</Type>
-    ///   <Interval>60</Interval>
-    ///   <Exporter>CsvExporter</Exporter>
-    ///   <Settings>
-    ///     <ExportSetting>
-    ///       <Name>OutputFile</Name>
-    ///       <Value>c:\CsvExportOutput.csv</Value>
-    ///     </ExportSetting>
-    ///   </Settings>
-    ///   <Records>
-    ///     <ExportRecord>
-    ///       <Instance>P2</Instance>
-    ///       <Identifier>1885</Identifier>
-    ///     </ExportRecord>  
-    ///     <ExportRecord>
-    ///       <Instance>P2</Instance>
-    ///       <Identifier>2711</Identifier>
-    ///     </ExportRecord>      
-    ///   </Records>
-    /// </Export>
-    /// ]]>
-    /// </code>
-    /// <para>
-    /// Description of custom settings required by <see cref="CsvExporter"/> in an <see cref="Export"/>:
-    /// <list type="table">
-    ///     <listheader>
-    ///         <term>Setting Name</term>
-    ///         <description>Setting Description</description>
-    ///     </listheader>
-    ///     <item>
-    ///         <term>OutputFile</term>
-    ///         <description>Name of the CSV file (including path) where export data is to be written.</description>
-    ///     </item>
-    /// </list>
-    /// </para>
-    /// </example>
-    /// <seealso cref="Export"/>
-    public class CsvExporter : ExporterBase
+    public CsvExporter()
+        : this(nameof(CsvExporter))
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CsvExporter"/> class.
-        /// </summary>
-        public CsvExporter()
-            : this("CsvExporter")
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CsvExporter"/> class.
-        /// </summary>
-        /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
-        protected CsvExporter(string name)
-            : base(name)
-        {
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <exception cref="ArgumentException"><b>OutputFile</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
-        protected override void ProcessExport(Export export)
-        {
-            // Ensure that required settings are present.
-            ExportSetting outputFileSetting = export.FindSetting("OutputFile");
-            if (outputFileSetting == null)
-                throw new ArgumentException("OutputFile setting is missing");
-
-            // Write the current data for the export to the specified files in CSV format.
-            FileHelper.WriteToFile(outputFileSetting.Value, "CSV", GetExportDataAsDataset(export, null));
-        }
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-        /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
-        /// <exception cref="NotSupportedException">Always</exception>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
-        {
-            throw new NotSupportedException();  // Real-Time exports not supported.
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CsvExporter"/> class.
+    /// </summary>
+    /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
+    protected CsvExporter(string name)
+        : base(name)
+    {
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <exception cref="ArgumentException"><b>OutputFile</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
+    protected override void ProcessExport(Export export)
+    {
+        // Ensure that required settings are present.
+        ExportSetting outputFileSetting = export.FindSetting("OutputFile");
+
+        if (outputFileSetting is null)
+            throw new ArgumentException("OutputFile setting is missing");
+
+        // Write the current data for the export to the specified files in CSV format.
+        FileHelper.WriteToFile(outputFileSetting.Value, "CSV", GetExportDataAsDataset(export, null));
+    }
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+    /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
+    /// <exception cref="NotSupportedException">Always</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
+    {
+        throw new NotSupportedException();  // Real-Time exports not supported.
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/DataMonitorExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/DataMonitorExporter.cs
@@ -40,278 +40,281 @@ using GSF.Communication;
 using GSF.Historian.Packets;
 using GSF.Parsing;
 
-namespace GSF.Historian.Exporters
+// ReSharper disable ClassNeverInstantiated.Local
+
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Represents an exporter that can export real-time time-series data over a TCP server socket.
+/// </summary>
+/// <example>
+/// Definition of a sample <see cref="Export"/> that can be processed by <see cref="DataMonitorExporter"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-16"?>
+/// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <Name>DataMonitorExport</Name>
+///   <Type>RealTime</Type>
+///   <Interval>0</Interval>
+///   <Exporter>DataMonitorExporter</Exporter>
+///   <Settings>
+///     <ExportSetting>
+///       <Name>ServerPort</Name>
+///       <Value>8500</Value>
+///     </ExportSetting>
+///     <ExportSetting>
+///       <Name>LegacyMode</Name>
+///       <Value>True</Value>
+///     </ExportSetting>
+///   </Settings>
+///   <Records>
+///     <ExportRecord>
+///       <Instance>P2</Instance>
+///       <Identifier>1885</Identifier>
+///     </ExportRecord>  
+///     <ExportRecord>
+///       <Instance>P2</Instance>
+///       <Identifier>2711</Identifier>
+///     </ExportRecord>
+///   </Records> 
+/// </Export>
+/// ]]>
+/// </code>
+/// <para>
+/// Description of custom settings required by <see cref="DataMonitorExporter"/> in an <see cref="Export"/>:
+/// <list type="table">
+///     <listheader>
+///         <term>Setting Name</term>
+///         <description>Setting Description</description>
+///     </listheader>
+///     <item>
+///         <term>ServerPort</term>
+///         <description>TCP server socket port number over which export data is to be transmitted.</description>
+///     </item>
+///     <item>
+///         <term>LegacyMode (Optional)</term>
+///         <description>True if export data is to be transmitted in <see cref="PacketType1"/> and False if export data is to be transmitted in <see cref="PacketType101"/>.</description>
+///     </item>
+/// </list>
+/// </para>
+/// </example>
+/// <seealso cref="Export"/>
+public class DataMonitorExporter : RebroadcastExporter
 {
+    #region [ Members ]
+
+    // Nested Types
+
     /// <summary>
-    /// Represents an exporter that can export real-time time-series data over a TCP server socket.
+    /// A class for storing runtime information of an <see cref="Export"/>.
     /// </summary>
-    /// <example>
-    /// Definition of a sample <see cref="Export"/> that can be processed by <see cref="DataMonitorExporter"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-16"?>
-    /// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <Name>DataMonitorExport</Name>
-    ///   <Type>RealTime</Type>
-    ///   <Interval>0</Interval>
-    ///   <Exporter>DataMonitorExporter</Exporter>
-    ///   <Settings>
-    ///     <ExportSetting>
-    ///       <Name>ServerPort</Name>
-    ///       <Value>8500</Value>
-    ///     </ExportSetting>
-    ///     <ExportSetting>
-    ///       <Name>LegacyMode</Name>
-    ///       <Value>True</Value>
-    ///     </ExportSetting>
-    ///   </Settings>
-    ///   <Records>
-    ///     <ExportRecord>
-    ///       <Instance>P2</Instance>
-    ///       <Identifier>1885</Identifier>
-    ///     </ExportRecord>  
-    ///     <ExportRecord>
-    ///       <Instance>P2</Instance>
-    ///       <Identifier>2711</Identifier>
-    ///     </ExportRecord>
-    ///   </Records> 
-    /// </Export>
-    /// ]]>
-    /// </code>
-    /// <para>
-    /// Description of custom settings required by <see cref="DataMonitorExporter"/> in an <see cref="Export"/>:
-    /// <list type="table">
-    ///     <listheader>
-    ///         <term>Setting Name</term>
-    ///         <description>Setting Description</description>
-    ///     </listheader>
-    ///     <item>
-    ///         <term>ServerPort</term>
-    ///         <description>TCP server socket port number over which export data is to be transmitted.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>LegacyMode (Optional)</term>
-    ///         <description>True if export data is to be transmitted in <see cref="PacketType1"/> and False if export data is to be transmitted in <see cref="PacketType101"/>.</description>
-    ///     </item>
-    /// </list>
-    /// </para>
-    /// </example>
-    /// <seealso cref="Export"/>
-    public class DataMonitorExporter : RebroadcastExporter
+    private class ExportContext
     {
-        #region [ Members ]
-
-        // Nested Types
+        /// <summary>
+        /// <see cref="IServer"/> used for transmitting the time-series data.
+        /// </summary>
+        public IServer Socket;
 
         /// <summary>
-        /// A class for storing runtime information of an <see cref="Export"/>.
+        /// Number of time-series data points to be transmitted in a single packet.
         /// </summary>
-        private class ExportContext
-        {
-            /// <summary>
-            /// <see cref="IServer"/> used for transmitting the time-series data.
-            /// </summary>
-            public IServer Socket;
-
-            /// <summary>
-            /// Number of time-series data points to be transmitted in a single packet.
-            /// </summary>
-            public int DataPerPacket;
-
-            /// <summary>
-            /// <see cref="Delegate"/> to invoke for transmitting the time-series data.
-            /// </summary>
-            public Action<ExportContext, IList<IDataPoint>> TransmitHandler;
-        }
-
-        // Fields
-        private readonly Dictionary<string, ExportContext> m_contexts;
-
-        #endregion
-
-        #region [ Constructors ]
+        public int DataPerPacket;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DataMonitorExporter"/> class.
+        /// <see cref="Delegate"/> to invoke for transmitting the time-series data.
         /// </summary>
-        public DataMonitorExporter()
-            : this("DataMonitorExporter")
+        public Action<ExportContext, IList<IDataPoint>> TransmitHandler;
+    }
+
+    // Fields
+    private readonly Dictionary<string, ExportContext> m_contexts;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataMonitorExporter"/> class.
+    /// </summary>
+    public DataMonitorExporter()
+        : this(nameof(DataMonitorExporter))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataMonitorExporter"/> class.
+    /// </summary>
+    /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
+    protected DataMonitorExporter(string name)
+        : base(name)
+    {
+        m_contexts = new Dictionary<string, ExportContext>();
+
+        // Register handlers.
+        ExportAddedHandler = CreateContext;
+        ExportRemovedHandler = RemoveContext;
+        ExportUpdatedHandler = UpdateContext;
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Performs the transmission of time-series data for the <paramref name="export"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> whose time-series data os to be transmitted.</param>
+    /// <param name="dataToTransmit">Collection of time-series data to be transmitted.</param>
+    protected override void TransmitData(Export export, IList<IDataPoint> dataToTransmit)
+    {
+        // Retrieve the export context.
+        ExportContext context;
+
+        lock (m_contexts)
+            m_contexts.TryGetValue(export.Name, out context);
+
+        // Transmit export data if export context exists and socket is connected.
+        if (context is not null && context.Socket.CurrentState == ServerState.Running)
+            context.TransmitHandler(context, dataToTransmit);
+    }
+
+    /// <summary>
+    /// Transmits export data in <see cref="PacketType1"/>
+    /// </summary>
+    private void TransmitPacketType1(ExportContext context, IList<IDataPoint> dataToTransmit)
+    {
+        byte[] dataBuffer = new byte[context.DataPerPacket * PacketType1.FixedLength];
+
+        for (int i = 0; i < dataToTransmit.Count; i += context.DataPerPacket)
         {
-        }
+            // Transmit the data at the maximum allowed rate.
+            int dataCount = 0;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataMonitorExporter"/> class.
-        /// </summary>
-        /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
-        protected DataMonitorExporter(string name)
-            : base(name)
-        {
-            m_contexts = new Dictionary<string, ExportContext>();
-
-            // Register handlers.
-            ExportAddedHandler = CreateContext;
-            ExportRemovedHandler = RemoveContext;
-            ExportUpdatedHandler = UpdateContext;
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Performs the transmission of time-series data for the <paramref name="export"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> whose time-series data os to be transmitted.</param>
-        /// <param name="dataToTransmit">Collection of time-series data to be transmitted.</param>
-        protected override void TransmitData(Export export, IList<IDataPoint> dataToTransmit)
-        {
-            // Retrieve the export context.
-            ExportContext context = null;
-            lock (m_contexts)
+            for (int j = i; j < i + (dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket); j++)
             {
-                m_contexts.TryGetValue(export.Name, out context);
+                // Prepare binary image of the data.
+                new PacketType1(dataToTransmit[j]).GenerateBinaryImage(dataBuffer, dataCount * PacketType1.FixedLength);
+                dataCount++;
             }
 
-            // Transmit export data if export context exists and socket is connected.
-            if (context != null && context.Socket.CurrentState == ServerState.Running)
-                context.TransmitHandler(context, dataToTransmit);
+            // Transmit the prepared binary image.
+            context.Socket.MulticastAsync(dataBuffer, 0, dataCount * PacketType1.FixedLength);
         }
+    }
 
-        /// <summary>
-        /// Transmits export data in <see cref="PacketType1"/>
-        /// </summary>
-        private void TransmitPacketType1(ExportContext context, IList<IDataPoint> dataToTransmit)
+    /// <summary>
+    /// Transmits export data in <see cref="PacketType101"/>
+    /// </summary>
+    private void TransmitPacketType101(ExportContext context, IList<IDataPoint> dataToTransmit)
+    {
+        PacketType101 packet;
+
+        if (dataToTransmit.Count <= context.DataPerPacket)
         {
-            byte[] dataBuffer = new byte[context.DataPerPacket * PacketType1.FixedLength];
+            // Transmit all the data.
+            packet = new PacketType101(dataToTransmit);
+            context.Socket.MulticastAsync(packet.BinaryImage(), 0, packet.BinaryLength);
+        }
+        else
+        {
+            // Transmit data at the maximum allowed rate.
             for (int i = 0; i < dataToTransmit.Count; i += context.DataPerPacket)
             {
-                // Transmit the data at the maximum allowed rate.
-                int dataCount = 0;
-                for (int j = i; j < (i + (dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket)); j++)
-                {
-                    // Prepare binary image of the data.
-                    new PacketType1(dataToTransmit[j]).GenerateBinaryImage(dataBuffer, dataCount * PacketType1.FixedLength);
-                    dataCount++;
-                }
-                // Transmit the prepared binary image.
-                context.Socket.MulticastAsync(dataBuffer, 0, dataCount * PacketType1.FixedLength);
+                packet = new PacketType101(dataToTransmit.GetRange(i, dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket));
+                context.Socket.MulticastAsync(packet.BinaryImage(), 0, packet.BinaryLength);
             }
         }
+    }
 
-        /// <summary>
-        /// Transmits export data in <see cref="PacketType101"/>
-        /// </summary>
-        private void TransmitPacketType101(ExportContext context, IList<IDataPoint> dataToTransmit)
+    private void CreateContext(Export export)
+    {
+        lock (m_contexts)
         {
-            PacketType101 packet;
-            if (dataToTransmit.Count <= context.DataPerPacket)
+            if (m_contexts.TryGetValue(export.Name, out ExportContext context))
+                return;
+            
+            // Context for the export does not exist, so we create one.
+            ExportSetting serverPortSetting = export.FindSetting("ServerPort");
+            ExportSetting legacyModeSetting = export.FindSetting("LegacyMode");
+
+            if (serverPortSetting is null || string.IsNullOrEmpty(serverPortSetting.Value))
+                return;
+
+            // Create the server socket for export context.
+            context = new ExportContext { Socket = ServerBase.Create($"Protocol=TCP;Port={serverPortSetting.Value}") };
+            context.Socket.Start(); // Start the server; need to do only one time.
+            context.Socket.ClientConnected += CommunicationServer_ClientConnected;
+            context.Socket.ClientDisconnected += CommunicationServer_ClientDisconnected;
+
+            // Determine the format of transmission.
+            if (legacyModeSetting is not null && Convert.ToBoolean(legacyModeSetting.Value))
             {
-                // Transmit all the data.
-                packet = new PacketType101(dataToTransmit);
-                context.Socket.MulticastAsync(packet.BinaryImage(), 0, packet.BinaryLength);
+                // Data is to be transmitted using PacketType1.
+                context.DataPerPacket = 50;
+                context.TransmitHandler = TransmitPacketType1;
             }
             else
             {
-                // Transmit data at the maximum allowed rate.
-                for (int i = 0; i < dataToTransmit.Count; i += context.DataPerPacket)
-                {
-                    packet = new PacketType101(dataToTransmit.GetRange(i, dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket));
-                    context.Socket.MulticastAsync(packet.BinaryImage(), 0, packet.BinaryLength);
-                }
+                // Data is to be transmitted using PacketType101.
+                context.DataPerPacket = 1000000;
+                context.TransmitHandler = TransmitPacketType101;
             }
+
+            // Save export context
+            m_contexts.Add(export.Name, context);
+
+            // Provide a status update.
+            OnStatusUpdate($"TCP server created for export {export.Name}");
         }
-
-        private void CreateContext(Export export)
-        {
-            ExportContext context = null;
-            lock (m_contexts)
-            {
-                if (!m_contexts.TryGetValue(export.Name, out context))
-                {
-                    // Context for the export does not exist, so we create one.
-                    ExportSetting serverPortSetting = export.FindSetting("ServerPort");
-                    ExportSetting legacyModeSetting = export.FindSetting("LegacyMode");
-                    if ((serverPortSetting != null) && !string.IsNullOrEmpty(serverPortSetting.Value))
-                    {
-                        // Create the server socket for export context.
-                        context.Socket = ServerBase.Create(string.Format("Protocol=TCP;Port={0}", serverPortSetting.Value));
-                        context.Socket.Start();             // Start the server; need to do only one time.
-                        context.Socket.ClientConnected += CommunicationServer_ClientConnected;
-                        context.Socket.ClientDisconnected += CommunicationServer_ClientDisconnected;
-
-                        // Determine the format of transmission.
-                        if (legacyModeSetting != null && Convert.ToBoolean(legacyModeSetting.Value))
-                        {
-                            // Data is to be transmitted using PacketType1.
-                            context.DataPerPacket = 50;
-                            context.TransmitHandler = TransmitPacketType1;
-                        }
-                        else
-                        {
-                            // Data is to be transmitted using PacketType101.
-                            context.DataPerPacket = 1000000;
-                            context.TransmitHandler = TransmitPacketType101;
-                        }
-
-                        // Save export context
-                        m_contexts.Add(export.Name, context);
-
-                        // Provide a status update.
-                        OnStatusUpdate(string.Format("TCP server created for export {0}", export.Name));
-                    }
-                }
-            }
-        }
-
-        private void RemoveContext(Export export)
-        {
-            ExportContext context = null;
-            lock (m_contexts)
-            {
-                if (m_contexts.TryGetValue(export.Name, out context))
-                {
-                    // Context for the export exists, so remove it from the list.
-                    context.Socket.ClientConnected -= CommunicationServer_ClientConnected;
-                    context.Socket.ClientDisconnected -= CommunicationServer_ClientDisconnected;
-                    context.Socket.Dispose();
-                    m_contexts.Remove(export.Name);
-
-                    // Provide a status update.
-                    OnStatusUpdate(string.Format("TCP server of export {0} removed", export.Name));
-                }
-            }
-        }
-
-        private void UpdateContext(Export export)
-        {
-            RemoveContext(export);   // Remove context.
-            CreateContext(export);   // Create context.
-        }
-
-        private void CommunicationServer_ClientConnected(object sender, EventArgs<Guid> e)
-        {
-            TcpServer server = (TcpServer)sender;
-            TransportProvider<Socket> client;
-
-            if (server.TryGetClient(e.Argument, out client))
-            {
-                IPEndPoint serverEndPoint = (IPEndPoint)server.Server.LocalEndPoint;
-                IPEndPoint clientEndPoint = (IPEndPoint)client.Provider.RemoteEndPoint;
-
-                // Notify that a new client has connected.
-                OnStatusUpdate(string.Format("Remote TCP client {0} connected to port {1}", clientEndPoint.Address, serverEndPoint.Port));
-            }
-        }
-
-        private void CommunicationServer_ClientDisconnected(object sender, EventArgs<Guid> e)
-        {
-            TcpServer server = (TcpServer)sender;
-            Dictionary<string, string> configString = server.ConfigurationString.ParseKeyValuePairs();
-
-            // Notify that existing client has disconnected.
-            OnStatusUpdate(string.Format("Remote TCP client disconnected from port {0}", configString["port"]));
-        }
-
-        #endregion
     }
+
+    private void RemoveContext(Export export)
+    {
+        lock (m_contexts)
+        {
+            if (!m_contexts.TryGetValue(export.Name, out ExportContext context))
+                return;
+            
+            // Context for the export exists, so remove it from the list.
+            context.Socket.ClientConnected -= CommunicationServer_ClientConnected;
+            context.Socket.ClientDisconnected -= CommunicationServer_ClientDisconnected;
+            context.Socket.Dispose();
+            
+            m_contexts.Remove(export.Name);
+
+            // Provide a status update.
+            OnStatusUpdate($"TCP server of export {export.Name} removed");
+        }
+    }
+
+    private void UpdateContext(Export export)
+    {
+        RemoveContext(export);   // Remove context.
+        CreateContext(export);   // Create context.
+    }
+
+    private void CommunicationServer_ClientConnected(object sender, EventArgs<Guid> e)
+    {
+        TcpServer server = (TcpServer)sender;
+
+        if (!server.TryGetClient(e.Argument, out TransportProvider<Socket> client))
+            return;
+        
+        IPEndPoint serverEndPoint = (IPEndPoint)server.Server.LocalEndPoint;
+        IPEndPoint clientEndPoint = (IPEndPoint)client.Provider.RemoteEndPoint;
+
+        // Notify that a new client has connected.
+        OnStatusUpdate($"Remote TCP client {clientEndPoint.Address} connected to port {serverEndPoint.Port}");
+    }
+
+    private void CommunicationServer_ClientDisconnected(object sender, EventArgs<Guid> e)
+    {
+        TcpServer server = (TcpServer)sender;
+        Dictionary<string, string> configString = server.ConfigurationString.ParseKeyValuePairs();
+
+        // Notify that existing client has disconnected.
+        OnStatusUpdate($"Remote TCP client disconnected from port {configString["port"]}");
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/Export.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/Export.cs
@@ -39,334 +39,277 @@ using System.Collections.Generic;
 using System.Xml.Serialization;
 using GSF.Units;
 
-namespace GSF.Historian.Exporters
+// ReSharper disable NonReadonlyMemberInGetHashCode
+
+namespace GSF.Historian.Exporters;
+
+#region [ Enumerations ]
+
+/// <summary>
+/// Indicates the processing frequency of an <see cref="Export"/>.
+/// </summary>
+public enum ExportType
 {
-    #region [ Enumerations ]
+    /// <summary>
+    /// <see cref="Export"/> is to be processed only when a request is made to process it.
+    /// </summary>
+    Manual,
+    /// <summary>
+    /// <see cref="Export"/> is to be processed as time-series data is received in real-time.
+    /// </summary>
+    RealTime,
+    /// <summary>
+    /// <see cref="Export"/> is to be processed at a set interval regardless of change in the time-series data.
+    /// </summary>
+    Intervaled
+}
+
+/// <summary>
+/// Indicates the processing result of an <see cref="Export"/>.
+/// </summary>
+public enum ExportProcessResult
+{
+    /// <summary>
+    /// <see cref="Export"/> has not been processed yet.
+    /// </summary>
+    Unknown,
+    /// <summary>
+    /// <see cref="Export"/> was processed successfully.
+    /// </summary>
+    Success,
+    /// <summary>
+    /// <see cref="Export"/> failed to process successfully.
+    /// </summary>
+    Failure
+}
+
+#endregion
+
+/// <summary>
+/// A class with information that can be used by an exporter for exporting time-series data.
+/// </summary>
+/// <seealso cref="ExportRecord"/>
+/// <seealso cref="ExportSetting"/>
+[Serializable]
+public class Export
+{
+    #region [ Members ]
+
+    // Fields
+    private string m_name;
+    private ExportType m_type;
+    private double m_interval;
+    private string m_exporter;
+    [NonSerialized]
+    private ExportProcessResult m_lastProcessResult;
+    [NonSerialized]
+    private Exception m_lastProcessError;
+    [NonSerialized]
+    private Time m_lastProcessTime;
+    [NonSerialized]
+    private DateTime m_lastProcessTimestamp;
+    private readonly List<ExportSetting> m_settings;
+    private readonly List<ExportRecord> m_records;
+
+    #endregion
+
+    #region [ Constructors ]
 
     /// <summary>
-    /// Indicates the processing frequency of an <see cref="Export"/>.
+    /// Initializes a new instance of the <see cref="Export"/> class.
     /// </summary>
-    public enum ExportType
+    /// <seealso cref="ExportRecord"/>
+    /// <seealso cref="ExportSetting"/>
+    public Export()
     {
-        /// <summary>
-        /// <see cref="Export"/> is to be processed only when a request is made to process it.
-        /// </summary>
-        Manual,
-        /// <summary>
-        /// <see cref="Export"/> is to be processed as time-series data is received in real-time.
-        /// </summary>
-        RealTime,
-        /// <summary>
-        /// <see cref="Export"/> is to be processed at a set interval regardless of change in the time-series data.
-        /// </summary>
-        Intervaled
-    }
-
-    /// <summary>
-    /// Indicates the processing result of an <see cref="Export"/>.
-    /// </summary>
-    public enum ExportProcessResult
-    {
-        /// <summary>
-        /// <see cref="Export"/> has not been processed yet.
-        /// </summary>
-        Unknown,
-        /// <summary>
-        /// <see cref="Export"/> was processed successfully.
-        /// </summary>
-        Success,
-        /// <summary>
-        /// <see cref="Export"/> failed to process successfully.
-        /// </summary>
-        Failure
+        m_name = nameof(Export);
+        m_exporter = nameof(Exporter);
+        m_settings = [];
+        m_records = [];
     }
 
     #endregion
 
+    #region [ Properties ]
+
     /// <summary>
-    /// A class with information that can be used by an exporter for exporting time-series data.
+    /// Gets or sets the name of the <see cref="Export"/>.
     /// </summary>
-    /// <seealso cref="ExportRecord"/>
-    /// <seealso cref="ExportSetting"/>
-    [Serializable]
-    public class Export
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    public string Name
     {
-        #region [ Members ]
-
-        // Fields
-        private string m_name;
-        private ExportType m_type;
-        private double m_interval;
-        private string m_exporter;
-        [NonSerialized]
-        private ExportProcessResult m_lastProcessResult;
-        [NonSerialized]
-        private Exception m_lastProcessError;
-        [NonSerialized]
-        private Time m_lastProcessTime;
-        [NonSerialized]
-        private DateTime m_lastProcessTimestamp;
-        private readonly List<ExportSetting> m_settings;
-        private readonly List<ExportRecord> m_records;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Export"/> class.
-        /// </summary>
-        /// <seealso cref="ExportRecord"/>
-        /// <seealso cref="ExportSetting"/>
-        public Export()
+        get => m_name;
+        set
         {
-            m_name = "Export";
-            m_exporter = "Exporter";
-            m_settings = new List<ExportSetting>();
-            m_records = new List<ExportRecord>();
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_name = value;
         }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the name of the <see cref="Export"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        public string Name
-        {
-            get
-            {
-                return m_name;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_name = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ExportType"/> of the <see cref="Export"/>.
-        /// </summary>
-        public ExportType Type
-        {
-            get
-            {
-                return m_type;
-            }
-            set
-            {
-                m_type = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the interval (in seconds) at which the <see cref="Export"/> is to be processed if its <see cref="Type"/> is <see cref="ExportType.Intervaled"/>.
-        /// </summary>
-        public double Interval
-        {
-            get
-            {
-                return m_interval;
-            }
-            set
-            {
-                m_interval = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the exporter (any <see cref="Type"/> that implements the <see cref="IExporter"/> interface) responsible for processing the export.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        public string Exporter
-        {
-            get
-            {
-                return m_exporter;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_exporter = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ExportProcessResult"/> of the <see cref="Export"/> when it was last processed.
-        /// </summary>
-        [XmlIgnore]
-        public ExportProcessResult LastProcessResult
-        {
-            get
-            {
-                return m_lastProcessResult;
-            }
-            set
-            {
-                m_lastProcessResult = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets any <see cref="Exception"/> encountered when the <see cref="Export"/> was last processed.
-        /// </summary>
-        [XmlIgnore]
-        public Exception LastProcessError
-        {
-            get
-            {
-                return m_lastProcessError;
-            }
-            set
-            {
-                m_lastProcessError = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Time"/> it took to process the <see cref="Export"/> when it was last processed.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="LastProcessTime"/> will be zero if the <see cref="Export.Type"/> is <see cref="ExportType.RealTime"/>.
-        /// </remarks>
-        [XmlIgnore]
-        public Time LastProcessTime
-        {
-            get
-            {
-                return m_lastProcessTime;
-            }
-            set
-            {
-                m_lastProcessTime = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="DateTime"/> of when the <see cref="Export"/> was last processed.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="LastProcessTimestamp"/> will be <see cref="DateTime.MinValue"/> if the <see cref="Export.Type"/> is <see cref="ExportType.RealTime"/>.
-        /// </remarks>
-        [XmlIgnore]
-        public DateTime LastProcessTimestamp
-        {
-            get
-            {
-                return m_lastProcessTimestamp;
-            }
-            set
-            {
-                m_lastProcessTimestamp = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the custom <see cref="ExportSetting"/>s used by the <see cref="Exporter"/> of the <see cref="Export"/>.
-        /// </summary>
-        public virtual List<ExportSetting> Settings
-        {
-            get
-            {
-                return m_settings;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ExportRecord"/>s whose time-series data is to be exported by the <see cref="Exporter"/>.
-        /// </summary>
-        public virtual List<ExportRecord> Records
-        {
-            get
-            {
-                return m_records;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Returns the <see cref="ExportSetting"/> for the specified <paramref name="settingName"/> from the <see cref="Settings"/>.
-        /// </summary>
-        /// <param name="settingName"><see cref="ExportSetting.Name"/> of the <see cref="ExportSetting"/> to be retrieved.</param>
-        /// <returns>An <see cref="ExportSetting"/> object if a match is found; otherwise null.</returns>
-        public ExportSetting FindSetting(string settingName)
-        {
-            return m_settings.Find(setting => (string.Compare(setting.Name, settingName, true) == 0));
-        }
-
-        /// <summary>
-        /// Returns the <see cref="ExportRecord"/> for the specified <paramref name="instance"/> and <paramref name="identifier"/> from the <see cref="Records"/>.
-        /// </summary>
-        /// <param name="instance"><see cref="ExportRecord.Instance"/> name of the <see cref="ExportRecord"/> to be retrieved.</param>
-        /// <param name="identifier"><see cref="ExportRecord.Identifier"/> of the <see cref="ExportRecord"/> to be retrieved.</param>
-        /// <returns>An <see cref="ExportRecord"/> object if a match is found; otherwise null.</returns>
-        public ExportRecord FindRecord(string instance, int identifier)
-        {
-            return m_records.Find(record => (string.Compare(record.Instance, instance, true) == 0 && record.Identifier == identifier));
-        }
-
-        /// <summary>
-        /// Returns the <see cref="ExportRecord"/>s for the specified <paramref name="instance"/> from the <see cref="Records"/>.
-        /// </summary>
-        /// <param name="instance"><see cref="ExportRecord.Instance"/> name of the <see cref="ExportRecord"/>s to be retrieved.</param>
-        /// <returns>An <see cref="List{T}"/> object containing matching <see cref="ExportRecord"/>s.</returns>
-        public IList<ExportRecord> FindRecords(string instance)
-        {
-            return m_records.FindAll(record => (string.Compare(record.Instance, instance, true) == 0));
-        }
-
-        /// <summary>
-        /// Determines if it is time to process the <see cref="Export"/> if its <see cref="Type"/> is <see cref="ExportType.Intervaled"/>.
-        /// </summary>
-        /// <returns><see cref="Boolean"/> indicating whether it is time to process the <see cref="Export"/>.</returns>
-        public bool ShouldProcess()
-        {
-            DateTime currentTime = DateTime.UtcNow;
-
-            if (m_type == ExportType.Intervaled && m_interval > 0 && currentTime.Subtract(m_lastProcessTimestamp).TotalSeconds >= m_interval)
-            {
-                m_lastProcessTimestamp = currentTime;
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Determines whether the current <see cref="Export"/> object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="Export"/> object is to be compared for equality.</param>
-        /// <returns>true if the current <see cref="Export"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            Export other = obj as Export;
-
-            if (other == null)
-                return false;
-
-            // We'll compare name since *Name* is considered as the "ID" for *Export*.
-            return (string.Compare(m_name, other.Name, true) == 0);
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current <see cref="Export"/> object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return m_name.GetHashCode();
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ExportType"/> of the <see cref="Export"/>.
+    /// </summary>
+    public ExportType Type
+    {
+        get => m_type;
+        set => m_type = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the interval (in seconds) at which the <see cref="Export"/> is to be processed if its <see cref="Type"/> is <see cref="ExportType.Intervaled"/>.
+    /// </summary>
+    public double Interval
+    {
+        get => m_interval;
+        set => m_interval = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the exporter (any <see cref="Type"/> that implements the <see cref="IExporter"/> interface) responsible for processing the export.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    public string Exporter
+    {
+        get => m_exporter;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_exporter = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ExportProcessResult"/> of the <see cref="Export"/> when it was last processed.
+    /// </summary>
+    [XmlIgnore]
+    public ExportProcessResult LastProcessResult
+    {
+        get => m_lastProcessResult;
+        set => m_lastProcessResult = value;
+    }
+
+    /// <summary>
+    /// Gets or sets any <see cref="Exception"/> encountered when the <see cref="Export"/> was last processed.
+    /// </summary>
+    [XmlIgnore]
+    public Exception LastProcessError
+    {
+        get => m_lastProcessError;
+        set => m_lastProcessError = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Time"/> it took to process the <see cref="Export"/> when it was last processed.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="LastProcessTime"/> will be zero if the <see cref="Export.Type"/> is <see cref="ExportType.RealTime"/>.
+    /// </remarks>
+    [XmlIgnore]
+    public Time LastProcessTime
+    {
+        get => m_lastProcessTime;
+        set => m_lastProcessTime = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="DateTime"/> of when the <see cref="Export"/> was last processed.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="LastProcessTimestamp"/> will be <see cref="DateTime.MinValue"/> if the <see cref="Export.Type"/> is <see cref="ExportType.RealTime"/>.
+    /// </remarks>
+    [XmlIgnore]
+    public DateTime LastProcessTimestamp
+    {
+        get => m_lastProcessTimestamp;
+        set => m_lastProcessTimestamp = value;
+    }
+
+    /// <summary>
+    /// Gets the custom <see cref="ExportSetting"/>s used by the <see cref="Exporter"/> of the <see cref="Export"/>.
+    /// </summary>
+    public virtual List<ExportSetting> Settings => m_settings;
+
+    /// <summary>
+    /// Gets the <see cref="ExportRecord"/>s whose time-series data is to be exported by the <see cref="Exporter"/>.
+    /// </summary>
+    public virtual List<ExportRecord> Records => m_records;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Returns the <see cref="ExportSetting"/> for the specified <paramref name="settingName"/> from the <see cref="Settings"/>.
+    /// </summary>
+    /// <param name="settingName"><see cref="ExportSetting.Name"/> of the <see cref="ExportSetting"/> to be retrieved.</param>
+    /// <returns>An <see cref="ExportSetting"/> object if a match is found; otherwise null.</returns>
+    public ExportSetting FindSetting(string settingName)
+    {
+        return m_settings.Find(setting => string.Compare(setting.Name, settingName, StringComparison.OrdinalIgnoreCase) == 0);
+    }
+
+    /// <summary>
+    /// Returns the <see cref="ExportRecord"/> for the specified <paramref name="instance"/> and <paramref name="identifier"/> from the <see cref="Records"/>.
+    /// </summary>
+    /// <param name="instance"><see cref="ExportRecord.Instance"/> name of the <see cref="ExportRecord"/> to be retrieved.</param>
+    /// <param name="identifier"><see cref="ExportRecord.Identifier"/> of the <see cref="ExportRecord"/> to be retrieved.</param>
+    /// <returns>An <see cref="ExportRecord"/> object if a match is found; otherwise null.</returns>
+    public ExportRecord FindRecord(string instance, int identifier)
+    {
+        return m_records.Find(record => string.Compare(record.Instance, instance, StringComparison.OrdinalIgnoreCase) == 0 && record.Identifier == identifier);
+    }
+
+    /// <summary>
+    /// Returns the <see cref="ExportRecord"/>s for the specified <paramref name="instance"/> from the <see cref="Records"/>.
+    /// </summary>
+    /// <param name="instance"><see cref="ExportRecord.Instance"/> name of the <see cref="ExportRecord"/>s to be retrieved.</param>
+    /// <returns>An <see cref="List{T}"/> object containing matching <see cref="ExportRecord"/>s.</returns>
+    public IList<ExportRecord> FindRecords(string instance)
+    {
+        return m_records.FindAll(record => string.Compare(record.Instance, instance, StringComparison.OrdinalIgnoreCase) == 0);
+    }
+
+    /// <summary>
+    /// Determines if it is time to process the <see cref="Export"/> if its <see cref="Type"/> is <see cref="ExportType.Intervaled"/>.
+    /// </summary>
+    /// <returns><see cref="Boolean"/> indicating whether it is time to process the <see cref="Export"/>.</returns>
+    public bool ShouldProcess()
+    {
+        DateTime currentTime = DateTime.UtcNow;
+
+        if (m_type != ExportType.Intervaled || !(m_interval > 0) || !(currentTime.Subtract(m_lastProcessTimestamp).TotalSeconds >= m_interval))
+            return false;
+        
+        m_lastProcessTimestamp = currentTime;
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the current <see cref="Export"/> object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="Export"/> object is to be compared for equality.</param>
+    /// <returns>true if the current <see cref="Export"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        if (obj is not Export other)
+            return false;
+
+        // We'll compare name since *Name* is considered as the "ID" for *Export*.
+        return string.Compare(m_name, other.Name, StringComparison.OrdinalIgnoreCase) == 0;
+    }
+
+    /// <summary>
+    /// Returns the hash code for the current <see cref="Export"/> object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        return m_name.GetHashCode();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/ExportRecord.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/ExportRecord.cs
@@ -31,135 +31,125 @@
 
 using System;
 
-namespace GSF.Historian.Exporters
+// ReSharper disable NonReadonlyMemberInGetHashCode
+
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// A class that can be used to define the time-series data to be exported for an <see cref="Export"/>.
+/// </summary>
+/// <seealso cref="Export"/>
+[Serializable]
+public class ExportRecord : IComparable
 {
+    #region [ Members ]
+
+    // Fields
+    private string m_instance;
+    private int m_identifier;
+
+    #endregion
+
+    #region [ Constructors ]
+
     /// <summary>
-    /// A class that can be used to define the time-series data to be exported for an <see cref="Export"/>.
+    /// Initializes a new instance of the <see cref="ExportRecord"/> class.
     /// </summary>
-    /// <seealso cref="Export"/>
-    [Serializable]
-    public class ExportRecord : IComparable
+    public ExportRecord()
+        : this("Default", -1)
     {
-        #region [ Members ]
-
-        // Fields
-        private string m_instance;
-        private int m_identifier;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExportRecord"/> class.
-        /// </summary>
-        public ExportRecord()
-            : this("Default", -1)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExportRecord"/> class.
-        /// </summary>
-        /// <param name="instance">Name of the historian instance providing the time-series data.</param>
-        /// <param name="identifier">Historian identifier of the <paramref name="instance"/> whose time-series data is to be exported.</param>
-        public ExportRecord(string instance, int identifier)
-        {
-            this.Instance = instance;
-            this.Identifier = identifier;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the name of the historian instance providing the time-series data.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        public string Instance
-        {
-            get
-            {
-                return m_instance;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_instance = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the historian identifier of the <see cref="Instance"/> whose time-series data is to be exported.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
-        public int Identifier
-        {
-            get
-            {
-                return m_identifier;
-            }
-            set
-            {
-                if (value < 1 && value != -1)
-                    throw new ArgumentException("Value must be positive or -1");
-
-                m_identifier = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Compares the current <see cref="ExportRecord"/> object to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="ExportRecord"/> object is to be compared.</param>
-        /// <returns>
-        /// Negative value if the current <see cref="ExportRecord"/> object is less than <paramref name="obj"/>, 
-        /// Zero if the current <see cref="ExportRecord"/> object is equal to <paramref name="obj"/>, 
-        /// Positive value if the current <see cref="ExportRecord"/> object is greater than <paramref name="obj"/>.
-        /// </returns>
-        public virtual int CompareTo(object obj)
-        {
-            ExportRecord other = obj as ExportRecord;
-            if (other == null)
-            {
-                return 1;
-            }
-            else
-            {
-                int result = string.Compare(m_instance, other.Instance, true);
-                if (result != 0)
-                    return result;
-                else
-                    return m_identifier.CompareTo(other.Identifier);
-            }
-        }
-
-        /// <summary>
-        /// Determines whether the current <see cref="ExportRecord"/> object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="ExportRecord"/> object is to be compared for equality.</param>
-        /// <returns>true if the current <see cref="ExportRecord"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            return CompareTo(obj) == 0;
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current <see cref="ExportRecord"/> object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return m_instance.GetHashCode();
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportRecord"/> class.
+    /// </summary>
+    /// <param name="instance">Name of the historian instance providing the time-series data.</param>
+    /// <param name="identifier">Historian identifier of the <paramref name="instance"/> whose time-series data is to be exported.</param>
+    public ExportRecord(string instance, int identifier)
+    {
+        Instance = instance;
+        Identifier = identifier;
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the name of the historian instance providing the time-series data.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    public string Instance
+    {
+        get => m_instance;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_instance = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the historian identifier of the <see cref="Instance"/> whose time-series data is to be exported.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
+    public int Identifier
+    {
+        get => m_identifier;
+        set
+        {
+            if (value < 1 && value != -1)
+                throw new ArgumentException("Value must be positive or -1");
+
+            m_identifier = value;
+        }
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Compares the current <see cref="ExportRecord"/> object to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="ExportRecord"/> object is to be compared.</param>
+    /// <returns>
+    /// Negative value if the current <see cref="ExportRecord"/> object is less than <paramref name="obj"/>, 
+    /// Zero if the current <see cref="ExportRecord"/> object is equal to <paramref name="obj"/>, 
+    /// Positive value if the current <see cref="ExportRecord"/> object is greater than <paramref name="obj"/>.
+    /// </returns>
+    public virtual int CompareTo(object obj)
+    {
+        if (obj is not ExportRecord other)
+        {
+            return 1;
+        }
+
+        int result = string.Compare(m_instance, other.Instance, StringComparison.OrdinalIgnoreCase);
+        
+        return result != 0 ? result : m_identifier.CompareTo(other.Identifier);
+    }
+
+    /// <summary>
+    /// Determines whether the current <see cref="ExportRecord"/> object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="ExportRecord"/> object is to be compared for equality.</param>
+    /// <returns>true if the current <see cref="ExportRecord"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        return CompareTo(obj) == 0;
+    }
+
+    /// <summary>
+    /// Returns the hash code for the current <see cref="ExportRecord"/> object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        return m_instance.GetHashCode();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/ExportSetting.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/ExportSetting.cs
@@ -31,82 +31,72 @@
 
 using System;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// A class that can be used to add custom settings to an <see cref="Export"/>.
+/// </summary>
+/// <seealso cref="Export"/>
+[Serializable]
+public class ExportSetting
 {
+    #region [ Members ]
+
+    // Fields
+    private string m_name;
+    private string m_value;
+
+    #endregion
+
+    #region [ Constructors ]
+
     /// <summary>
-    /// A class that can be used to add custom settings to an <see cref="Export"/>.
+    /// Initializes a new instance of the <see cref="ExportSetting"/> class.
     /// </summary>
-    /// <seealso cref="Export"/>
-    [Serializable]
-    public class ExportSetting
+    public ExportSetting()
+        : this(nameof(Name), nameof(Value))
     {
-        #region [ Members ]
-
-        // Fields
-        private string m_name;
-        private string m_value;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExportSetting"/> class.
-        /// </summary>
-        public ExportSetting()
-            : this("Name", "Value")
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExportSetting"/> class.
-        /// </summary>
-        /// <param name="name">Name of the <see cref="ExportSetting"/>.</param>
-        /// <param name="value">Value of the <see cref="ExportSetting"/>.</param>
-        public ExportSetting(string name, string value)
-        {
-            this.Name = name;
-            this.Value = value;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the name of the <see cref="ExportSetting"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        public string Name
-        {
-            get
-            {
-                return m_name;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_name = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the <see cref="ExportSetting"/>.
-        /// </summary>
-        public string Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportSetting"/> class.
+    /// </summary>
+    /// <param name="name">Name of the <see cref="ExportSetting"/>.</param>
+    /// <param name="value">Value of the <see cref="ExportSetting"/>.</param>
+    public ExportSetting(string name, string value)
+    {
+        Name = name;
+        Value = value;
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the name of the <see cref="ExportSetting"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    public string Name
+    {
+        get => m_name;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_name = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the value of the <see cref="ExportSetting"/>.
+    /// </summary>
+    public string Value
+    {
+        get => m_value;
+        set => m_value = value;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/ExporterBase.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/ExporterBase.cs
@@ -49,827 +49,745 @@ using System.Diagnostics;
 using System.Linq;
 using System.Timers;
 using GSF.Collections;
+using GSF.Diagnostics;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.Exporters
+// ReSharper disable NonReadonlyMemberInGetHashCode
+// ReSharper disable InconsistentlySynchronizedField
+
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Base class for an exporter of real-time time-series data.
+/// </summary>
+/// <seealso cref="Export"/>
+/// <seealso cref="DataListener"/>
+public abstract class ExporterBase : IExporter
 {
+    #region [ Members ]
+
+    // Nested Types
+
     /// <summary>
-    /// Base class for an exporter of real-time time-series data.
+    /// A class that can be used to save real-time time-series data for <see cref="Export"/>s of type <see cref="ExportType.RealTime"/>.
     /// </summary>
     /// <seealso cref="Export"/>
-    /// <seealso cref="DataListener"/>
-    public abstract class ExporterBase : IExporter
+    protected class RealTimeData
     {
-        #region [ Members ]
-
-        // Nested Types
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RealTimeData"/> class.
+        /// </summary>
+        /// <param name="export">The <see cref="Export"/> to which the <paramref name="data"/> belongs.</param>
+        /// <param name="listener">The <see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+        /// <param name="data">The real-time time-series data received by the <paramref name="listener"/>.</param>
+        public RealTimeData(Export export, DataListener listener, IList<IDataPoint> data)
+        {
+            Export = export;
+            Listener = listener;
+            Data = data;
+        }
 
         /// <summary>
-        /// A class that can be used to save real-time time-series data for <see cref="Export"/>s of type <see cref="ExportType.RealTime"/>.
+        /// Gets or sets the <see cref="Export"/> to which the <see cref="Data"/> belongs.
         /// </summary>
-        /// <seealso cref="Export"/>
-        protected class RealTimeData
+        public Export Export;
+
+        /// <summary>
+        /// Gets or sets the <see cref="DataListener"/> that provided the <see cref="Data"/>.
+        /// </summary>
+        public DataListener Listener;
+
+        /// <summary>
+        /// Gets or sets the real-time time-series data received by the <see cref="Listener"/>.
+        /// </summary>
+        public IList<IDataPoint> Data;
+    }
+
+    // Constants
+
+    /// <summary>
+    /// Number of seconds to wait to obtain a write lock on a file.
+    /// </summary>
+    public const int FileLockWaitTime = 3;
+
+    /// <summary>
+    /// Maximum number of request that could be queued in the real-time and non real-time queues.
+    /// </summary>
+    private const int MaximumQueuedRequest = 1000;
+
+    // Events
+
+    /// <summary>
+    /// Occurs when the exporter want to provide a status update.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the status update message.
+    /// </remarks>
+    public event EventHandler<EventArgs<string>> StatusUpdate;
+
+    /// <summary>
+    /// Occurs when the exporter finishes processing an <see cref="Export"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter finished processing.
+    /// </remarks>
+    public event EventHandler<EventArgs<Export>> ExportProcessed;
+
+    /// <summary>
+    /// Occurs when the exporter fails to process an <see cref="Export"/> due to an <see cref="Exception"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter failed to process.
+    /// </remarks>
+    public event EventHandler<EventArgs<Export>> ExportProcessException;
+
+    // Fields
+    private string m_name;
+    private readonly ObservableCollection<Export> m_exports;
+    private readonly ObservableCollection<DataListener> m_listeners;
+    private readonly Timer m_exportTimer;
+    private readonly ProcessQueue<Export> m_nonRealTimeExportQueue;
+    private bool m_disposed;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the exporter.
+    /// </summary>
+    /// <param name="name">Name of the exporter.</param>
+    protected ExporterBase(string name)
+    {
+        m_name = name;
+        m_exports = [];
+        m_exports.CollectionChanged += Exports_CollectionChanged;
+        m_listeners = [];
+        m_listeners.CollectionChanged += Listeners_CollectionChanged;
+        m_exportTimer = new Timer(1000);
+        m_exportTimer.Elapsed += ExportTimer_Elapsed;
+        RealTimeExportQueue = ProcessQueue<RealTimeData>.CreateRealTimeQueue(ProcessRealTimeExports);
+        m_nonRealTimeExportQueue = ProcessQueue<Export>.CreateRealTimeQueue(ProcessExport);
+
+        m_exportTimer.Start();
+        RealTimeExportQueue.Start();
+        m_nonRealTimeExportQueue.Start();
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources before the exporter is reclaimed by <see cref="GC"/>.
+    /// </summary>
+    ~ExporterBase()
+    {
+        Dispose(false);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the name of the exporter.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    public string Name
+    {
+        get => m_name;
+        set
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="RealTimeData"/> class.
-            /// </summary>
-            /// <param name="export">The <see cref="Export"/> to which the <paramref name="data"/> belongs.</param>
-            /// <param name="listener">The <see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-            /// <param name="data">The real-time time-series data received by the <paramref name="listener"/>.</param>
-            public RealTimeData(Export export, DataListener listener, IList<IDataPoint> data)
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_name = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Export"/>s associated with the exporter.
+    /// </summary>
+    /// <remarks>
+    /// WARNING: <see cref="Exports"/> is thread unsafe. Synchronized access is required.
+    /// </remarks>
+    public IList<Export> Exports => m_exports;
+
+    /// <summary>
+    /// Gets the <see cref="DataListener"/>s providing real-time time-series data to the exporter.
+    /// </summary>
+    /// <remarks>
+    /// WARNING: <see cref="Listeners"/> is thread unsafe. Synchronized access is required.
+    /// </remarks>
+    public IList<DataListener> Listeners => m_listeners;
+
+    /// <summary>
+    /// Gets or sets the <see cref="Delegate"/> to be invoked when a new <see cref="Export"/> is added to the <see cref="Exports"/>.
+    /// </summary>
+    protected Action<Export> ExportAddedHandler { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Delegate"/> to be invoked when an existing <see cref="Export"/> is removed from the <see cref="Exports"/>.
+    /// </summary>
+    protected Action<Export> ExportRemovedHandler { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Delegate"/> to be invoked when an existing <see cref="Export"/> from the <see cref="Exports"/> is updated.
+    /// </summary>
+    protected Action<Export> ExportUpdatedHandler { get; set; }
+
+    /// <summary>
+    /// Gets the internal <see cref="ProcessQueue{T}"/> used for processing <see cref="Exports"/> defined as <see cref="ExportType.RealTime"/>.
+    /// </summary>
+    protected ProcessQueue<RealTimeData> RealTimeExportQueue { get; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    #region [ Abstract ]
+
+    /// <summary>
+    /// When overridden in a derived class, processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    protected abstract void ProcessExport(Export export);
+
+    /// <summary>
+    /// When overridden in a derived class, processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+    /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
+    protected abstract void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data);
+
+    #endregion
+
+    /// <summary>
+    /// Releases all the resources used by the exporter.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Processes <see cref="Export"/> with the specified <paramref name="exportName"/>.
+    /// </summary>
+    /// <param name="exportName"><see cref="Export.Name"/> of the <see cref="Export"/> to be processed.</param>
+    /// <exception cref="InvalidOperationException"><see cref="Export"/> does not exist for the specified <paramref name="exportName"/>.</exception>
+    public void ProcessExport(string exportName)
+    {
+        Export export = FindExport(exportName);
+
+        // Queue the export for processing regardless of its type.
+        if (export is not null)
+            m_nonRealTimeExportQueue.Add(export);
+        else
+            throw new InvalidOperationException($"Export \"{exportName}\" does not exist");
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Export"/> for the specified <paramref name="exportName"/> from the <see cref="Exports"/>.
+    /// </summary>
+    /// <param name="exportName"><see cref="Export.Name"/> of the <see cref="Export"/> to be retrieved.</param>
+    /// <returns>An <see cref="Export"/> object if a match is found; otherwise null.</returns>
+    public Export FindExport(string exportName)
+    {
+        lock (m_exports)
+            return m_exports.FirstOrDefault(export => string.Compare(export.Name, exportName, true) == 0);
+    }
+
+    /// <summary>
+    /// Returns the <see cref="DataListener"/> for the specified <paramref name="listenerName"/> from the <see cref="Listeners"/>.
+    /// </summary>
+    /// <param name="listenerName"><see cref="DataListener.Name"/> of the <see cref="DataListener"/> to be retrieved.</param>
+    /// <returns>A <see cref="DataListener"/> object if a match is found; otherwise null.</returns>
+    public DataListener FindListener(string listenerName)
+    {
+        lock (m_listeners)
+            return m_listeners.FirstOrDefault(listener => string.Compare(listener.Name, listenerName, true) == 0);
+    }
+
+    /// <summary>
+    /// Determines whether the current exporter object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current exporter object is to be compared for equality.</param>
+    /// <returns>true if the current exporter object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        if (obj is not ExporterBase other)
+            return false;
+        
+        return string.Compare(m_name, other.Name, StringComparison.OrdinalIgnoreCase) == 0;
+    }
+
+    /// <summary>
+    /// Returns the hash code for the current exporter object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        return m_name.GetHashCode();
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the exporter and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (m_disposed)
+            return;
+        
+        try
+        {
+            // This will be done regardless of whether the object is finalized or disposed.
+            if (!disposing)
+                return;
+            
+            // This will be done only when the object is disposed by calling Dispose().
+            RealTimeExportQueue?.Dispose();
+
+            m_nonRealTimeExportQueue?.Dispose();
+
+            if (m_exportTimer is not null)
             {
-                this.Export = export;
-                this.Listener = listener;
-                this.Data = data;
+                m_exportTimer.Elapsed -= ExportTimer_Elapsed;
+                m_exportTimer.Dispose();
             }
 
-            /// <summary>
-            /// Gets or sets the <see cref="Export"/> to which the <see cref="Data"/> belongs.
-            /// </summary>
-            public Export Export;
-
-            /// <summary>
-            /// Gets or sets the <see cref="DataListener"/> that provided the <see cref="Data"/>.
-            /// </summary>
-            public DataListener Listener;
-
-            /// <summary>
-            /// Gets or sets the real-time time-series data received by the <see cref="Listener"/>.
-            /// </summary>
-            public IList<IDataPoint> Data;
-        }
-
-        // Constants
-
-        /// <summary>
-        /// Number of seconds to wait to obtain a write lock on a file.
-        /// </summary>
-        public const int FileLockWaitTime = 3;
-
-        /// <summary>
-        /// Maximum number of request that could be queued in the real-time and non real-time queues.
-        /// </summary>
-        private const int MaximumQueuedRequest = 1000;
-
-        // Events
-
-        /// <summary>
-        /// Occurs when the exporter want to provide a status update.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the status update message.
-        /// </remarks>
-        public event EventHandler<EventArgs<string>> StatusUpdate;
-
-        /// <summary>
-        /// Occurs when the exporter finishes processing an <see cref="Export"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter finished processing.
-        /// </remarks>
-        public event EventHandler<EventArgs<Export>> ExportProcessed;
-
-        /// <summary>
-        /// Occurs when the exporter fails to process an <see cref="Export"/> due to an <see cref="Exception"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter failed to process.
-        /// </remarks>
-        public event EventHandler<EventArgs<Export>> ExportProcessException;
-
-        // Fields
-        private string m_name;
-        private readonly ObservableCollection<Export> m_exports;
-        private readonly ObservableCollection<DataListener> m_listeners;
-        private Action<Export> m_exportAddedHandler;
-        private Action<Export> m_exportRemovedHandler;
-        private Action<Export> m_exportUpdatedHandler;
-        private readonly Timer m_exportTimer;
-        private readonly ProcessQueue<RealTimeData> m_realTimeExportQueue;
-        private readonly ProcessQueue<Export> m_nonRealTimeExportQueue;
-        private bool m_disposed;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the exporter.
-        /// </summary>
-        /// <param name="name">Name of the exporter.</param>
-        protected ExporterBase(string name)
-        {
-            m_name = name;
-            m_exports = new ObservableCollection<Export>();
-            m_exports.CollectionChanged += Exports_CollectionChanged;
-            m_listeners = new ObservableCollection<DataListener>();
-            m_listeners.CollectionChanged += Listeners_CollectionChanged;
-            m_exportTimer = new Timer(1000);
-            m_exportTimer.Elapsed += ExportTimer_Elapsed;
-            m_realTimeExportQueue = ProcessQueue<RealTimeData>.CreateRealTimeQueue(ProcessRealTimeExports);
-            m_nonRealTimeExportQueue = ProcessQueue<Export>.CreateRealTimeQueue(ProcessExport);
-
-            m_exportTimer.Start();
-            m_realTimeExportQueue.Start();
-            m_nonRealTimeExportQueue.Start();
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources before the exporter is reclaimed by <see cref="GC"/>.
-        /// </summary>
-        ~ExporterBase()
-        {
-            Dispose(false);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the name of the exporter.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        public string Name
-        {
-            get
+            // Remove all associated exports.
+            if (m_exports is not null)
             {
-                return m_name;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_name = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="Export"/>s associated with the exporter.
-        /// </summary>
-        /// <remarks>
-        /// WARNING: <see cref="Exports"/> is thread unsafe. Synchronized access is required.
-        /// </remarks>
-        public IList<Export> Exports
-        {
-            get
-            {
-                return m_exports;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="DataListener"/>s providing real-time time-series data to the exporter.
-        /// </summary>
-        /// <remarks>
-        /// WARNING: <see cref="Listeners"/> is thread unsafe. Synchronized access is required.
-        /// </remarks>
-        public IList<DataListener> Listeners
-        {
-            get
-            {
-                return m_listeners;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Delegate"/> to be invoked when a new <see cref="Export"/> is added to the <see cref="Exports"/>.
-        /// </summary>
-        protected Action<Export> ExportAddedHandler
-        {
-            get
-            {
-                return m_exportAddedHandler;
-            }
-            set
-            {
-                m_exportAddedHandler = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Delegate"/> to be invoked when an existing <see cref="Export"/> is removed from the <see cref="Exports"/>.
-        /// </summary>
-        protected Action<Export> ExportRemovedHandler
-        {
-            get
-            {
-                return m_exportRemovedHandler;
-            }
-            set
-            {
-                m_exportRemovedHandler = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Delegate"/> to be invoked when an existing <see cref="Export"/> from the <see cref="Exports"/> is updated.
-        /// </summary>
-        protected Action<Export> ExportUpdatedHandler
-        {
-            get
-            {
-                return m_exportUpdatedHandler;
-            }
-            set
-            {
-                m_exportUpdatedHandler = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the internal <see cref="ProcessQueue{T}"/> used for processing <see cref="Exports"/> defined as <see cref="ExportType.RealTime"/>.
-        /// </summary>
-        protected ProcessQueue<RealTimeData> RealTimeExportQueue
-        {
-            get
-            {
-                return m_realTimeExportQueue;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        #region [ Abstract ]
-
-        /// <summary>
-        /// When overridden in a derived class, processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        protected abstract void ProcessExport(Export export);
-
-        /// <summary>
-        /// When overridden in a derived class, processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-        /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
-        protected abstract void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data);
-
-        #endregion
-
-        /// <summary>
-        /// Releases all the resources used by the exporter.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Processes <see cref="Export"/> with the specified <paramref name="exportName"/>.
-        /// </summary>
-        /// <param name="exportName"><see cref="Export.Name"/> of the <see cref="Export"/> to be processed.</param>
-        /// <exception cref="InvalidOperationException"><see cref="Export"/> does not exist for the specified <paramref name="exportName"/>.</exception>
-        public void ProcessExport(string exportName)
-        {
-            Export export = FindExport(exportName);
-
-            // Queue the export for processing regardless of its type.
-            if (export != null)
-                m_nonRealTimeExportQueue.Add(export);
-            else
-                throw new InvalidOperationException(string.Format("Export \"{0}\" does not exist", exportName));
-        }
-
-        /// <summary>
-        /// Returns the <see cref="Export"/> for the specified <paramref name="exportName"/> from the <see cref="Exports"/>.
-        /// </summary>
-        /// <param name="exportName"><see cref="Export.Name"/> of the <see cref="Export"/> to be retrieved.</param>
-        /// <returns>An <see cref="Export"/> object if a match is found; otherwise null.</returns>
-        public Export FindExport(string exportName)
-        {
-            lock (m_exports)
-            {
-                return m_exports.FirstOrDefault(export => (string.Compare(export.Name, exportName, true) == 0));
-            }
-        }
-
-        /// <summary>
-        /// Returns the <see cref="DataListener"/> for the specified <paramref name="listenerName"/> from the <see cref="Listeners"/>.
-        /// </summary>
-        /// <param name="listenerName"><see cref="DataListener.Name"/> of the <see cref="DataListener"/> to be retrieved.</param>
-        /// <returns>A <see cref="DataListener"/> object if a match is found; otherwise null.</returns>
-        public DataListener FindListener(string listenerName)
-        {
-            lock (m_listeners)
-            {
-                return m_listeners.FirstOrDefault(listener => (string.Compare(listener.Name, listenerName, true) == 0));
-            }
-        }
-
-        /// <summary>
-        /// Determines whether the current exporter object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current exporter object is to be compared for equality.</param>
-        /// <returns>true if the current exporter object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            ExporterBase other = obj as ExporterBase;
-            if (other == null)
-                return false;
-            else
-                return string.Compare(m_name, other.Name, true) == 0;
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current exporter object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return m_name.GetHashCode();
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the exporter and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!m_disposed)
-            {
-                try
+                lock (m_exports)
                 {
-                    // This will be done regardless of whether the object is finalized or disposed.
-                    if (disposing)
-                    {
-                        // This will be done only when the object is disposed by calling Dispose().
-                        if (m_realTimeExportQueue != null)
-                            m_realTimeExportQueue.Dispose();
-
-                        if (m_nonRealTimeExportQueue != null)
-                            m_nonRealTimeExportQueue.Dispose();
-
-                        if (m_exportTimer != null)
-                        {
-                            m_exportTimer.Elapsed -= ExportTimer_Elapsed;
-                            m_exportTimer.Dispose();
-                        }
-
-                        // Remove all associated exports.
-                        if (m_exports != null)
-                        {
-                            lock (m_exports)
-                            {
-                                while (m_exports.GetEnumerator().MoveNext())
-                                {
-                                    m_exports.RemoveAt(0);
-                                }
-                            }
-                            m_exports.CollectionChanged -= Exports_CollectionChanged;
-                        }
-
-                        // Remove all associated listeners.
-                        if (m_listeners != null)
-                        {
-                            lock (m_listeners)
-                            {
-                                while (m_listeners.GetEnumerator().MoveNext())
-                                {
-                                    m_listeners.RemoveAt(0);
-                                }
-                            }
-                            m_listeners.CollectionChanged -= Listeners_CollectionChanged;
-                        }
-                    }
+                    using IEnumerator<Export> enumerator = m_exports.GetEnumerator();
+                    
+                    while (enumerator.MoveNext())
+                        m_exports.RemoveAt(0);
                 }
-                finally
+                m_exports.CollectionChanged -= Exports_CollectionChanged;
+            }
+
+            // Remove all associated listeners.
+            if (m_listeners is not null)
+            {
+                lock (m_listeners)
                 {
-                    m_disposed = true;  // Prevent duplicate dispose.
+                    using IEnumerator<DataListener> enumerator = m_listeners.GetEnumerator();
+                    
+                    while (enumerator.MoveNext())
+                        m_listeners.RemoveAt(0);
                 }
+                m_listeners.CollectionChanged -= Listeners_CollectionChanged;
             }
         }
-
-        /// <summary>
-        /// Raises the <see cref="StatusUpdate"/> event.
-        /// </summary>
-        /// <param name="status">Status update message to send to <see cref="StatusUpdate"/> event.</param>
-        protected virtual void OnStatusUpdate(string status)
+        finally
         {
-            if (StatusUpdate != null)
-                StatusUpdate(this, new EventArgs<string>(status));
+            m_disposed = true;  // Prevent duplicate dispose.
         }
+    }
 
-        /// <summary>
-        /// Raises the <see cref="ExportProcessed"/> event.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to send to <see cref="ExportProcessed"/> event.</param>
-        protected virtual void OnExportProcessed(Export export)
-        {
-            export.LastProcessError = null;
-            export.LastProcessResult = ExportProcessResult.Success;
-            if (ExportProcessed != null)
-                ExportProcessed(this, new EventArgs<Export>(export));
-        }
+    /// <summary>
+    /// Raises the <see cref="StatusUpdate"/> event.
+    /// </summary>
+    /// <param name="status">Status update message to send to <see cref="StatusUpdate"/> event.</param>
+    protected virtual void OnStatusUpdate(string status)
+    {
+        StatusUpdate?.Invoke(this, new EventArgs<string>(status));
+    }
 
-        /// <summary>
-        /// Raises the <see cref="ExportProcessException"/> event.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to send to <see cref="ExportProcessException"/> event.</param>
-        /// <param name="exception"><see cref="Exception"/> to send to <see cref="ExportProcessException"/> event.</param>
-        protected virtual void OnExportProcessException(Export export, Exception exception)
-        {
-            export.LastProcessError = exception;
-            export.LastProcessResult = ExportProcessResult.Failure;
-            if (ExportProcessException != null)
-                ExportProcessException(this, new EventArgs<Export>(export));
-        }
+    /// <summary>
+    /// Raises the <see cref="ExportProcessed"/> event.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to send to <see cref="ExportProcessed"/> event.</param>
+    protected virtual void OnExportProcessed(Export export)
+    {
+        export.LastProcessError = null;
+        export.LastProcessResult = ExportProcessResult.Success;
+        ExportProcessed?.Invoke(this, new EventArgs<Export>(export));
+    }
 
-        /// <summary>
-        /// Handles the <see cref="DataListener.DataExtracted"/> event for all the <see cref="Listeners"/>.
-        /// </summary>
-        /// <param name="sender"><see cref="DataListener"/> object that raised the event.</param>
-        /// <param name="e"><see cref="EventArgs{T}"/> object where <see cref="EventArgs{T}.Argument"/> is the collection of real-time time-sereis data received.</param>
-        protected virtual void ProcessRealTimeData(object sender, EventArgs<IList<IDataPoint>> e)
+    /// <summary>
+    /// Raises the <see cref="ExportProcessException"/> event.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to send to <see cref="ExportProcessException"/> event.</param>
+    /// <param name="exception"><see cref="Exception"/> to send to <see cref="ExportProcessException"/> event.</param>
+    protected virtual void OnExportProcessException(Export export, Exception exception)
+    {
+        export.LastProcessError = exception;
+        export.LastProcessResult = ExportProcessResult.Failure;
+        ExportProcessException?.Invoke(this, new EventArgs<Export>(export));
+    }
+
+    /// <summary>
+    /// Handles the <see cref="DataListener.DataExtracted"/> event for all the <see cref="Listeners"/>.
+    /// </summary>
+    /// <param name="sender"><see cref="DataListener"/> object that raised the event.</param>
+    /// <param name="e"><see cref="EventArgs{T}"/> object where <see cref="EventArgs{T}.Argument"/> is the collection of real-time time-sereis data received.</param>
+    protected virtual void ProcessRealTimeData(object sender, EventArgs<IList<IDataPoint>> e)
+    {
+        DataListener listener = (DataListener)sender;
+        List<Export> exportsList = [];
+
+        // Get a local copy of all the exports associated with this exporter.
+        lock (m_exports)
+            exportsList.AddRange(m_exports);
+
+        // Process all the exports.
+        foreach (Export export in exportsList)
         {
-            DataListener listener = (DataListener)sender;
-            List<Export> exportsList = new List<Export>();
-            // Get a local copy of all the exports associated with this exporter.
-            lock (m_exports)
+            if (export.Type == ExportType.RealTime && export.FindRecords(listener.ID).Count > 0)
             {
-                exportsList.AddRange(m_exports);
+                // This export is configured to be processed in real-time and has one or more records 
+                // from this listener to be exported, so we'll queue the real-time data for processing.
+                RealTimeExportQueue.Add(new RealTimeData(export, listener, e.Argument));
             }
-
-            // Process all the exports.
-            foreach (Export export in exportsList)
-            {
-                if (export.Type == ExportType.RealTime && export.FindRecords(listener.ID).Count > 0)
-                {
-                    // This export is configured to be processed in real-time and has one or more records 
-                    // from this listener to be exported, so we'll queue the real-time data for processing.
-                    m_realTimeExportQueue.Add(new RealTimeData(export, listener, e.Argument));
-                }
-            }
-
-            // We prevent flooding the queue by allowing a fixed number of request to queued at a given time.
-            // Doing so also prevents running out-of-memory that could be caused by exporters taking longer than
-            // normal to process its exports. Longer than normal processing time will back-log processing to a
-            // point that it might become impossible to catch-up because of the rate at which data may be parsed.
-            int drops = 0;
-            RealTimeData data;
-
-            while (m_realTimeExportQueue.Count > MaximumQueuedRequest)
-            {
-                m_realTimeExportQueue.TryTake(out data);
-                drops++;
-            }
-
-            if (drops > 0)
-                OnStatusUpdate(string.Format("Dropped {0} time-series data points to prevent flooding.", drops));
         }
 
-        /// <summary>
-        /// Returns the current time-series data for the specified <paramref name="export"/> organized by listener.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> whose current time-series data is to be returned.</param>
-        /// <returns>A <see cref="Dictionary{TKey,TValue}"/> object where the <b>key</b> is the <see cref="DataListener.Name"/> and <b>value</b> is the time-series data.</returns>
-        protected Dictionary<string, IList<IDataPoint>> GetExportData(Export export)
+        // We prevent flooding the queue by allowing a fixed number of request to queued at a given time.
+        // Doing so also prevents running out-of-memory that could be caused by exporters taking longer than
+        // normal to process its exports. Longer than normal processing time will back-log processing to a
+        // point that it might become impossible to catch-up because of the rate at which data may be parsed.
+        int drops = 0;
+        RealTimeData data;
+
+        while (RealTimeExportQueue.Count > MaximumQueuedRequest)
         {
-            // Arrange all export records by listeners.
-            Dictionary<string, IList<ExportRecord>> exportRecords = new Dictionary<string, IList<ExportRecord>>(StringComparer.CurrentCultureIgnoreCase);
-            foreach (ExportRecord record in export.Records)
-            {
-                if (!exportRecords.ContainsKey(record.Instance))
-                    exportRecords.Add(record.Instance, new List<ExportRecord>());
+            RealTimeExportQueue.TryTake(out data);
+            drops++;
+        }
 
-                exportRecords[record.Instance].Add(record);
-            }
+        if (drops > 0)
+            OnStatusUpdate($"Dropped {drops} time-series data points to prevent flooding.");
+    }
 
-            // Gather time-series data for the export records.
+    /// <summary>
+    /// Returns the current time-series data for the specified <paramref name="export"/> organized by listener.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> whose current time-series data is to be returned.</param>
+    /// <returns>A <see cref="Dictionary{TKey,TValue}"/> object where the <b>key</b> is the <see cref="DataListener.Name"/> and <b>value</b> is the time-series data.</returns>
+    protected Dictionary<string, IList<IDataPoint>> GetExportData(Export export)
+    {
+        // Arrange all export records by listeners.
+        Dictionary<string, IList<ExportRecord>> exportRecords = new(StringComparer.CurrentCultureIgnoreCase);
+        foreach (ExportRecord record in export.Records)
+        {
+            if (!exportRecords.ContainsKey(record.Instance))
+                exportRecords.Add(record.Instance, new List<ExportRecord>());
+
+            exportRecords[record.Instance].Add(record);
+        }
+
+        // Gather time-series data for the export records.
+        List<IDataPoint> listenerData = [];
+        Dictionary<string, IList<IDataPoint>> exportData = new();
+
+        foreach (string listenerName in exportRecords.Keys)
+        {
+            // Don't proceed if the listener doesn't exist.
             DataListener listener;
-            List<IDataPoint> listenerData = new List<IDataPoint>();
-            Dictionary<string, IList<IDataPoint>> exportData = new Dictionary<string, IList<IDataPoint>>();
-            foreach (string listenerName in exportRecords.Keys)
+
+            if ((listener = FindListener(listenerName)) is null)
+                continue;
+
+            // Get a local copy of the listener's current data.
+            listenerData.Clear();
+
+            lock (listener.Data)
+                listenerData.AddRange(listener.Data);
+
+            exportData.Add(listenerName, new List<IDataPoint>());
+            
+            if (exportRecords[listenerName].Count == 1 && exportRecords[listenerName][0].Identifier == -1)
             {
-                // Don't proceed if the listener doesn't exist.
-                if ((listener = FindListener(listenerName)) == null)
-                    continue;
+                // Include all current data from the listener.
+                exportData[listenerName].AddRange(listenerData);
+            }
+            else
+            {
+                // Specific records have been defined for this listener, so we'll gather data for those records.
+                foreach (ExportRecord record in exportRecords[listenerName])
+                    exportData[listenerName].Add(record.Identifier <= listenerData.Count ? listenerData[record.Identifier - 1] : new ArchiveDataPoint(record.Identifier));
+            }
+        }
+        return exportData;
+    }
 
-                // Get a local copy of the listener's current data.
-                listenerData.Clear();
-                lock (listener.Data)
-                {
-                    listenerData.AddRange(listener.Data);
-                }
+    /// <summary>
+    /// Returns the current time-series data for the specified <paramref name="export"/> in a <see cref="DataSet"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> whose current time-series data is to be returned.</param>
+    /// <param name="dataTableName">Name of the <see cref="DataTable"/> containing the time-series data.</param>
+    /// <returns>A <see cref="DataSet"/> object.</returns>
+    protected DataSet GetExportDataAsDataset(Export export, string dataTableName)
+    {
+        DataSet result = DatasetTemplate(dataTableName);
+        Dictionary<string, IList<IDataPoint>> exportData = GetExportData(export);
 
-                exportData.Add(listenerName, new List<IDataPoint>());
-                if (exportRecords[listenerName].Count == 1 && exportRecords[listenerName][0].Identifier == -1)
+        // Populate the dataset with time-series data.
+        foreach (string listenerName in exportData.Keys)
+        {
+            foreach (IDataPoint dataPoint in exportData[listenerName])
+                result.Tables[0].Rows.Add(listenerName, dataPoint.HistorianID, dataPoint.Time.ToString(), dataPoint.Value, (int)dataPoint.Quality);
+        }
+
+        // Set the export timestamp, row count and interval.
+        result.Tables[1].Rows.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), result.Tables[0].Rows.Count, $"{export.Interval} seconds");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Processes non-real-time exports.
+    /// </summary>
+    private void ProcessExports(Export[] items)
+    {
+        Stopwatch watch = new();
+        
+        foreach (Export item in items)
+        {
+            try
+            {
+                watch.Reset();
+                watch.Start();
+                ProcessExport(item);
+                watch.Stop();
+                item.LastProcessTime = watch.Elapsed.TotalSeconds;
+                OnExportProcessed(item);
+            }
+            catch (Exception ex)
+            {
+                OnExportProcessException(item, ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Processes real-time exports.
+    /// </summary>
+    private void ProcessRealTimeExports(RealTimeData[] items)
+    {
+        foreach (RealTimeData item in items)
+        {
+            try
+            {
+                List<IDataPoint> filteredData = [];
+                IList<ExportRecord> exportRecords = item.Export.FindRecords(item.Listener.ID);
+                
+                if (exportRecords.Count == 1 && exportRecords[0].Identifier == -1)
                 {
-                    // Include all current data from the listener.
-                    exportData[listenerName].AddRange(listenerData);
+                    // Include all data from the listener.
+                    filteredData.AddRange(item.Data);
                 }
                 else
                 {
-                    // Specific records have been defined for this listener, so we'll gather data for those records.
-                    foreach (ExportRecord record in exportRecords[listenerName])
+                    // Export data for selected records only (filtered).
+                    foreach (IDataPoint dataPoint in item.Data)
                     {
-                        if (record.Identifier <= listenerData.Count)
-                        {
-                            // Data does exist for the defined point.
-                            exportData[listenerName].Add(listenerData[record.Identifier - 1]);
-                        }
-                        else
-                        {
-                            // Data does not exist for the point, so provide empty data.
-                            exportData[listenerName].Add(new ArchiveDataPoint(record.Identifier));
-                        }
+                        if (exportRecords.FirstOrDefault(record => record.Identifier == dataPoint.HistorianID) is not null)
+                            filteredData.Add(dataPoint);
                     }
                 }
+
+                ProcessRealTimeExport(item.Export, item.Listener, filteredData);
+                item.Export.LastProcessResult = ExportProcessResult.Success;
             }
-            return exportData;
-        }
-
-        /// <summary>
-        /// Returns the current time-series data for the specified <paramref name="export"/> in a <see cref="DataSet"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> whose current time-series data is to be returned.</param>
-        /// <param name="dataTableName">Name of the <see cref="DataTable"/> containing the time-series data.</param>
-        /// <returns>A <see cref="DataSet"/> object.</returns>
-        protected DataSet GetExportDataAsDataset(Export export, string dataTableName)
-        {
-            DataSet result = DatasetTemplate(dataTableName);
-            Dictionary<string, IList<IDataPoint>> exportData = GetExportData(export);
-
-            // Populate the dataset with time-series data.
-            foreach (string listenerName in exportData.Keys)
+            catch (Exception ex)
             {
-                foreach (IDataPoint dataPoint in exportData[listenerName])
-                {
-                    result.Tables[0].Rows.Add(listenerName, dataPoint.HistorianID, dataPoint.Time.ToString(), dataPoint.Value, (int)dataPoint.Quality);
-                }
-            }
-
-            // Set the export timestamp, row count and interval.
-            result.Tables[1].Rows.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), result.Tables[0].Rows.Count, string.Format("{0} seconds", export.Interval));
-
-            return result;
-        }
-
-        /// <summary>
-        /// Processes non-real-time exports.
-        /// </summary>
-        private void ProcessExports(Export[] items)
-        {
-            Stopwatch watch = new Stopwatch();
-            foreach (Export item in items)
-            {
-                try
-                {
-                    watch.Reset();
-                    watch.Start();
-                    ProcessExport(item);
-                    watch.Stop();
-                    item.LastProcessTime = watch.Elapsed.TotalSeconds;
-                    OnExportProcessed(item);
-                }
-                catch (Exception ex)
-                {
-                    OnExportProcessException(item, ex);
-                }
+                OnExportProcessException(item.Export, ex);
             }
         }
-
-        /// <summary>
-        /// Processes real-time exports.
-        /// </summary>
-        private void ProcessRealTimeExports(RealTimeData[] items)
-        {
-            IList<ExportRecord> exportRecords;
-            foreach (RealTimeData item in items)
-            {
-                try
-                {
-                    List<IDataPoint> filteredData = new List<IDataPoint>();
-
-                    exportRecords = item.Export.FindRecords(item.Listener.ID);
-                    if (exportRecords.Count == 1 && exportRecords[0].Identifier == -1)
-                    {
-                        // Include all data from the listener.
-                        filteredData.AddRange(item.Data);
-                    }
-                    else
-                    {
-                        // Export data for selected records only (filtered).
-                        foreach (IDataPoint dataPoint in item.Data)
-                        {
-                            if (exportRecords.FirstOrDefault(record => record.Identifier == dataPoint.HistorianID) != null)
-                                filteredData.Add(dataPoint);
-                        }
-                    }
-
-                    ProcessRealTimeExport(item.Export, item.Listener, filteredData);
-                    item.Export.LastProcessResult = ExportProcessResult.Success;
-                }
-                catch (Exception ex)
-                {
-                    OnExportProcessException(item.Export, ex);
-                }
-            }
-        }
-
-        private void ExportTimer_Elapsed(object sender, ElapsedEventArgs e)
-        {
-            List<Export> exports = new List<Export>();
-
-            lock (m_exports)
-            {
-                exports.AddRange(m_exports);
-            }
-
-            // Process all exports and queue them for processing if it's time.
-            foreach (Export export in exports)
-            {
-                if (export.Type == ExportType.Intervaled && export.ShouldProcess())
-                {
-                    m_nonRealTimeExportQueue.Add(export);
-                }
-            }
-        }
-
-        private void Exports_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    // Notify that a new export is added.
-                    if (m_exportAddedHandler != null)
-                    {
-                        foreach (Export export in e.NewItems)
-                        {
-                            try
-                            {
-                                m_exportAddedHandler(export);
-                            }
-                            catch
-                            {
-                            }
-                        }
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Remove:
-                    // Notify that an existing export is removed.
-                    if (m_exportRemovedHandler != null)
-                    {
-                        foreach (Export export in e.OldItems)
-                        {
-                            try
-                            {
-                                m_exportRemovedHandler(export);
-                            }
-                            catch
-                            {
-                            }
-                        }
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Replace:
-                    // Notify that an existing export is updated.
-                    if (m_exportUpdatedHandler != null)
-                    {
-                        foreach (Export export in e.NewItems)
-                        {
-                            try
-                            {
-                                m_exportUpdatedHandler(export);
-                            }
-                            catch
-                            {
-                            }
-                        }
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        private void Listeners_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    // Register event handler.
-                    foreach (DataListener listener in e.NewItems)
-                    {
-                        listener.DataExtracted += ProcessRealTimeData;
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Remove:
-                    // Unregister event handler.
-                    foreach (DataListener listener in e.NewItems)
-                    {
-                        listener.DataExtracted -= ProcessRealTimeData;
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        #endregion
-
-        #region [ Static ]
-
-        // Static Methods
-
-        /// <summary>
-        /// Returns a template <see cref="DataSet"/> that can be used for storing time-series data in a tabular format.
-        /// </summary>
-        /// <param name="dataTableName">Name of the <see cref="DataTable"/> that will be used for storing the time-series data.</param>
-        /// <returns>A <see cref="DataSet"/> object.</returns>
-        /// <remarks>
-        /// <para>
-        /// The returned <see cref="DataSet"/> consists of two <see cref="DataTable"/>s with the following structure:<br/>
-        /// </para>
-        /// <para>
-        /// Table 1 is to be used for storing time-series data.
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Column Name</term>
-        ///         <description>Column Description</description>
-        ///     </listheader>
-        ///     <item>
-        ///         <term>Instance</term>
-        ///         <description>Historian instance providing the time-series data.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>ID</term>
-        ///         <description><see cref="IDataPoint.HistorianID"/> of the time-series data.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>Time</term>
-        ///         <description><see cref="IDataPoint.Time"/> of the time-series data.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>Value</term>
-        ///         <description><see cref="IDataPoint.Value"/> of the time-series data.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>Quality</term>
-        ///         <description><see cref="IDataPoint.Quality"/> of the time-series data.</description>
-        ///     </item>
-        /// </list>
-        /// Table 2 is to be used for providing information about Table 1.
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Column Name</term>
-        ///         <description>Column Description</description>
-        ///     </listheader>
-        ///     <item>
-        ///         <term>RunTime</term>
-        ///         <description><see cref="DateTime"/> (in UTC) when the data in Table 1 was populated.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>RecordCount</term>
-        ///         <description>Number of time-series data points in Table 1.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>RefreshSchedule</term>
-        ///         <description>Interval (in seconds) at which the data in Table 1 is to be refreshed.</description>
-        ///     </item>
-        /// </list>
-        /// </para>
-        /// </remarks>
-        public static DataSet DatasetTemplate(string dataTableName)
-        {
-            // Provide output table name if none provided.
-            if (string.IsNullOrEmpty(dataTableName))
-                dataTableName = "Measurements";
-
-            DataSet data = new DataSet(dataTableName);
-            // -- Table 1 --
-            data.Tables.Add(dataTableName);
-            DataTable dataTable = data.Tables[dataTableName];
-            dataTable.Columns.Add("Instance", typeof(string));
-            dataTable.Columns.Add("ID", typeof(int));
-            dataTable.Columns.Add("Time", typeof(string));
-            dataTable.Columns.Add("Value", typeof(float));
-            dataTable.Columns.Add("Quality", typeof(int));
-            dataTable.PrimaryKey = new[] { dataTable.Columns[0], dataTable.Columns[1], dataTable.Columns[2] };
-            // -- Table 2 --
-            data.Tables.Add("ExportInformation");
-            DataTable infoTable = data.Tables["ExportInformation"];
-            infoTable.Columns.Add("RunTime", typeof(string));
-            infoTable.Columns.Add("RecordCount", typeof(string));
-            infoTable.Columns.Add("RefreshSchedule", typeof(string));
-
-            // We'll output the xml data as attributes to save space.
-            foreach (DataTable table in data.Tables)
-            {
-                foreach (DataColumn column in table.Columns)
-                {
-                    column.ColumnMapping = MappingType.Attribute;
-                }
-            }
-
-            return data;
-        }
-
-        #endregion
     }
+
+    private void ExportTimer_Elapsed(object sender, ElapsedEventArgs e)
+    {
+        List<Export> exports = [];
+
+        lock (m_exports)
+            exports.AddRange(m_exports);
+
+        // Process all exports and queue them for processing if it's time.
+        foreach (Export export in exports.Where(export => export.Type == ExportType.Intervaled && export.ShouldProcess()))
+            m_nonRealTimeExportQueue.Add(export);
+    }
+
+    private void Exports_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        switch (e.Action)
+        {
+            case NotifyCollectionChangedAction.Add:
+                // Notify that a new export is added.
+                if (ExportAddedHandler is not null)
+                {
+                    foreach (Export export in e.NewItems)
+                    {
+                        try
+                        {
+                            ExportAddedHandler(export);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.SwallowException(ex);
+                        }
+                    }
+                }
+                break;
+            case NotifyCollectionChangedAction.Remove:
+                // Notify that an existing export is removed.
+                if (ExportRemovedHandler is not null)
+                {
+                    foreach (Export export in e.OldItems)
+                    {
+                        try
+                        {
+                            ExportRemovedHandler(export);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.SwallowException(ex);
+                        }
+                    }
+                }
+                break;
+            case NotifyCollectionChangedAction.Replace:
+                // Notify that an existing export is updated.
+                if (ExportUpdatedHandler is not null)
+                {
+                    foreach (Export export in e.NewItems)
+                    {
+                        try
+                        {
+                            ExportUpdatedHandler(export);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.SwallowException(ex);
+                        }
+                    }
+                }
+                break;
+        }
+    }
+
+    private void Listeners_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        switch (e.Action)
+        {
+            case NotifyCollectionChangedAction.Add:
+                // Register event handler.
+                foreach (DataListener listener in e.NewItems)
+                {
+                    listener.DataExtracted += ProcessRealTimeData;
+                }
+                break;
+            case NotifyCollectionChangedAction.Remove:
+                // Unregister event handler.
+                foreach (DataListener listener in e.NewItems)
+                {
+                    listener.DataExtracted -= ProcessRealTimeData;
+                }
+                break;
+        }
+    }
+
+    #endregion
+
+    #region [ Static ]
+
+    // Static Methods
+
+    /// <summary>
+    /// Returns a template <see cref="DataSet"/> that can be used for storing time-series data in a tabular format.
+    /// </summary>
+    /// <param name="dataTableName">Name of the <see cref="DataTable"/> that will be used for storing the time-series data.</param>
+    /// <returns>A <see cref="DataSet"/> object.</returns>
+    /// <remarks>
+    /// <para>
+    /// The returned <see cref="DataSet"/> consists of two <see cref="DataTable"/>s with the following structure:<br/>
+    /// </para>
+    /// <para>
+    /// Table 1 is to be used for storing time-series data.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Column Name</term>
+    ///         <description>Column Description</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>Instance</term>
+    ///         <description>Historian instance providing the time-series data.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>ID</term>
+    ///         <description><see cref="IDataPoint.HistorianID"/> of the time-series data.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Time</term>
+    ///         <description><see cref="IDataPoint.Time"/> of the time-series data.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Value</term>
+    ///         <description><see cref="IDataPoint.Value"/> of the time-series data.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Quality</term>
+    ///         <description><see cref="IDataPoint.Quality"/> of the time-series data.</description>
+    ///     </item>
+    /// </list>
+    /// Table 2 is to be used for providing information about Table 1.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Column Name</term>
+    ///         <description>Column Description</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>RunTime</term>
+    ///         <description><see cref="DateTime"/> (in UTC) when the data in Table 1 was populated.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>RecordCount</term>
+    ///         <description>Number of time-series data points in Table 1.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>RefreshSchedule</term>
+    ///         <description>Interval (in seconds) at which the data in Table 1 is to be refreshed.</description>
+    ///     </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static DataSet DatasetTemplate(string dataTableName)
+    {
+        // Provide output table name if none provided.
+        if (string.IsNullOrEmpty(dataTableName))
+            dataTableName = "Measurements";
+
+        DataSet data = new(dataTableName);
+        // -- Table 1 --
+        data.Tables.Add(dataTableName);
+        DataTable dataTable = data.Tables[dataTableName];
+        dataTable.Columns.Add("Instance", typeof(string));
+        dataTable.Columns.Add("ID", typeof(int));
+        dataTable.Columns.Add("Time", typeof(string));
+        dataTable.Columns.Add("Value", typeof(float));
+        dataTable.Columns.Add(nameof(Quality), typeof(int));
+        dataTable.PrimaryKey = [dataTable.Columns[0], dataTable.Columns[1], dataTable.Columns[2]];
+        // -- Table 2 --
+        data.Tables.Add("ExportInformation");
+        DataTable infoTable = data.Tables["ExportInformation"];
+        infoTable.Columns.Add("RunTime", typeof(string));
+        infoTable.Columns.Add("RecordCount", typeof(string));
+        infoTable.Columns.Add("RefreshSchedule", typeof(string));
+
+        // We'll output the xml data as attributes to save space.
+        foreach (DataTable table in data.Tables)
+        {
+            foreach (DataColumn column in table.Columns)
+            {
+                column.ColumnMapping = MappingType.Attribute;
+            }
+        }
+
+        return data;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/FileHelper.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/FileHelper.cs
@@ -35,80 +35,74 @@ using System.IO;
 using GSF.Data;
 using GSF.IO;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// A class with helper methods for file related operations.
+/// </summary>
+public static class FileHelper
 {
     /// <summary>
-    /// A class with helper methods for file related operations.
+    /// Writes <paramref name="data"/> to the specified <paramref name="files"/> in the specified <paramref name="format"/>.
     /// </summary>
-    public static class FileHelper
+    /// <param name="files">Comma or semicolon delimited list of file names to which <paramref name="data"/> is to be written.</param>
+    /// <param name="format">Format (CSV or XML) in which <paramref name="data"/> is to be written to the <paramref name="files"/>.</param>
+    /// <param name="data"><see cref="DataSet"/> containing the data to be written to the <paramref name="files"/>.</param>
+    public static void WriteToFile(string files, string format, DataSet data)
     {
-        /// <summary>
-        /// Writes <paramref name="data"/> to the specified <paramref name="files"/> in the specified <paramref name="format"/>.
-        /// </summary>
-        /// <param name="files">Comma or semi-colon delimitted list of file names to which <paramref name="data"/> is to be written.</param>
-        /// <param name="format">Format (CSV or XML) in which <paramref name="data"/> is to be written to the <paramref name="files"/>.</param>
-        /// <param name="data"><see cref="DataSet"/> containing the data to be written to the <paramref name="files"/>.</param>
-        public static void WriteToFile(string files, string format, DataSet data)
+        switch (format.ToLower())
         {
-            switch (format.ToLower())
+            case "xml":
+                // Get the data in XML format and write it to the specified files.
+                WriteToFile(files, data.GetXml());
+                break;
+            case "csv":
+                // Get the data in CSV format and write it to the specified files.
+                WriteToFile(files, data.Tables[0].ToDelimitedString(",", false, true));
+                break;
+            default:
+                // Throw an exception if a non-supported file format is specified.
+                throw new ArgumentException($"{format.ToUpper()} file format is not supported");
+        }
+    }
+
+    /// <summary>
+    /// Writes the specified <paramref name="text"/> to the specified <paramref name="files"/>.
+    /// </summary>
+    /// <param name="files">Comma or semicolon delimited list of file names to which the <paramref name="text"/> is to be written.</param>
+    /// <param name="text">Text to be written to the <paramref name="files"/>.</param>
+    public static void WriteToFile(string files, string text)
+    {
+        if (string.IsNullOrEmpty(files))
+            throw new ArgumentNullException(nameof(files));
+
+        // Since the text may need to be written to one or more files, the text is first written to a temporary
+        // file and then copied to overwrite the specified files in order to speed up the write process.
+        string tempFile = FilePath.GetAbsolutePath(Path.GetTempFileName());
+
+        try
+        {
+            // Write the text to the temp file.
+            File.WriteAllText(tempFile, text);
+
+            foreach (string fileName in files.Split(';', ','))
             {
-                case "xml":
-                    // Get the data in XML format and write it to the specified files.
-                    WriteToFile(files, data.GetXml());
-                    break;
-                case "csv":
-                    // Get the data in CSV format and write it to the specified files.
-                    WriteToFile(files, data.Tables[0].ToDelimitedString(",", false, true));
-                    break;
-                default:
-                    // Throw an exception if a non-supported file format is specified.
-                    throw new ArgumentException(string.Format("{0} file format is not supported", format.ToUpper()));
+                // Make the filename absolute to the app.
+                string prepFileName = FilePath.GetAbsolutePath(fileName.Trim());
+
+                // Wait for a lock on the file if it exits.
+                if (File.Exists(prepFileName))
+                    FilePath.WaitForWriteLock(prepFileName, ExporterBase.FileLockWaitTime);
+
+                // Copy the temp file to replace the file even if it exists.
+                File.Copy(tempFile, prepFileName, true);
             }
         }
-
-        /// <summary>
-        /// Writes the specified <paramref name="text"/> to the specified <paramref name="files"/>.
-        /// </summary>
-        /// <param name="files">Comma or semi-colon delimitted list of file names to which the <paramref name="text"/> is to be written.</param>
-        /// <param name="text">Text to be written to the <paramref name="files"/>.</param>
-        public static void WriteToFile(string files, string text)
+        finally
         {
-            if (string.IsNullOrEmpty(files))
-                throw new ArgumentNullException(nameof(files));
-
-            // Since the text may need to be written to one or more files, the text is first written to a temporary
-            // file and then copied to overwrite the specified files in order to speedup the write process.
-            string tempFile = FilePath.GetAbsolutePath(Path.GetTempFileName());
-            try
-            {
-                // Write the text to the temp file.
-                File.WriteAllText(tempFile, text);
-
-                string prepFileName;
-                foreach (string fileName in files.Split(';', ','))
-                {
-                    // Make the filename absolute to the app.
-                    prepFileName = FilePath.GetAbsolutePath(fileName.Trim());
-
-                    // Wait for a lock on the file if it exits.
-                    if (File.Exists(prepFileName))
-                        FilePath.WaitForWriteLock(prepFileName, ExporterBase.FileLockWaitTime);
-
-                    // Copy the temp file to replace the file even if it exists.
-                    File.Copy(tempFile, prepFileName, true);
-                }
-            }
-            catch
-            {
-                // Propagate the encountered exception.
-                throw;
-            }
-            finally
-            {
-                // Delete the temp file if we were able to create it to begin with.
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
-            }
+            // Delete the temp file if we were able to create it to begin with.
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
         }
     }
 }

--- a/Source/Libraries/GSF.Historian/Exporters/IExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/IExporter.cs
@@ -34,72 +34,71 @@
 using System;
 using System.Collections.Generic;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Defines an exporter of real-time time-series data.
+/// </summary>
+/// <seealso cref="Export"/>
+/// <seealso cref="DataListener"/>
+public interface IExporter : IDisposable
 {
+    #region [ Members ]
+
+    // Events
+
     /// <summary>
-    /// Defines an exporter of real-time time-series data.
+    /// Occurs when the exporter want to provide a status update.
     /// </summary>
-    /// <seealso cref="Export"/>
-    /// <seealso cref="DataListener"/>
-    public interface IExporter : IDisposable
-    {
-        #region [ Members ]
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the status update message.
+    /// </remarks>
+    event EventHandler<EventArgs<string>> StatusUpdate;
 
-        // Events
+    /// <summary>
+    /// Occurs when the exporter finishes processing an <see cref="Export"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter finished processing.
+    /// </remarks>
+    event EventHandler<EventArgs<Export>> ExportProcessed;
 
-        /// <summary>
-        /// Occurs when the exporter want to provide a status update.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the status update message.
-        /// </remarks>
-        event EventHandler<EventArgs<string>> StatusUpdate;
+    /// <summary>
+    /// Occurs when the exporter fails to process an <see cref="Export"/> due to an <see cref="Exception"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter failed to process.
+    /// </remarks>
+    event EventHandler<EventArgs<Export>> ExportProcessException;
 
-        /// <summary>
-        /// Occurs when the exporter finishes processing an <see cref="Export"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter finished processing.
-        /// </remarks>
-        event EventHandler<EventArgs<Export>> ExportProcessed;
+    #endregion
 
-        /// <summary>
-        /// Occurs when the exporter fails to process an <see cref="Export"/> due to an <see cref="Exception"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Export"/> that the exporter failed to process.
-        /// </remarks>
-        event EventHandler<EventArgs<Export>> ExportProcessException;
+    #region [ Properties ]
 
-        #endregion
+    /// <summary>
+    /// Gets or sets the name of the exporter.
+    /// </summary>
+    string Name { get; set; }
 
-        #region [ Properties ]
+    /// <summary>
+    /// Gets the <see cref="Export"/>s associated with the exporter.
+    /// </summary>
+    IList<Export> Exports { get; }
 
-        /// <summary>
-        /// Gets or sets the name of the exporter.
-        /// </summary>
-        string Name { get; set; }
+    /// <summary>
+    /// Gets the <see cref="DataListener"/>s providing real-time time-series data to the exporter.
+    /// </summary>
+    IList<DataListener> Listeners { get; }
 
-        /// <summary>
-        /// Gets the <see cref="Export"/>s associated with the exporter.
-        /// </summary>
-        IList<Export> Exports { get; }
+    #endregion
 
-        /// <summary>
-        /// Gets the <see cref="DataListener"/>s providing real-time time-series data to the exporter.
-        /// </summary>
-        IList<DataListener> Listeners { get; }
+    #region [ Methods ]
 
-        #endregion
+    /// <summary>
+    /// Causes the <see cref="Export"/> with the specified <paramref name="exportName"/> to be processed.
+    /// </summary>
+    /// <param name="exportName"><see cref="Export.Name"/> of the <see cref="Export"/> to be processed.</param>
+    void ProcessExport(string exportName);
 
-        #region [ Methods ]
-
-        /// <summary>
-        /// Causes the <see cref="Export"/> with the specified <paramref name="exportName"/> to be processed.
-        /// </summary>
-        /// <param name="exportName"><see cref="Export.Name"/> of the <see cref="Export"/> to be processed.</param>
-        void ProcessExport(string exportName);
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Contains classes used for automating data exports in a variety of formats.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains classes used for automating data exports in a variety of formats.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/Exporters/RawDataExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/RawDataExporter.cs
@@ -40,313 +40,297 @@ using System.Data;
 using System.Linq;
 using System.Threading;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Represents an exporter that can export real-time time-series data in CSV or XML format to a file.
+/// </summary>
+/// <example>
+/// Definition of a sample <see cref="Export"/> that can be processed by <see cref="RawDataExporter"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-16"?>
+/// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <Name>RawDataExport</Name>
+///   <Type>Intervaled</Type>
+///   <Interval>10</Interval>
+///   <Exporter>RawDataExporter</Exporter>
+///   <Settings>
+///     <ExportSetting>
+///       <Name>OutputFile</Name>
+///       <Value>c:\RawDataExporterOutput.xml</Value>
+///     </ExportSetting>
+///     <ExportSetting>
+///       <Name>OutputFormat</Name>
+///       <Value>XML</Value>
+///     </ExportSetting>    
+///   </Settings>
+///   <Records>
+///     <ExportRecord>
+///       <Instance>P3</Instance>
+///       <Identifier>3261</Identifier>
+///     </ExportRecord>
+///     <ExportRecord>
+///       <Instance>P3</Instance>
+///       <Identifier>3266</Identifier>
+///     </ExportRecord>  
+///  </Records>
+/// </Export>
+/// ]]>
+/// </code>
+/// <para>
+/// Description of custom settings required by <see cref="RawDataExporter"/> in an <see cref="Export"/>:
+/// <list type="table">
+///     <listheader>
+///         <term>Setting Name</term>
+///         <description>Setting Description</description>
+///     </listheader>
+///     <item>
+///         <term>OutputFile</term>
+///         <description>Name of the CSV or XML file (including path) where export data is to be written.</description>
+///     </item>
+///     <item>
+///         <term>OutputFormat</term>
+///         <description>Format (CSV or XML) in which export data is to be written to the output file.</description>
+///     </item>
+/// </list>
+/// </para>
+/// </example>
+/// <seealso cref="Export"/>
+public class RawDataExporter : ExporterBase
 {
+    #region [ Members ]
+
+    // Fields
+    private readonly Dictionary<string, DataSet> m_rawData;
+
+    #endregion
+
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents an exporter that can export real-time time-series data in CSV or XML format to a file.
+    /// Initializes a new instance of the <see cref="RawDataExporter"/> class.
     /// </summary>
-    /// <example>
-    /// Definition of a sample <see cref="Export"/> that can be processed by <see cref="RawDataExporter"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-16"?>
-    /// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <Name>RawDataExport</Name>
-    ///   <Type>Intervaled</Type>
-    ///   <Interval>10</Interval>
-    ///   <Exporter>RawDataExporter</Exporter>
-    ///   <Settings>
-    ///     <ExportSetting>
-    ///       <Name>OutputFile</Name>
-    ///       <Value>c:\RawDataExporterOutput.xml</Value>
-    ///     </ExportSetting>
-    ///     <ExportSetting>
-    ///       <Name>OutputFormat</Name>
-    ///       <Value>XML</Value>
-    ///     </ExportSetting>    
-    ///   </Settings>
-    ///   <Records>
-    ///     <ExportRecord>
-    ///       <Instance>P3</Instance>
-    ///       <Identifier>3261</Identifier>
-    ///     </ExportRecord>
-    ///     <ExportRecord>
-    ///       <Instance>P3</Instance>
-    ///       <Identifier>3266</Identifier>
-    ///     </ExportRecord>  
-    ///  </Records>
-    /// </Export>
-    /// ]]>
-    /// </code>
-    /// <para>
-    /// Description of custom settings required by <see cref="RawDataExporter"/> in an <see cref="Export"/>:
-    /// <list type="table">
-    ///     <listheader>
-    ///         <term>Setting Name</term>
-    ///         <description>Setting Description</description>
-    ///     </listheader>
-    ///     <item>
-    ///         <term>OutputFile</term>
-    ///         <description>Name of the CSV or XML file (including path) where export data is to be written.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>OutputFormat</term>
-    ///         <description>Format (CSV or XML) in which export data is to be written to the output file.</description>
-    ///     </item>
-    /// </list>
-    /// </para>
-    /// </example>
-    /// <seealso cref="Export"/>
-    public class RawDataExporter : ExporterBase
+    public RawDataExporter()
+        : this(nameof(RawDataExporter))
     {
-        #region [ Members ]
+    }
 
-        // Fields
-        private readonly Dictionary<string, DataSet> m_rawData;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RawDataExporter"/> class.
+    /// </summary>
+    /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
+    protected RawDataExporter(string name)
+        : base(name)
+    {
+        m_rawData = new Dictionary<string, DataSet>();
 
-        #endregion
+        // Register handlers.
+        ExportAddedHandler = CreateBuffer;
+        ExportRemovedHandler = RemoveBuffer;
+        RealTimeExportQueue.ProcessItemsFunction = ProcessRealTimeExport;
+    }
 
-        #region [ Constructors ]
+    #endregion
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RawDataExporter"/> class.
-        /// </summary>
-        public RawDataExporter()
-            : this("RawDataExporter")
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <exception cref="ArgumentException"><b>OutputFile</b> or <b>OutputFormat</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
+    protected override void ProcessExport(Export export)
+    {
+        DataSet rawData = GetBufferedData(export.Name);
+
+        try
         {
+            // Ensure that required settings are present.
+            ExportSetting outputFileSetting = export.FindSetting("OutputFile");
+            
+            if (outputFileSetting is null)
+                throw new ArgumentException("OutputFile setting is missing");
+            
+            ExportSetting outputFormatSetting = export.FindSetting("OutputFormat");
+            
+            if (outputFormatSetting is null)
+                throw new ArgumentException("OutputFormat setting is missing");
+
+            if (rawData is null)
+                return;
+            
+            // Buffered data exists for exporting.
+            lock (rawData)
+            {
+                // Update the export timestamp, row count and interval.
+                rawData.Tables[1].Rows.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), rawData.Tables[0].Rows.Count, $"{export.Interval} seconds");
+
+                // Write the buffered raw data for the export to the specified files in specified format.
+                FileHelper.WriteToFile(outputFileSetting.Value, outputFormatSetting.Value, rawData);
+            }
         }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RawDataExporter"/> class.
-        /// </summary>
-        /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
-        protected RawDataExporter(string name)
-            : base(name)
+        finally
         {
-            m_rawData = new Dictionary<string, DataSet>();
-
-            // Register handlers.
-            ExportAddedHandler = CreateBuffer;
-            ExportRemovedHandler = RemoveBuffer;
-            RealTimeExportQueue.ProcessItemsFunction = ProcessRealTimeExport;
+            if (rawData is not null)
+            {
+                lock (rawData)
+                {
+                    // Clear the buffered data to make space for new data that is to be buffered.
+                    rawData.Tables[0].Clear();
+                    rawData.Tables[1].Clear();
+                }
+            }
         }
+    }
 
-        #endregion
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+    /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
+    /// <exception cref="NotSupportedException">Always</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
+    {
+        throw new NotSupportedException();  // Real-Time exports not supported.
+    }
 
-        #region [ Methods ]
+    /// <summary>
+    /// Handles the <see cref="DataListener.DataExtracted"/> event for all the <see cref="ExporterBase.Listeners"/>.
+    /// </summary>
+    /// <param name="sender"><see cref="DataListener"/> object that raised the event.</param>
+    /// <param name="e"><see cref="EventArgs{T}"/> object where <see cref="EventArgs{T}.Argument"/> is the collection of real-time time-sereis data received.</param>
+    protected override void ProcessRealTimeData(object sender, EventArgs<IList<IDataPoint>> e)
+    {
+        DataListener listener = (DataListener)sender;
+        List<Export> exportsList = [];
 
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <exception cref="ArgumentException"><b>OutputFile</b> or <b>OutputFormat</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
-        protected override void ProcessExport(Export export)
+        // Get a local copy of all the exports this exporter is responsible for.
+        lock (Exports)
+            exportsList.AddRange(Exports);
+
+        // Queue the export and parsed data for processing if:
+        // - Export has records that are from the listener whose data we have received
+        // - Export is not "Real-Time", since real-time exports are not supported by this exporter
+        foreach (Export export in exportsList.Where(export => export.FindRecords(listener.ID).Count > 0 && export.Type != ExportType.RealTime))
+            RealTimeExportQueue.Add(new RealTimeData(export, listener, e.Argument));
+    }
+
+    /// <summary>
+    /// Returns a <see cref="DataSet"/> containing the buffered real-time time-series data.
+    /// </summary>
+    /// <param name="exportName"><see cref="Export.Name"/> of the export whose buffered data is to be retrieved.</param>
+    /// <returns>A <see cref="DataSet"/> object if buffered data exists; otherwise null.</returns>
+    protected DataSet GetBufferedData(string exportName)
+    {
+        DataSet data;
+
+        // Get the buffered data for the export.
+        lock (m_rawData)
+            m_rawData.TryGetValue(exportName, out data);
+
+        return data;
+    }
+
+    private void ProcessRealTimeExport(RealTimeData[] items)
+    {
+        foreach (RealTimeData item in items)
         {
-            DataSet rawData = GetBufferedData(export.Name);
             try
             {
-                // Ensure that required settings are present.
-                ExportSetting outputFileSetting = export.FindSetting("OutputFile");
-                if (outputFileSetting == null)
-                    throw new ArgumentException("OutputFile setting is missing");
-                ExportSetting outputFormatSetting = export.FindSetting("OutputFormat");
-                if (outputFormatSetting == null)
-                    throw new ArgumentException("OutputFormat setting is missing");
+                DataSet rawData;
 
-                if (rawData != null)
+                lock (m_rawData)
+                    m_rawData.TryGetValue(item.Export.Name, out rawData);
+
+                if (rawData is null)
+                    continue;
+                
+                // Buffer-up the parsed data for the export.
+                IList<ExportRecord> exportRecords = item.Export.FindRecords(item.Listener.ID);
+                
+                if (exportRecords.Count == 1 && exportRecords[0].Identifier == -1)
                 {
-                    // Buffered data exists for exporting.
-                    lock (rawData)
+                    // Include all data from the listener.
+                    if (!Monitor.TryEnter(rawData))
+                        continue;
+                    
+                    try
                     {
-                        // Update the export timestamp, row count and interval.
-                        rawData.Tables[1].Rows.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), rawData.Tables[0].Rows.Count, string.Format("{0} seconds", export.Interval));
-
-                        // Write the buffered raw data for the export to the specified files in specified format.
-                        FileHelper.WriteToFile(outputFileSetting.Value, outputFormatSetting.Value, rawData);
-                    }
-                }
-            }
-            catch
-            {
-                throw;
-            }
-            finally
-            {
-                if (rawData != null)
-                {
-                    lock (rawData)
-                    {
-                        // Clear the buffered data to make space for new data that is to be buffered.
-                        rawData.Tables[0].Clear();
-                        rawData.Tables[1].Clear();
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-        /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
-        /// <exception cref="NotSupportedException">Always</exception>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
-        {
-            throw new NotSupportedException();  // Real-Time exports not supported.
-        }
-
-        /// <summary>
-        /// Handles the <see cref="DataListener.DataExtracted"/> event for all the <see cref="ExporterBase.Listeners"/>.
-        /// </summary>
-        /// <param name="sender"><see cref="DataListener"/> object that raised the event.</param>
-        /// <param name="e"><see cref="EventArgs{T}"/> object where <see cref="EventArgs{T}.Argument"/> is the collection of real-time time-sereis data received.</param>
-        protected override void ProcessRealTimeData(object sender, EventArgs<IList<IDataPoint>> e)
-        {
-            DataListener listener = (DataListener)sender;
-            List<Export> exportsList = new List<Export>();
-            lock (Exports)
-            {
-                // Get a local copy of all the exports this exporter is responsible for.
-                exportsList.AddRange(Exports);
-            }
-
-            // Queue the export and parsed data for processing if:
-            // - Export has records that are from the listener whose data we have received
-            // - Export is not "Real-Time", since real-time exports are not supported by this exporter
-            foreach (Export export in exportsList)
-            {
-                if (export.FindRecords(listener.ID).Count > 0 && export.Type != ExportType.RealTime)
-                    RealTimeExportQueue.Add(new RealTimeData(export, listener, e.Argument));
-            }
-        }
-
-        /// <summary>
-        /// Returns a <see cref="DataSet"/> containing the buffered real-time time-series data.
-        /// </summary>
-        /// <param name="exportName"><see cref="Export.Name"/> of the export whose buffered data is to be retrieved.</param>
-        /// <returns>A <see cref="DataSet"/> object if buffered data exists; otherwise null.</returns>
-        protected DataSet GetBufferedData(string exportName)
-        {
-            DataSet data = null;
-            lock (m_rawData)
-            {
-                // Get the buffered data for the export.
-                m_rawData.TryGetValue(exportName, out data);
-            }
-
-            return data;
-        }
-
-        private void ProcessRealTimeExport(RealTimeData[] items)
-        {
-            DataSet rawData;
-            IList<ExportRecord> exportRecords;
-            foreach (RealTimeData item in items)
-            {
-                try
-                {
-                    lock (m_rawData)
-                    {
-                        m_rawData.TryGetValue(item.Export.Name, out rawData);
-                    }
-
-                    if (rawData != null)
-                    {
-                        // Buffer-up the parsed data for the export.
-                        exportRecords = item.Export.FindRecords(item.Listener.ID);
-                        if (exportRecords.Count == 1 && exportRecords[0].Identifier == -1)
+                        foreach (IDataPoint dataPoint in item.Data)
                         {
-                            // Include all data from the listener.
-                            if (Monitor.TryEnter(rawData))
-                            {
-                                try
-                                {
-                                    foreach (IDataPoint dataPoint in item.Data)
-                                    {
-                                        rawData.Tables[0].Rows.Add(item.Listener.ID, dataPoint.HistorianID, dataPoint.Time.ToString(), dataPoint.Value, (int)dataPoint.Quality);
-                                    }
-                                }
-                                catch
-                                {
-                                    throw;
-                                }
-                                finally
-                                {
-                                    Monitor.Exit(rawData);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // Buffer data for selected records only (filtered).
-                            ExportRecord comparer = new ExportRecord(item.Listener.ID, -1);
-                            if (Monitor.TryEnter(rawData))
-                            {
-                                try
-                                {
-                                    foreach (IDataPoint dataPoint in item.Data)
-                                    {
-                                        if (exportRecords.FirstOrDefault(record => record.Identifier == dataPoint.HistorianID) != null)
-                                            rawData.Tables[0].Rows.Add(item.Listener.ID, dataPoint.HistorianID, dataPoint.Time.ToString(), dataPoint.Value, (int)dataPoint.Quality);
-                                    }
-                                }
-                                catch
-                                {
-                                    throw;
-                                }
-                                finally
-                                {
-                                    Monitor.Exit(rawData);
-                                }
-                            }
+                            rawData.Tables[0].Rows.Add(item.Listener.ID, dataPoint.HistorianID, dataPoint.Time.ToString(), dataPoint.Value, (int)dataPoint.Quality);
                         }
                     }
+                    finally
+                    {
+                        Monitor.Exit(rawData);
+                    }
                 }
-                catch (Exception ex)
+                else
                 {
-                    OnStatusUpdate(string.Format("Data prep failed for export \"{0}\" - {1}", item.Export.Name, ex.Message));
+                    // Buffer data for selected records only (filtered).
+
+                    if (!Monitor.TryEnter(rawData))
+                        continue;
+                    
+                    try
+                    {
+                        foreach (IDataPoint dataPoint in item.Data)
+                        {
+                            if (exportRecords.FirstOrDefault(record => record.Identifier == dataPoint.HistorianID) is not null)
+                                rawData.Tables[0].Rows.Add(item.Listener.ID, dataPoint.HistorianID, dataPoint.Time.ToString(), dataPoint.Value, (int)dataPoint.Quality);
+                        }
+                    }
+                    finally
+                    {
+                        Monitor.Exit(rawData);
+                    }
                 }
             }
-        }
-
-        private void CreateBuffer(Export export)
-        {
-            DataSet rawData = null;
-            lock (m_rawData)
+            catch (Exception ex)
             {
-                if (!m_rawData.TryGetValue(export.Name, out rawData))
-                {
-                    // Dataset for buffering export data does not exist.
-                    rawData = DatasetTemplate(null);
-
-                    // Save the dataset.
-                    m_rawData.Add(export.Name, rawData);
-
-                    // Provide a status update.
-                    OnStatusUpdate(string.Format("Data buffer created for export {0}", export.Name));
-                }
+                OnStatusUpdate($"Data prep failed for export \"{item.Export.Name}\" - {ex.Message}");
             }
         }
-
-        private void RemoveBuffer(Export export)
-        {
-            lock (m_rawData)
-            {
-                DataSet data = null;
-                if (m_rawData.TryGetValue(export.Name, out data))
-                {
-                    // Remove the dataset used for buffering export data.
-                    data.Dispose();
-                    m_rawData.Remove(export.Name);
-
-                    // Provide a status update.
-                    OnStatusUpdate(string.Format("Data buffer of export {0} removed", export.Name));
-                }
-            }
-        }
-
-        #endregion
     }
+
+    private void CreateBuffer(Export export)
+    {
+        lock (m_rawData)
+        {
+            if (m_rawData.TryGetValue(export.Name, out DataSet rawData))
+                return;
+            
+            // Dataset for buffering export data does not exist.
+            rawData = DatasetTemplate(null);
+
+            // Save the dataset.
+            m_rawData.Add(export.Name, rawData);
+
+            // Provide a status update.
+            OnStatusUpdate($"Data buffer created for export {export.Name}");
+        }
+    }
+
+    private void RemoveBuffer(Export export)
+    {
+        lock (m_rawData)
+        {
+            if (!m_rawData.TryGetValue(export.Name, out DataSet data))
+                return;
+            
+            // Remove the dataset used for buffering export data.
+            data.Dispose();
+            
+            m_rawData.Remove(export.Name);
+
+            // Provide a status update.
+            OnStatusUpdate($"Data buffer of export {export.Name} removed");
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/RebroadcastExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/RebroadcastExporter.cs
@@ -38,317 +38,318 @@ using GSF.Communication;
 using GSF.Historian.Packets;
 using GSF.Parsing;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Represents an exporter that can export real-time time-series data using TCP or UDP to a listening <see cref="System.Net.Sockets.Socket"/>.
+/// </summary>
+/// <example>
+/// Definition of a sample <see cref="Export"/> that can be processed by <see cref="RebroadcastExporter"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-16"?>
+/// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <Name>RebroadcastExport</Name>
+///   <Type>RealTime</Type>
+///   <Interval>0</Interval>
+///   <Exporter>RebroadcastExporter</Exporter>
+///   <Settings>
+///     <ExportSetting>
+///       <Name>CommunicationConfiguration</Name>
+///       <Value>Protocol=TCP;Server=localhost:1002</Value>
+///     </ExportSetting>
+///     <ExportSetting>
+///       <Name>LegacyMode</Name>
+///       <Value>True</Value>
+///     </ExportSetting>
+///     <ExportSetting>
+///       <Name>PacketSize</Name>
+///       <Value>1100</Value>
+///     </ExportSetting>
+///   </Settings>
+///   <Records>
+///     <ExportRecord>
+///       <Instance>P2</Instance>
+///       <Identifier>1885</Identifier>
+///     </ExportRecord>  
+///     <ExportRecord>
+///       <Instance>P2</Instance>
+///       <Identifier>2711</Identifier>
+///     </ExportRecord>
+///   </Records>
+/// </Export>
+/// ]]>
+/// </code>
+/// <para>
+/// Description of custom settings required by <see cref="RebroadcastExporter"/> in an <see cref="Export"/>:
+/// <list type="table">
+///     <listheader>
+///         <term>Setting Name</term>
+///         <description>Setting Description</description>
+///     </listheader>
+///     <item>
+///         <term>CommunicationConfiguration</term>
+///         <description>
+///         Connection information for connecting to a remote <see cref="System.Net.Sockets.Socket"/>.<br/><br/>
+///         TCP example: Protocol=TCP;Server=localhost:1002<br/>
+///         UDP example: Protocol=UDP;Server=localhost:1002<br/>
+///         where the value of <b>Server</b> must be in the format of <b>[Remote IP or DNS Name]:[Remote Port]</b>
+///         </description>
+///     </item>
+///     <item>
+///         <term>LegacyMode (Optional)</term>
+///         <description>True if export data is to be transmitted in <see cref="PacketType1"/> and False if export data is to be transmitted in <see cref="PacketType101"/>.</description>
+///     </item>
+///     <item>
+///         <term>PacketSize (Optional)</term>
+///         <description>Maximum size of the packet in which the export data is to be transmitted.</description>
+///     </item>
+/// </list>
+/// </para>
+/// </example>
+/// <seealso cref="Export"/>
+public class RebroadcastExporter : ExporterBase
 {
+    #region [ Members ]
+
+    // Nested Types
+
     /// <summary>
-    /// Represents an exporter that can export real-time time-series data using TCP or UDP to a listening <see cref="System.Net.Sockets.Socket"/>.
+    /// A class for storing runtime information of an <see cref="Export"/>.
     /// </summary>
-    /// <example>
-    /// Definition of a sample <see cref="Export"/> that can be processed by <see cref="RebroadcastExporter"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-16"?>
-    /// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <Name>RebroadcastExport</Name>
-    ///   <Type>RealTime</Type>
-    ///   <Interval>0</Interval>
-    ///   <Exporter>RebroadcastExporter</Exporter>
-    ///   <Settings>
-    ///     <ExportSetting>
-    ///       <Name>CommunicationConfiguration</Name>
-    ///       <Value>Protocol=TCP;Server=localhost:1002</Value>
-    ///     </ExportSetting>
-    ///     <ExportSetting>
-    ///       <Name>LegacyMode</Name>
-    ///       <Value>True</Value>
-    ///     </ExportSetting>
-    ///     <ExportSetting>
-    ///       <Name>PacketSize</Name>
-    ///       <Value>1100</Value>
-    ///     </ExportSetting>
-    ///   </Settings>
-    ///   <Records>
-    ///     <ExportRecord>
-    ///       <Instance>P2</Instance>
-    ///       <Identifier>1885</Identifier>
-    ///     </ExportRecord>  
-    ///     <ExportRecord>
-    ///       <Instance>P2</Instance>
-    ///       <Identifier>2711</Identifier>
-    ///     </ExportRecord>
-    ///   </Records>
-    /// </Export>
-    /// ]]>
-    /// </code>
-    /// <para>
-    /// Description of custom settings required by <see cref="RebroadcastExporter"/> in an <see cref="Export"/>:
-    /// <list type="table">
-    ///     <listheader>
-    ///         <term>Setting Name</term>
-    ///         <description>Setting Description</description>
-    ///     </listheader>
-    ///     <item>
-    ///         <term>CommunicationConfiguration</term>
-    ///         <description>
-    ///         Connection information for connecting to a remote <see cref="System.Net.Sockets.Socket"/>.<br/><br/>
-    ///         TCP example: Protocol=TCP;Server=localhost:1002<br/>
-    ///         UDP example: Protocol=UDP;Server=localhost:1002<br/>
-    ///         where the value of <b>Server</b> must be in the format of <b>[Remote IP or DNS Name]:[Remote Port]</b>
-    ///         </description>
-    ///     </item>
-    ///     <item>
-    ///         <term>LegacyMode (Optional)</term>
-    ///         <description>True if export data is to be transmitted in <see cref="PacketType1"/> and False if export data is to be transmitted in <see cref="PacketType101"/>.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>PacketSize (Optional)</term>
-    ///         <description>Maximum size of the packet in which the export data is to be transmitted.</description>
-    ///     </item>
-    /// </list>
-    /// </para>
-    /// </example>
-    /// <seealso cref="Export"/>
-    public class RebroadcastExporter : ExporterBase
+    private class ExportContext
     {
-        #region [ Members ]
-
-        // Nested Types
+        /// <summary>
+        /// <see cref="IClient"/> used for transmitting the time-series data.
+        /// </summary>
+        public IClient Socket;
 
         /// <summary>
-        /// A class for storing runtime information of an <see cref="Export"/>.
+        /// Number of time-series data points to be transmitted in a single packet.
         /// </summary>
-        private class ExportContext
+        public int DataPerPacket;
+
+        /// <summary>
+        /// <see cref="Delegate"/> to invoke for transmitting the time-series data.
+        /// </summary>
+        public Action<ExportContext, IList<IDataPoint>> TransmitHandler;
+    }
+
+    // Fields
+    private readonly Dictionary<string, ExportContext> m_contexts;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RebroadcastExporter"/> class.
+    /// </summary>
+    public RebroadcastExporter()
+        : this(nameof(RebroadcastExporter))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RebroadcastExporter"/> class.
+    /// </summary>
+    /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
+    protected RebroadcastExporter(string name)
+        : base(name)
+    {
+        m_contexts = new Dictionary<string, ExportContext>();
+
+        // Register handlers.
+        ExportAddedHandler = CreateContext;
+        ExportRemovedHandler = RemoveContext;
+        ExportUpdatedHandler = UpdateContext;
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    protected override void ProcessExport(Export export)
+    {
+        List<IDataPoint> dataToTransmit = [];
+        Dictionary<string, IList<IDataPoint>> exportData = GetExportData(export);
+
+        // Gather the current data to be transmitted for the export.
+        foreach (string listenerName in exportData.Keys)
+            dataToTransmit.AddRange(exportData[listenerName]);
+
+        // Transmit the prepared current data.
+        TransmitData(export, dataToTransmit);
+    }
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+    /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
+    protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
+    {
+        // In case of real-time export, immediately transmit the received data.
+        TransmitData(export, data);
+    }
+
+    /// <summary>
+    /// Performs the transmission of time-series data for the <paramref name="export"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> whose time-series data os to be transmitted.</param>
+    /// <param name="dataToTransmit">Collection of time-series data to be transmitted.</param>
+    protected virtual void TransmitData(Export export, IList<IDataPoint> dataToTransmit)
+    {
+        // Retrieve the export context.
+        ExportContext context;
+        
+        lock (m_contexts)
+            m_contexts.TryGetValue(export.Name, out context);
+
+        if (context is null)
+            return;
+        
+        // Context for the export exists.
+        if (context.Socket.CurrentState == ClientState.Disconnected)
         {
-            /// <summary>
-            /// <see cref="IClient"/> used for transmitting the time-series data.
-            /// </summary>
-            public IClient Socket;
-
-            /// <summary>
-            /// Number of time-series data points to be transmitted in a single packet.
-            /// </summary>
-            public int DataPerPacket;
-
-            /// <summary>
-            /// <see cref="Delegate"/> to invoke for transmitting the time-series data.
-            /// </summary>
-            public Action<ExportContext, IList<IDataPoint>> TransmitHandler;
+            // Attempt to connect the socket.
+            context.Socket.Connect();
+            
+            if (context.Socket.CurrentState != ClientState.Connected)
+                return;
         }
 
-        // Fields
-        private readonly Dictionary<string, ExportContext> m_contexts;
+        // Socket is connected, so transmit the export data.
+        context.TransmitHandler(context, dataToTransmit);
+    }
 
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RebroadcastExporter"/> class.
-        /// </summary>
-        public RebroadcastExporter()
-            : this("RebroadcastExporter")
+    /// <summary>
+    /// Transmits export data in <see cref="PacketType1"/>
+    /// </summary>
+    private void TransmitPacketType1(ExportContext context, IList<IDataPoint> dataToTransmit)
+    {
+        byte[] dataBuffer = new byte[context.DataPerPacket * PacketType1.FixedLength];
+        
+        for (int i = 0; i < dataToTransmit.Count; i += context.DataPerPacket)
         {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RebroadcastExporter"/> class.
-        /// </summary>
-        /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
-        protected RebroadcastExporter(string name)
-            : base(name)
-        {
-            m_contexts = new Dictionary<string, ExportContext>();
-
-            // Register handlers.
-            ExportAddedHandler = CreateContext;
-            ExportRemovedHandler = RemoveContext;
-            ExportUpdatedHandler = UpdateContext;
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        protected override void ProcessExport(Export export)
-        {
-            List<IDataPoint> dataToTransmit = new List<IDataPoint>();
-            Dictionary<string, IList<IDataPoint>> exportData = GetExportData(export);
-
-            // Gather the current data to be transmitted for the export.
-            foreach (string listenerName in exportData.Keys)
+            // Transmit the data at the maximum allowed rate.
+            int dataCount = 0;
+            
+            for (int j = i; j < i + (dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket); j++)
             {
-                dataToTransmit.AddRange(exportData[listenerName]);
+                // Prepare binary image of the data.
+                new PacketType1(dataToTransmit[j]).GenerateBinaryImage(dataBuffer, dataCount * PacketType1.FixedLength);
+                dataCount++;
             }
-
-            // Transmit the prepared current data.
-            TransmitData(export, dataToTransmit);
+            
+            // Transmit the prepared binary image.
+            context.Socket.SendAsync(dataBuffer, 0, dataCount * PacketType1.FixedLength);
         }
+    }
 
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-        /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
-        protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
+    /// <summary>
+    /// Transmits export data in <see cref="PacketType101"/>
+    /// </summary>
+    private void TransmitPacketType101(ExportContext context, IList<IDataPoint> dataToTransmit)
+    {
+        PacketType101 packet;
+        
+        if (dataToTransmit.Count <= context.DataPerPacket)
         {
-            // In case of real-time export, immediately transmit the received data.
-            TransmitData(export, data);
+            // Transmit all the data.
+            packet = new PacketType101(dataToTransmit);
+            context.Socket.SendAsync(packet.BinaryImage(), 0, packet.BinaryLength);
         }
-
-        /// <summary>
-        /// Performs the transmission of time-series data for the <paramref name="export"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> whose time-series data os to be transmitted.</param>
-        /// <param name="dataToTransmit">Collection of time-series data to be transmitted.</param>
-        protected virtual void TransmitData(Export export, IList<IDataPoint> dataToTransmit)
+        else
         {
-            // Retrieve the export context.
-            ExportContext context;
-            lock (m_contexts)
-            {
-                m_contexts.TryGetValue(export.Name, out context);
-            }
-
-            if (context != null)
-            {
-                // Context for the export exists.
-                if (context.Socket.CurrentState == ClientState.Disconnected)
-                {
-                    // Attempt to connect the socket.
-                    context.Socket.Connect();
-                    if (context.Socket.CurrentState != ClientState.Connected)
-                        return;
-                }
-
-                // Socket is connected, so transmit the export data.
-                context.TransmitHandler(context, dataToTransmit);
-            }
-        }
-
-        /// <summary>
-        /// Transmits export data in <see cref="PacketType1"/>
-        /// </summary>
-        private void TransmitPacketType1(ExportContext context, IList<IDataPoint> dataToTransmit)
-        {
-            byte[] dataBuffer = new byte[context.DataPerPacket * PacketType1.FixedLength];
+            // Transmit data at the maximum allowed rate.
             for (int i = 0; i < dataToTransmit.Count; i += context.DataPerPacket)
             {
-                // Transmit the data at the maximum allowed rate.
-                int dataCount = 0;
-                for (int j = i; j < (i + (dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket)); j++)
-                {
-                    // Prepare binary image of the data.
-                    new PacketType1(dataToTransmit[j]).GenerateBinaryImage(dataBuffer, dataCount * PacketType1.FixedLength);
-                    dataCount++;
-                }
-                // Transmit the prepared binary image.
-                context.Socket.SendAsync(dataBuffer, 0, dataCount * PacketType1.FixedLength);
+                packet = new PacketType101(dataToTransmit.GetRange(i, dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket));
+                context.Socket.SendAsync(packet.BinaryImage(), 0, packet.BinaryLength);
             }
         }
+    }
 
-        /// <summary>
-        /// Transmits export data in <see cref="PacketType101"/>
-        /// </summary>
-        private void TransmitPacketType101(ExportContext context, IList<IDataPoint> dataToTransmit)
+    private void CreateContext(Export export)
+    {
+        lock (m_contexts)
         {
-            PacketType101 packet;
-            if (dataToTransmit.Count <= context.DataPerPacket)
+            if (m_contexts.TryGetValue(export.Name, out ExportContext context))
+                return;
+
+            // Context for the export does not exist, so we create one.
+            ExportSetting clientConfigSetting = export.FindSetting("CommunicationConfiguration");
+            ExportSetting legacyModeSetting = export.FindSetting("LegacyMode");
+            ExportSetting packetSizeSetting = export.FindSetting("PacketSize");
+
+            if (clientConfigSetting is null || string.IsNullOrEmpty(clientConfigSetting.Value))
+                return;
+            
+            // Create the client socket for the export context.
+            context = new ExportContext { Socket = ClientBase.Create($"{clientConfigSetting.Value}; Port=0") };
+            context.Socket.MaxConnectionAttempts = 1;   // Try connection attempt no more than 1 time.
+
+            // Determine the format of transmission.
+            if (legacyModeSetting is not null && Convert.ToBoolean(legacyModeSetting.Value))
             {
-                // Transmit all the data.
-                packet = new PacketType101(dataToTransmit);
-                context.Socket.SendAsync(packet.BinaryImage(), 0, packet.BinaryLength);
+                // Data is to be transmitted using PacketType1.
+                context.TransmitHandler = TransmitPacketType1;
+                
+                if (packetSizeSetting is not null)
+                    // Custom packet size is specified, so determine the maximum number of data points in a packet.
+                    context.DataPerPacket = Convert.ToInt32(packetSizeSetting.Value) / PacketType1.FixedLength;
+                else
+                    // Custom packet size is not specified, so used the defaults for the transmission protocol.
+                    context.DataPerPacket = context.Socket.TransportProtocol == TransportProtocol.Tcp ? 50 : 1400;
             }
             else
             {
-                // Transmit data at the maximum allowed rate.
-                for (int i = 0; i < dataToTransmit.Count; i += context.DataPerPacket)
-                {
-                    packet = new PacketType101(dataToTransmit.GetRange(i, dataToTransmit.Count - i < context.DataPerPacket ? dataToTransmit.Count - i : context.DataPerPacket));
-                    context.Socket.SendAsync(packet.BinaryImage(), 0, packet.BinaryLength);
-                }
+                // Data is to be transmitted using PacketType101.
+                context.TransmitHandler = TransmitPacketType101;
+                
+                if (packetSizeSetting is not null)
+                    // Custom packet size is specified, so determine the maximum number of data points in a packet.
+                    context.DataPerPacket = Convert.ToInt32(packetSizeSetting.Value) / PacketType101DataPoint.FixedLength;
+                else
+                    // Custom packet size is not specified, so used the defaults for the transmission protocol.
+                    context.DataPerPacket = context.Socket.TransportProtocol == TransportProtocol.Tcp ? 1000000 : 2200;
             }
+
+            // Save export context.
+            m_contexts.Add(export.Name, context);
+
+            // Provide a status update.
+            OnStatusUpdate($"{context.Socket.TransportProtocol.ToString().ToUpper()} based client created for export {export.Name}");
         }
-
-        private void CreateContext(Export export)
-        {
-            ExportContext context;
-            lock (m_contexts)
-            {
-                if (!m_contexts.TryGetValue(export.Name, out context))
-                {
-                    // Context for the export does not exist, so we create one.
-                    ExportSetting clientConfigSetting = export.FindSetting("CommunicationConfiguration");
-                    ExportSetting legacyModeSetting = export.FindSetting("LegacyMode");
-                    ExportSetting packetSizeSetting = export.FindSetting("PacketSize");
-                    if ((clientConfigSetting != null) && !string.IsNullOrEmpty(clientConfigSetting.Value))
-                    {
-                        // Create the client socket for the export context.
-                        context = new ExportContext();
-                        context.Socket = ClientBase.Create(clientConfigSetting.Value + "; Port=0");
-                        context.Socket.MaxConnectionAttempts = 1;   // Try connection attempt no more than 1 time.
-
-                        // Determine the format of transmission.
-                        if (legacyModeSetting != null && Convert.ToBoolean(legacyModeSetting.Value))
-                        {
-                            // Data is to be transmitted using PacketType1.
-                            context.TransmitHandler = TransmitPacketType1;
-                            if (packetSizeSetting != null)
-                                // Custom packet size is specified, so determine the maximum number of data points in a packet.
-                                context.DataPerPacket = Convert.ToInt32(packetSizeSetting.Value) / PacketType1.FixedLength;
-                            else
-                                // Custom packet size is not specified, so used the defaults for the transmission protocol.
-                                context.DataPerPacket = (context.Socket.TransportProtocol == TransportProtocol.Tcp ? 50 : 1400);
-                        }
-                        else
-                        {
-                            // Data is to be transmitted using PacketType101.
-                            context.TransmitHandler = TransmitPacketType101;
-                            if (packetSizeSetting != null)
-                                // Custom packet size is specified, so determine the maximum number of data points in a packet.
-                                context.DataPerPacket = Convert.ToInt32(packetSizeSetting.Value) / PacketType101DataPoint.FixedLength;
-                            else
-                                // Custom packet size is not specified, so used the defaults for the transmission protocol.
-                                context.DataPerPacket = (context.Socket.TransportProtocol == TransportProtocol.Tcp ? 1000000 : 2200);
-                        }
-
-                        // Save export context.
-                        m_contexts.Add(export.Name, context);
-
-                        // Provide a status update.
-                        OnStatusUpdate(string.Format("{0} based client created for export {1}", context.Socket.TransportProtocol.ToString().ToUpper(), export.Name));
-                    }
-                }
-            }
-        }
-
-        private void RemoveContext(Export export)
-        {
-            ExportContext context;
-            lock (m_contexts)
-            {
-                if (m_contexts.TryGetValue(export.Name, out context))
-                {
-                    // Context for the export exists, so remove it from the list.
-                    context.Socket.Dispose();
-                    m_contexts.Remove(export.Name);
-
-                    // Provide a status update.
-                    OnStatusUpdate(string.Format("{0} based client of export {1} removed", context.Socket.TransportProtocol.ToString().ToUpper(), export.Name));
-                }
-            }
-        }
-
-        private void UpdateContext(Export export)
-        {
-            RemoveContext(export);   // Remove context.
-            CreateContext(export);   // Create context.
-        }
-
-        #endregion
     }
+
+    private void RemoveContext(Export export)
+    {
+        lock (m_contexts)
+        {
+            if (!m_contexts.TryGetValue(export.Name, out ExportContext context))
+                return;
+            
+            // Context for the export exists, so remove it from the list.
+            context.Socket.Dispose();
+            m_contexts.Remove(export.Name);
+
+            // Provide a status update.
+            OnStatusUpdate($"{context.Socket.TransportProtocol.ToString().ToUpper()} based client of export {export.Name} removed");
+        }
+    }
+
+    private void UpdateContext(Export export)
+    {
+        RemoveContext(export);   // Remove context.
+        CreateContext(export);   // Create context.
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/RollingHistoryExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/RollingHistoryExporter.cs
@@ -37,238 +37,239 @@ using System.IO;
 using GSF.Data;
 using GSF.IO;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Represents an exporter that can export current and runtime historic time-series data in CSV or XML format to a file.
+/// </summary>
+/// <example>
+/// Definition of a sample <see cref="Export"/> that can be processed by <see cref="RollingHistoryExporter"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-16"?>
+/// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <Name>RollingHistoryExport</Name>
+///   <Type>Intervaled</Type>
+///   <Interval>60</Interval>
+///   <Exporter>RollingHistoryExporter</Exporter>
+///   <Settings>
+///     <ExportSetting>
+///       <Name>OutputFile</Name>
+///       <Value>c:\RollingHistoryExportOutput.xml</Value>
+///     </ExportSetting>
+///     <ExportSetting>
+///       <Name>OutputFormat</Name>
+///       <Value>XML</Value>
+///     </ExportSetting>    
+///     <ExportSetting>
+///       <Name>OutputTimespan</Name>
+///       <Value>360</Value>
+///     </ExportSetting>        
+///   </Settings>
+///   <Records>
+///     <ExportRecord>
+///       <Instance>TP</Instance>
+///       <Identifier>25609</Identifier>
+///     </ExportRecord>
+///     <ExportRecord>
+///       <Instance>TP</Instance>
+///       <Identifier>41517</Identifier>
+///     </ExportRecord>
+///  </Records>
+/// </Export>
+/// ]]>
+/// </code>
+/// <para>
+/// Description of custom settings required by <see cref="RollingHistoryExporter"/> in an <see cref="Export"/>:
+/// <list type="table">
+///     <listheader>
+///         <term>Setting Name</term>
+///         <description>Setting Description</description>
+///     </listheader>
+///     <item>
+///         <term>OutputFile</term>
+///         <description>Name of the CSV or XML file (including path) where export data is to be written.</description>
+///     </item>
+///     <item>
+///         <term>OutputFormat</term>
+///         <description>Format (CSV or XML) in which export data is to be written to the output file.</description>
+///     </item>
+///     <item>
+///         <term>OutputTimespan</term>
+///         <description>Span (represented in seconds) of the moving window for which the runtime historic data is to be exported.</description>
+///     </item>
+/// </list>
+/// </para>
+/// </example>
+/// <seealso cref="Export"/>
+public class RollingHistoryExporter : ExporterBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents an exporter that can export current and runtime historic time-series data in CSV or XML format to a file.
+    /// Initializes a new instance of the <see cref="RollingHistoryExporter"/> class.
     /// </summary>
-    /// <example>
-    /// Definition of a sample <see cref="Export"/> that can be processed by <see cref="RollingHistoryExporter"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-16"?>
-    /// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <Name>RollingHistoryExport</Name>
-    ///   <Type>Intervaled</Type>
-    ///   <Interval>60</Interval>
-    ///   <Exporter>RollingHistoryExporter</Exporter>
-    ///   <Settings>
-    ///     <ExportSetting>
-    ///       <Name>OutputFile</Name>
-    ///       <Value>c:\RollingHistoryExportOutput.xml</Value>
-    ///     </ExportSetting>
-    ///     <ExportSetting>
-    ///       <Name>OutputFormat</Name>
-    ///       <Value>XML</Value>
-    ///     </ExportSetting>    
-    ///     <ExportSetting>
-    ///       <Name>OutputTimespan</Name>
-    ///       <Value>360</Value>
-    ///     </ExportSetting>        
-    ///   </Settings>
-    ///   <Records>
-    ///     <ExportRecord>
-    ///       <Instance>TP</Instance>
-    ///       <Identifier>25609</Identifier>
-    ///     </ExportRecord>
-    ///     <ExportRecord>
-    ///       <Instance>TP</Instance>
-    ///       <Identifier>41517</Identifier>
-    ///     </ExportRecord>
-    ///  </Records>
-    /// </Export>
-    /// ]]>
-    /// </code>
-    /// <para>
-    /// Description of custom settings required by <see cref="RollingHistoryExporter"/> in an <see cref="Export"/>:
-    /// <list type="table">
-    ///     <listheader>
-    ///         <term>Setting Name</term>
-    ///         <description>Setting Description</description>
-    ///     </listheader>
-    ///     <item>
-    ///         <term>OutputFile</term>
-    ///         <description>Name of the CSV or XML file (including path) where export data is to be written.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>OutputFormat</term>
-    ///         <description>Format (CSV or XML) in which export data is to be written to the output file.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>OutputTimespan</term>
-    ///         <description>Span (represented in seconds) of the moving window for which the runtime historic data is to be exported.</description>
-    ///     </item>
-    /// </list>
-    /// </para>
-    /// </example>
-    /// <seealso cref="Export"/>
-    public class RollingHistoryExporter : ExporterBase
+    public RollingHistoryExporter()
+        : this(nameof(RollingHistoryExporter))
     {
-        #region [ Constructors ]
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RollingHistoryExporter"/> class.
-        /// </summary>
-        public RollingHistoryExporter()
-            : this("RollingHistoryExporter")
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RollingHistoryExporter"/> class.
+    /// </summary>
+    /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
+    protected RollingHistoryExporter(string name)
+        : base(name)
+    {
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <exception cref="ArgumentException"><b>OutputFile</b>, <b>OutputFormat</b> or <b>OutputTimespan</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
+    protected override void ProcessExport(Export export)
+    {
+        // Ensure that required settings are present.
+        ExportSetting outputFileSetting = export.FindSetting("OutputFile");
+        
+        if (outputFileSetting is null)
+            throw new ArgumentException("OutputFile setting is missing");
+        
+        ExportSetting outputFormatSetting = export.FindSetting("OutputFormat");
+        
+        if (outputFormatSetting is null)
+            throw new ArgumentException("OutputFormat setting is missing");
+        
+        ExportSetting outputTimespanSetting = export.FindSetting("OutputTimespan");
+        
+        if (outputTimespanSetting is null)
+            throw new ArgumentException("OutputTimespan setting is missing");
+
+        // Initialize local variables.
+        DataSet output = null;
+        string[] outputFiles = outputFileSetting.Value.Split(';', ',');
+        DataSet current = GetExportDataAsDataset(export, null);
+        DateTime dataStartDate = DateTime.UtcNow.AddMinutes(-Convert.ToInt32(outputTimespanSetting.Value));
+
+        // Make the output filenames absolute.
+        for (int i = 0; i < outputFiles.Length; i++)
+            outputFiles[i] = FilePath.GetAbsolutePath(outputFiles[i].Trim());
+
+        // Try to read-in data that might have been exported previously.
+        foreach (string outputFile in outputFiles)
         {
-        }
+            if (!File.Exists(outputFile))
+                continue;
+            
+            // Wait for a lock on the file before reading.
+            FilePath.WaitForReadLock(outputFile, FileLockWaitTime);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RollingHistoryExporter"/> class.
-        /// </summary>
-        /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
-        protected RollingHistoryExporter(string name)
-            : base(name)
-        {
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <exception cref="ArgumentException"><b>OutputFile</b>, <b>OutputFormat</b> or <b>OutputTimespan</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
-        protected override void ProcessExport(Export export)
-        {
-            // Ensure that required settings are present.
-            ExportSetting outputFileSetting = export.FindSetting("OutputFile");
-            if (outputFileSetting == null)
-                throw new ArgumentException("OutputFile setting is missing");
-            ExportSetting outputFormatSetting = export.FindSetting("OutputFormat");
-            if (outputFormatSetting == null)
-                throw new ArgumentException("OutputFormat setting is missing");
-            ExportSetting outputTimespanSetting = export.FindSetting("OutputTimespan");
-            if (outputTimespanSetting == null)
-                throw new ArgumentException("OutputTimespan setting is missing");
-
-            // Initialize local variables.
-            DataSet output = null;
-            string[] outputFiles = outputFileSetting.Value.Split(';', ',');
-            DataSet current = GetExportDataAsDataset(export, null);
-            DateTime dataStartDate = DateTime.UtcNow.AddMinutes(-Convert.ToInt32(outputTimespanSetting.Value));
-
-            // Make the output filenames absolute.
-            for (int i = 0; i < outputFiles.Length; i++)
+            // Read the file data and keep it in memory to be merged later.
+            output = current.Clone();
+            
+            switch (outputFormatSetting.Value.ToLower())
             {
-                outputFiles[i] = FilePath.GetAbsolutePath(outputFiles[i].Trim());
+                case "xml":
+                    output.ReadXml(outputFile);
+                    break;
+                case "csv":
+                    MergeTables(output.Tables[0], File.ReadAllText(outputFile).ToDataTable(",", true), dataStartDate);
+                    break;
             }
 
-            // Try to read-in data that might have been exported previously.
-            foreach (string outputFile in outputFiles)
+            break; // Don't look any further.
+        }
+
+        if (output is null)
+            // Output will be just current data since there is no previously exported data.
+            output = current;
+        else
+            // Merge previously exported data loaded from file with the current data for the export.
+            MergeTables(output.Tables[0], current.Tables[0], dataStartDate);
+
+        // Delete any old data from the output that don't fall in the export's rolling window.
+        string filterCondition = $"Convert(Time, System.DateTime) < #{dataStartDate}#";
+        
+        foreach (DataRow row in output.Tables[0].Select(filterCondition))
+            row.Delete();
+
+        // Update the export timestamp, row count and interval.
+        DataRowCollection info = output.Tables[1].Rows;
+        
+        info.Clear();
+        info.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), output.Tables[0].Rows.Count, $"{export.Interval} seconds");
+
+        // Write the data for the export to the specified files in specified format.
+        FileHelper.WriteToFile(outputFileSetting.Value, outputFormatSetting.Value, output);
+    }
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+    /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
+    /// <exception cref="NotSupportedException">Always</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
+    {
+        throw new NotSupportedException();  // Real-Time exports not supported.
+    }
+
+    private void MergeTables(DataTable history, DataTable current, DateTime startDate)
+    {
+        foreach (DataRow newData in current.Rows)
+        {
+            DateTime dt = Convert.ToDateTime(newData["Time"]);
+            
+            if (dt != TimeTag.MinValue)
             {
-                if (File.Exists(outputFile))
+                // Data is real and not made-up.
+                if (dt >= startDate)
                 {
-                    // Wait for a lock on the file before reading.
-                    FilePath.WaitForReadLock(outputFile, FileLockWaitTime);
-
-                    // Read the file data and keep it in memory to be merged later.
-                    output = current.Clone();
-                    switch (outputFormatSetting.Value.ToLower())
+                    // Data falls within the export's rolling window.
+                    try
                     {
-                        case "xml":
-                            output.ReadXml(outputFile);
-                            break;
-                        case "csv":
-                            MergeTables(output.Tables[0], File.ReadAllText(outputFile).ToDataTable(",", true), dataStartDate);
-                            break;
-                        default:
-                            break;
+                        history.Rows.Add(newData.ItemArray);
                     }
-
-                    break; // Don't look any further.
-                }
-            }
-
-            if (output == null)
-                // Output will be just current data since there is no previously exported data.
-                output = current;
-            else
-                // Merge previously exported data loaded from file with the current data for the export.
-                MergeTables(output.Tables[0], current.Tables[0], dataStartDate);
-
-            // Delete any old data from the output that don't fall in the export's rolling window.
-            string filterCondition = string.Format("Convert(Time, System.DateTime) < #{0}#", dataStartDate);
-            foreach (DataRow row in output.Tables[0].Select(filterCondition))
-            {
-                row.Delete();
-            }
-
-            // Update the export timestamp, row count and interval.
-            DataRowCollection info = output.Tables[1].Rows;
-            info.Clear();
-            info.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), output.Tables[0].Rows.Count, string.Format("{0} seconds", export.Interval));
-
-            // Write the data for the export to the specified files in specified format.
-            FileHelper.WriteToFile(outputFileSetting.Value, outputFormatSetting.Value, output);
-        }
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-        /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
-        /// <exception cref="NotSupportedException">Always</exception>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
-        {
-            throw new NotSupportedException();  // Real-Time exports not supported.
-        }
-
-        private void MergeTables(DataTable history, DataTable current, DateTime startDate)
-        {
-            DateTime dt;
-            foreach (DataRow newData in current.Rows)
-            {
-                dt = Convert.ToDateTime(newData["Time"]);
-                if (dt != TimeTag.MinValue)
-                {
-                    // Data is real and not made-up.
-                    if (dt >= startDate)
+                    catch
                     {
-                        // Data falls within the export's rolling window.
-                        try
-                        {
-                            history.Rows.Add(newData.ItemArray);
-                        }
-                        catch
-                        {
-                            // Exception is encountered if duplicate data is inserted.
-                            AddDummyData(history, newData);
-                        }
-                    }
-                    else
-                    {
-                        // Data is outside the export's rolling window.
+                        // Exception is encountered if duplicate data is inserted.
                         AddDummyData(history, newData);
                     }
                 }
                 else
                 {
-                    // Data is not real but made-up.
+                    // Data is outside the export's rolling window.
                     AddDummyData(history, newData);
                 }
             }
+            else
+            {
+                // Data is not real but made-up.
+                AddDummyData(history, newData);
+            }
         }
-
-        private void AddDummyData(DataTable table, DataRow data)
-        {
-            // "Dummy" data is data of a point that is manufatured by changing the timetag to current timetag
-            // and putting in blanks in Value and Quality fields. This is needed in the following cases:
-            // - Data that has been added as placeholder because there is no actual data for that point is
-            //   available yet.
-            // - Data for a point was last received before the export's rolling history window.
-            // - Data for a point was not updated between the current and previous runs. This is required because
-            //   Instance, ID and Time make up the primary key for the table and since the data between runs has
-            //   not changed, we'll be adding duplicates resulting in an exception. So we add "dummy" data for that
-            //   point since we have to provide data for every defined point during every run.
-            table.Rows.Add(data["Instance"], data["ID"], new TimeTag(DateTime.UtcNow).ToString(), float.NaN, Quality.Unknown);
-        }
-
-        #endregion
     }
+
+    private void AddDummyData(DataTable table, DataRow data)
+    {
+        // "Dummy" data is data of a point that is manufactured by changing the time tag to current time tag
+        // and putting in blanks in Value and Quality fields. This is needed in the following cases:
+        // - Data that has been added as placeholder because there is no actual data for that point is
+        //   available yet.
+        // - Data for a point was last received before the export's rolling history window.
+        // - Data for a point was not updated between the current and previous runs. This is required because
+        //   Instance, ID and Time make up the primary key for the table and since the data between runs has
+        //   not changed, we'll be adding duplicates resulting in an exception. So we add "dummy" data for that
+        //   point since we have to provide data for every defined point during every run.
+        table.Rows.Add(data["Instance"], data["ID"], new TimeTag(DateTime.UtcNow).ToString(), float.NaN, Quality.Unknown);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/StatisticsExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/StatisticsExporter.cs
@@ -41,298 +41,292 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Represents an exporter that can export the <see cref="Statistics"/> in CSV or XML format to a file.
+/// </summary>
+/// <example>
+/// Definition of a sample <see cref="Export"/> that can be processed by <see cref="StatisticsExporter"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-16"?>
+/// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <Name>StatisticsExporte</Name>
+///   <Type>Intervaled</Type>
+///   <Interval>10</Interval>
+///   <Exporter>StatisticsExporter</Exporter>
+///   <Settings>
+///     <ExportSetting>
+///       <Name>OutputFile</Name>
+///       <Value>\\trotibco\XML\EIRA.xml</Value>
+///     </ExportSetting>
+///     <ExportSetting>
+///       <Name>OutputFormat</Name>
+///       <Value>XML</Value>
+///     </ExportSetting>    
+///     <ExportSetting>
+///       <Name>FilterClause</Name>
+///       <Value>Value&gt;=59 And Value&lt;=61</Value>
+///     </ExportSetting>
+///     <ExportSetting>
+///       <Name>SlopeThreshold</Name>
+///       <Value>.9</Value>
+///     </ExportSetting>
+///   </Settings>
+///   <Records>
+///     <ExportRecord>
+///       <Instance>P1</Instance>
+///       <Identifier>1285</Identifier>
+///     </ExportRecord>    
+///     <ExportRecord>
+///       <Instance>P2</Instance>
+///       <Identifier>3173</Identifier>
+///     </ExportRecord>    
+///     <ExportRecord>
+///       <Instance>P3</Instance>
+///       <Identifier>1838</Identifier>
+///     </ExportRecord>    
+///  </Records>
+/// </Export>
+/// ]]>
+/// </code>
+/// <para>
+/// Description of custom settings required by <see cref="StatisticsExporter"/> in an <see cref="Export"/>:
+/// <list type="table">
+///     <listheader>
+///         <term>Setting Name</term>
+///         <description>Setting Description</description>
+///     </listheader>
+///     <item>
+///         <term>OutputFile</term>
+///         <description>Name of the CSV or XML file (including path) where export data is to be written.</description>
+///     </item>
+///     <item>
+///         <term>OutputFormat</term>
+///         <description>Format (CSV or XML) in which export data is to be written to the output file.</description>
+///     </item>
+///     <item>
+///         <term>FilterClause (Optional)</term>
+///         <description>SQL-like expression to be used for limiting the data included in the calculation.</description>
+///     </item>
+///     <item>
+///         <term>SlopeThreshold (Optional)</term>
+///         <description>Floating point value to be used for eliminating data with a slope exceeding the specified threshold.</description>
+///     </item>
+/// </list>
+/// </para>
+/// </example>
+/// <seealso cref="Export"/>
+public class StatisticsExporter : RawDataExporter
 {
+    #region [ Members ]
+
+    // Nested Types
+
     /// <summary>
-    /// Represents an exporter that can export the <see cref="Statistics"/> in CSV or XML format to a file.
+    /// A class for calculating the MIN, MAX and AVG of time-series data over a period of time.
     /// </summary>
-    /// <example>
-    /// Definition of a sample <see cref="Export"/> that can be processed by <see cref="StatisticsExporter"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-16"?>
-    /// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <Name>StatisticsExporte</Name>
-    ///   <Type>Intervaled</Type>
-    ///   <Interval>10</Interval>
-    ///   <Exporter>StatisticsExporter</Exporter>
-    ///   <Settings>
-    ///     <ExportSetting>
-    ///       <Name>OutputFile</Name>
-    ///       <Value>\\trotibco\XML\EIRA.xml</Value>
-    ///     </ExportSetting>
-    ///     <ExportSetting>
-    ///       <Name>OutputFormat</Name>
-    ///       <Value>XML</Value>
-    ///     </ExportSetting>    
-    ///     <ExportSetting>
-    ///       <Name>FilterClause</Name>
-    ///       <Value>Value&gt;=59 And Value&lt;=61</Value>
-    ///     </ExportSetting>
-    ///     <ExportSetting>
-    ///       <Name>SlopeThreshold</Name>
-    ///       <Value>.9</Value>
-    ///     </ExportSetting>
-    ///   </Settings>
-    ///   <Records>
-    ///     <ExportRecord>
-    ///       <Instance>P1</Instance>
-    ///       <Identifier>1285</Identifier>
-    ///     </ExportRecord>    
-    ///     <ExportRecord>
-    ///       <Instance>P2</Instance>
-    ///       <Identifier>3173</Identifier>
-    ///     </ExportRecord>    
-    ///     <ExportRecord>
-    ///       <Instance>P3</Instance>
-    ///       <Identifier>1838</Identifier>
-    ///     </ExportRecord>    
-    ///  </Records>
-    /// </Export>
-    /// ]]>
-    /// </code>
-    /// <para>
-    /// Description of custom settings required by <see cref="StatisticsExporter"/> in an <see cref="Export"/>:
-    /// <list type="table">
-    ///     <listheader>
-    ///         <term>Setting Name</term>
-    ///         <description>Setting Description</description>
-    ///     </listheader>
-    ///     <item>
-    ///         <term>OutputFile</term>
-    ///         <description>Name of the CSV or XML file (including path) where export data is to be written.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>OutputFormat</term>
-    ///         <description>Format (CSV or XML) in which export data is to be written to the output file.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>FilterClause (Optional)</term>
-    ///         <description>SQL-like expression to be used for limiting the data included in the calculation.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>SlopeThreshold (Optional)</term>
-    ///         <description>Floating point value to be used for eliminating data with a slope exceeding the specified threshold.</description>
-    ///     </item>
-    /// </list>
-    /// </para>
-    /// </example>
-    /// <seealso cref="Export"/>
-    public class StatisticsExporter : RawDataExporter
+    protected class Statistics
     {
-        #region [ Members ]
-
-        // Nested Types
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Statistics"/> class.
+        /// </summary>
+        public Statistics()
+        {
+            MinimumValue = double.NaN;
+            MaximumValue = double.NaN;
+            AverageValue = double.NaN;
+        }
 
         /// <summary>
-        /// A class for calculating the MIN, MAX and AVG of time-series data over a period of time.
+        /// The smallest value in the time-series data.
         /// </summary>
-        protected class Statistics
+        public double MinimumValue;
+
+        /// <summary>
+        /// The largest value in the time-series data.
+        /// </summary>
+        public double MaximumValue;
+
+        /// <summary>
+        /// The average value in the time-series data.
+        /// </summary>
+        public double AverageValue;
+
+        /// <summary>
+        /// Calculates <see cref="Statistics"/> from the provided <paramref name="data"/> and clear the <paramref name="data"/> when done.
+        /// </summary>
+        /// <param name="data">A <see cref="DataSet"/> containing buffered real-time time-series data.</param>
+        /// <param name="filerClause">Filter clause to be applied for limiting the data included in the calculation.</param>
+        public void Calculate(DataSet data, string filerClause)
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Statistics"/> class.
-            /// </summary>
-            public Statistics()
+            object minimum;
+            object maximum;
+            object average;
+
+            lock (data)
             {
-                MinimumValue = double.NaN;
-                MaximumValue = double.NaN;
-                AverageValue = double.NaN;
+                // Synchronize to ensure no new data is being added during the computation.
+                minimum = data.Tables[0].Compute("Min(Value)", filerClause);
+                maximum = data.Tables[0].Compute("Max(Value)", filerClause);
+                average = data.Tables[0].Compute("Avg(Value)", filerClause);
+
+                // Clear all the buffered data to make space for new data to be buffered.
+                data.Tables[0].Clear();
             }
 
-            /// <summary>
-            /// The smallest value in the time-series data.
-            /// </summary>
-            public double MinimumValue;
-
-            /// <summary>
-            /// The largest value in the time-series data.
-            /// </summary>
-            public double MaximumValue;
-
-            /// <summary>
-            /// The average value in the time-series data.
-            /// </summary>
-            public double AverageValue;
-
-            /// <summary>
-            /// Calculates <see cref="Statistics"/> from the provided <paramref name="data"/> and clear the <paramref name="data"/> when done.
-            /// </summary>
-            /// <param name="data">A <see cref="DataSet"/> containing buffered real-time time-series data.</param>
-            /// <param name="filerClause">Filter clause to be applied for limiting the data included in the calculation.</param>
-            public void Calculate(DataSet data, string filerClause)
-            {
-                object minimum;
-                object maximum;
-                object average;
-                lock (data)
-                {
-                    // Synchronize to ensure no new data is being added during the computation.
-                    minimum = data.Tables[0].Compute("Min(Value)", filerClause);
-                    maximum = data.Tables[0].Compute("Max(Value)", filerClause);
-                    average = data.Tables[0].Compute("Avg(Value)", filerClause);
-
-                    // Clear all of the buffered data to make space for new data to be buffered.
-                    data.Tables[0].Clear();
-                }
-
-                // Expose the calculated stastical values.
-                MinimumValue = Convert.ToDouble(minimum == DBNull.Value ? double.NaN : minimum);
-                MaximumValue = Convert.ToDouble(maximum == DBNull.Value ? double.NaN : maximum);
-                AverageValue = Convert.ToDouble(average == DBNull.Value ? double.NaN : average);
-            }
+            // Expose the calculated statistical values.
+            MinimumValue = Convert.ToDouble(minimum == DBNull.Value ? double.NaN : minimum);
+            MaximumValue = Convert.ToDouble(maximum == DBNull.Value ? double.NaN : maximum);
+            AverageValue = Convert.ToDouble(average == DBNull.Value ? double.NaN : average);
         }
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StatisticsExporter"/> class.
-        /// </summary>
-        public StatisticsExporter()
-            : this("StatisticsExporter")
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StatisticsExporter"/> class.
-        /// </summary>
-        /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
-        protected StatisticsExporter(string name)
-            : base(name)
-        {
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <exception cref="ArgumentException"><b>OutputFile</b> or <b>OutputFormat</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
-        protected override void ProcessExport(Export export)
-        {
-            // Ensure that required settings are present.
-            ExportSetting outputFileSetting = export.FindSetting("OutputFile");
-            if (outputFileSetting == null)
-                throw new ArgumentException("OutputFile setting is missing");
-            ExportSetting outputFormatSetting = export.FindSetting("OutputFormat");
-            if (outputFormatSetting == null)
-                throw new ArgumentException("OutputFormat setting is missing");
-
-            // Get the calculated statistics.
-            Statistics stats = GetStatistics(export);
-
-            // Get the dataset template we'll be outputting.
-            DataSet output = DatasetTemplate("Statistics");
-
-            // Modify the dataset template for statistical values.
-            DataTable data = output.Tables[0];
-            data.PrimaryKey = null;
-            data.Columns.Clear();
-            data.Columns.Add("MinimumValue", typeof(double));
-            data.Columns.Add("MaximumValue", typeof(double));
-            data.Columns.Add("AverageValue", typeof(double));
-
-            foreach (DataColumn column in data.Columns)
-            {
-                column.ColumnMapping = MappingType.Attribute;
-            }
-
-            // Add the calculated statistical value.
-            data.Rows.Add(stats.MinimumValue, stats.MaximumValue, stats.AverageValue);
-
-            // Update the export timestamp, row count and interval.
-            output.Tables[1].Rows.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), output.Tables[0].Rows.Count, string.Format("{0} seconds", export.Interval));
-
-            // Write the statistical data for the export to the specified files in specified format.
-            FileHelper.WriteToFile(outputFileSetting.Value, outputFormatSetting.Value, output);
-        }
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-        /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
-        /// <exception cref="NotSupportedException">Always</exception>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
-        {
-            throw new NotSupportedException();  // Real-Time exports not supported.
-        }
-
-        /// <summary>
-        /// Returns the calculated <see cref="Statistics"/> from buffered data of the specified <paramref name="export"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> for which statistical values are to be calculated.</param>
-        /// <returns>The calculated <see cref="Statistics"/> from buffered data of the specified <paramref name="export"/>.</returns>
-        protected virtual Statistics GetStatistics(Export export)
-        {
-            Statistics stats = new Statistics();
-            DataSet rawData = GetBufferedData(export.Name);
-            ExportSetting filterClauseSetting = export.FindSetting("FilterClause");
-            ExportSetting slopeThresholdSetting = export.FindSetting("SlopeThreshold");
-            if (rawData != null)
-            {
-                // Buffered data is available for the export, so calculate the statistics.
-                if (slopeThresholdSetting != null)
-                {
-                    // Slope-based data elimination is to be employed.
-                    double slopeThreshold = Convert.ToDouble(slopeThresholdSetting.Value);
-                    lock (rawData)
-                    {
-                        foreach (ExportRecord record in export.Records)
-                        {
-                            // Run data for each record against the slope-based data elimination algorithm.
-                            double slope = 0;
-                            bool delete = false;
-                            DataRow[] records = rawData.Tables[0].Select(string.Format("Instance=\'{0}\' And ID={1}", record.Instance, record.Identifier), "TimeTag");
-                            if (records.Length > 0)
-                            {
-                                for (int i = 0; i < records.Length - 1; i++)
-                                {
-                                    // Calculate slope for the data using standard slope formula.
-                                    slope = Math.Abs((((float)records[i]["Value"]) - (float)records[i + 1]["Value"]) / (Ticks.ToSeconds((Convert.ToDateTime(records[i]["TimeTag"])).Ticks) - Ticks.ToSeconds((Convert.ToDateTime(records[i + 1]["TimeTag"])).Ticks)));
-                                    if (slope > slopeThreshold)
-                                    {
-                                        // Data for the point has slope that exceeds the specified slope threshold.
-                                        delete = true;
-                                        break;
-                                    }
-                                }
-
-                                if (delete)
-                                {
-                                    // Data for the record is to be excluded from the calculation.
-                                    for (int i = 0; i < records.Length; i++)
-                                    {
-                                        records[i].Delete();
-                                    }
-                                    OnStatusUpdate(string.Format("{0}:{1} data eliminated (Slope={2}; Threshold={3})", record.Instance, record.Identifier, slope, slopeThreshold));
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (filterClauseSetting == null)
-                {
-                    // No filter clause setting exist for the export.
-                    stats.Calculate(rawData, string.Empty);
-                }
-                else
-                {
-                    // Filter clause setting exists for the export so use it.
-                    stats.Calculate(rawData, filterClauseSetting.Value);
-                }
-            }
-
-            return stats;
-        }
-
-        #endregion
     }
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StatisticsExporter"/> class.
+    /// </summary>
+    public StatisticsExporter()
+        : this(nameof(StatisticsExporter))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StatisticsExporter"/> class.
+    /// </summary>
+    /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
+    protected StatisticsExporter(string name)
+        : base(name)
+    {
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <exception cref="ArgumentException"><b>OutputFile</b> or <b>OutputFormat</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
+    protected override void ProcessExport(Export export)
+    {
+        // Ensure that required settings are present.
+        ExportSetting outputFileSetting = export.FindSetting("OutputFile");
+        
+        if (outputFileSetting is null)
+            throw new ArgumentException("OutputFile setting is missing");
+        ExportSetting outputFormatSetting = export.FindSetting("OutputFormat");
+        
+        if (outputFormatSetting is null)
+            throw new ArgumentException("OutputFormat setting is missing");
+
+        // Get the calculated statistics.
+        Statistics stats = GetStatistics(export);
+
+        // Get the dataset template we'll be outputting.
+        DataSet output = DatasetTemplate(nameof(Statistics));
+
+        // Modify the dataset template for statistical values.
+        DataTable data = output.Tables[0];
+        data.PrimaryKey = null!;
+        data.Columns.Clear();
+        data.Columns.Add("MinimumValue", typeof(double));
+        data.Columns.Add("MaximumValue", typeof(double));
+        data.Columns.Add("AverageValue", typeof(double));
+
+        foreach (DataColumn column in data.Columns)
+            column.ColumnMapping = MappingType.Attribute;
+
+        // Add the calculated statistical value.
+        data.Rows.Add(stats.MinimumValue, stats.MaximumValue, stats.AverageValue);
+
+        // Update the export timestamp, row count and interval.
+        output.Tables[1].Rows.Add(DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt"), output.Tables[0].Rows.Count, $"{export.Interval} seconds");
+
+        // Write the statistical data for the export to the specified files in specified format.
+        FileHelper.WriteToFile(outputFileSetting.Value, outputFormatSetting.Value, output);
+    }
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+    /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
+    /// <exception cref="NotSupportedException">Always</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
+    {
+        throw new NotSupportedException();  // Real-Time exports not supported.
+    }
+
+    /// <summary>
+    /// Returns the calculated <see cref="Statistics"/> from buffered data of the specified <paramref name="export"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> for which statistical values are to be calculated.</param>
+    /// <returns>The calculated <see cref="Statistics"/> from buffered data of the specified <paramref name="export"/>.</returns>
+    protected virtual Statistics GetStatistics(Export export)
+    {
+        Statistics stats = new();
+        DataSet rawData = GetBufferedData(export.Name);
+        ExportSetting filterClauseSetting = export.FindSetting("FilterClause");
+        ExportSetting slopeThresholdSetting = export.FindSetting("SlopeThreshold");
+
+        if (rawData is null)
+            return stats;
+        
+        // Buffered data is available for the export, so calculate the statistics.
+        if (slopeThresholdSetting is not null)
+        {
+            // Slope-based data elimination is to be employed.
+            double slopeThreshold = Convert.ToDouble(slopeThresholdSetting.Value);
+        
+            lock (rawData)
+            {
+                foreach (ExportRecord record in export.Records)
+                {
+                    // Run data for each record against the slope-based data elimination algorithm.
+                    double slope = 0;
+                    bool delete = false;
+                    DataRow[] records = rawData.Tables[0].Select($"Instance=\'{record.Instance}\' And ID={record.Identifier}", nameof(TimeTag));
+
+                    if (records.Length <= 0)
+                        continue;
+                    
+                    for (int i = 0; i < records.Length - 1; i++)
+                    {
+                        // Calculate slope for the data using standard slope formula.
+                        slope = Math.Abs(((float)records[i]["Value"] - (float)records[i + 1]["Value"]) / (Ticks.ToSeconds(Convert.ToDateTime(records[i][nameof(TimeTag)]).Ticks) - Ticks.ToSeconds(Convert.ToDateTime(records[i + 1][nameof(TimeTag)]).Ticks)));
+                        
+                        if (!(slope > slopeThreshold))
+                            continue;
+                        
+                        // Data for the point has slope that exceeds the specified slope threshold.
+                        delete = true;
+                        break;
+                    }
+
+                    if (!delete)
+                        continue;
+                    
+                    // Data for the record is to be excluded from the calculation.
+                    for (int i = 0; i < records.Length; i++)
+                        records[i].Delete();
+                    
+                    OnStatusUpdate($"{record.Instance}:{record.Identifier} data eliminated (Slope={slope}; Threshold={slopeThreshold})");
+                }
+            }
+        }
+
+        stats.Calculate(rawData, filterClauseSetting is null ? string.Empty : filterClauseSetting.Value);
+
+        return stats;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Exporters/XmlExporter.cs
+++ b/Source/Libraries/GSF.Historian/Exporters/XmlExporter.cs
@@ -33,109 +33,109 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace GSF.Historian.Exporters
+namespace GSF.Historian.Exporters;
+
+/// <summary>
+/// Represents an exporter that can export the current time-series data in XML format to a file.
+/// </summary>
+/// <example>
+/// Definition of a sample <see cref="Export"/> that can be processed by <see cref="XmlExporter"/>:
+/// <code>
+/// <![CDATA[
+/// <?xml version="1.0" encoding="utf-16"?>
+/// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+///   <Name>XmlExport</Name>
+///   <Type>Intervaled</Type>
+///   <Interval>60</Interval>
+///   <Exporter>XmlExporter</Exporter>
+///   <Settings>
+///     <ExportSetting>
+///       <Name>OutputFile</Name>
+///       <Value>c:\XmlExportOutput.xml</Value>
+///     </ExportSetting>
+///   </Settings>
+///   <Records>
+///     <ExportRecord>
+///       <Instance>TP</Instance>
+///       <Identifier>25609</Identifier>
+///     </ExportRecord>
+///     <ExportRecord>
+///       <Instance>TP</Instance>
+///       <Identifier>41517</Identifier>
+///     </ExportRecord>    
+///   </Records>
+/// </Export>
+/// ]]>
+/// </code>
+/// <para>
+/// Description of custom settings required by <see cref="XmlExporter"/> in an <see cref="Export"/>:
+/// <list type="table">
+///     <listheader>
+///         <term>Setting Name</term>
+///         <description>Setting Description</description>
+///     </listheader>
+///     <item>
+///         <term>OutputFile</term>
+///         <description>Name of the XML file (including path) where export data is to be written.</description>
+///     </item>
+/// </list>
+/// </para>
+/// </example>
+/// <seealso cref="Export"/>
+public class XmlExporter : ExporterBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents an exporter that can export the current time-series data in XML format to a file.
+    /// Initializes a new instance of the <see cref="XmlExporter"/> class.
     /// </summary>
-    /// <example>
-    /// Definition of a sample <see cref="Export"/> that can be processed by <see cref="XmlExporter"/>:
-    /// <code>
-    /// <![CDATA[
-    /// <?xml version="1.0" encoding="utf-16"?>
-    /// <Export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    ///   <Name>XmlExport</Name>
-    ///   <Type>Intervaled</Type>
-    ///   <Interval>60</Interval>
-    ///   <Exporter>XmlExporter</Exporter>
-    ///   <Settings>
-    ///     <ExportSetting>
-    ///       <Name>OutputFile</Name>
-    ///       <Value>c:\XmlExportOutput.xml</Value>
-    ///     </ExportSetting>
-    ///   </Settings>
-    ///   <Records>
-    ///     <ExportRecord>
-    ///       <Instance>TP</Instance>
-    ///       <Identifier>25609</Identifier>
-    ///     </ExportRecord>
-    ///     <ExportRecord>
-    ///       <Instance>TP</Instance>
-    ///       <Identifier>41517</Identifier>
-    ///     </ExportRecord>    
-    ///   </Records>
-    /// </Export>
-    /// ]]>
-    /// </code>
-    /// <para>
-    /// Description of custom settings required by <see cref="XmlExporter"/> in an <see cref="Export"/>:
-    /// <list type="table">
-    ///     <listheader>
-    ///         <term>Setting Name</term>
-    ///         <description>Setting Description</description>
-    ///     </listheader>
-    ///     <item>
-    ///         <term>OutputFile</term>
-    ///         <description>Name of the XML file (including path) where export data is to be written.</description>
-    ///     </item>
-    /// </list>
-    /// </para>
-    /// </example>
-    /// <seealso cref="Export"/>
-    public class XmlExporter : ExporterBase
+    public XmlExporter()
+        : this(nameof(XmlExporter))
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="XmlExporter"/> class.
-        /// </summary>
-        public XmlExporter()
-            : this("XmlExporter")
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="XmlExporter"/> class.
-        /// </summary>
-        /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
-        protected XmlExporter(string name)
-            : base(name)
-        {
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <exception cref="ArgumentException"><b>OutputFile</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
-        protected override void ProcessExport(Export export)
-        {
-            // Ensure that required settings are present.
-            ExportSetting outputFileSetting = export.FindSetting("OutputFile");
-            if (outputFileSetting == null)
-                throw new ArgumentException("OutputFile setting is missing");
-            
-            // Write the current data for the export to the specified files in XML format.
-            FileHelper.WriteToFile(outputFileSetting.Value, "XML", GetExportDataAsDataset(export, null));
-        }
-
-        /// <summary>
-        /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
-        /// </summary>
-        /// <param name="export"><see cref="Export"/> to be processed.</param>
-        /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
-        /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
-        /// <exception cref="NotSupportedException">Always</exception>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
-        {
-            throw new NotSupportedException();  // Real-Time exports not supported.
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XmlExporter"/> class.
+    /// </summary>
+    /// <param name="name"><see cref="ExporterBase.Name"/> of the exporter.</param>
+    protected XmlExporter(string name)
+        : base(name)
+    {
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the current <see cref="DataListener.Data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <exception cref="ArgumentException"><b>OutputFile</b> setting is missing from the <see cref="Export.Settings"/> of the <paramref name="export"/>.</exception>
+    protected override void ProcessExport(Export export)
+    {
+        // Ensure that required settings are present.
+        ExportSetting outputFileSetting = export.FindSetting("OutputFile");
+
+        if (outputFileSetting is null)
+            throw new ArgumentException("OutputFile setting is missing");
+            
+        // Write the current data for the export to the specified files in XML format.
+        FileHelper.WriteToFile(outputFileSetting.Value, "XML", GetExportDataAsDataset(export, null));
+    }
+
+    /// <summary>
+    /// Processes the <paramref name="export"/> using the real-time <paramref name="data"/>.
+    /// </summary>
+    /// <param name="export"><see cref="Export"/> to be processed.</param>
+    /// <param name="listener"><see cref="DataListener"/> that provided the <paramref name="data"/>.</param>
+    /// <param name="data">Real-time time-series data received by the <paramref name="listener"/>.</param>
+    /// <exception cref="NotSupportedException">Always</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected override void ProcessRealTimeExport(Export export, DataListener listener, IList<IDataPoint> data)
+    {
+        throw new NotSupportedException();  // Real-Time exports not supported.
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveDataBlock.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveDataBlock.cs
@@ -52,278 +52,276 @@ using System.ComponentModel;
 using System.IO;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+// ReSharper disable MustUseReturnValue
+
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a block of <see cref="ArchiveDataPoint"/>s in an <see cref="ArchiveFile"/>.
+/// </summary>
+/// <seealso cref="ArchiveFile"/>
+/// <seealso cref="ArchiveDataPoint"/>
+public class ArchiveDataBlock
 {
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a block of <see cref="ArchiveDataPoint"/>s in an <see cref="ArchiveFile"/>.
+    /// Time in seconds after which the block is considered inactive if no reads or writes were performed.
     /// </summary>
-    /// <seealso cref="ArchiveFile"/>
-    /// <seealso cref="ArchiveDataPoint"/>
-    public class ArchiveDataBlock
+    private const int InactivityPeriod = 300;
+
+    // Fields
+    private readonly int m_historianID;
+    private readonly ArchiveFile m_parent;
+    private readonly byte[] m_readBuffer;
+    private long m_writeCursor;
+    private DateTime m_lastActivityTime;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered while reading <see cref="IDataPoint"/> from the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when an Exception is encountered while reading an IDataPoint from the ArchiveDataBlock.")]
+    public event EventHandler<EventArgs<Exception>> DataReadException;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered while writing <see cref="IDataPoint"/> to the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when an Exception is encountered while writing an IDataPoint to the ArchiveDataBlock.")]
+    public event EventHandler<EventArgs<Exception>> DataWriteException;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataBlock"/> class. 
+    /// </summary>
+    /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
+    /// <param name="index">0-based index of the <see cref="ArchiveDataBlock"/>.</param>
+    /// <param name="historianID">Historian identifier whose <see cref="ArchiveDataPoint"/> is stored in the <see cref="ArchiveDataBlock"/>.</param>
+    /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    internal ArchiveDataBlock(ArchiveFile parent, int index, int historianID, bool preRead = true)
     {
-        #region [ Members ]
+        m_parent = parent;
+        Index = index;
+        m_historianID = historianID;
+        m_readBuffer = new byte[ArchiveDataPoint.FixedLength];
+        m_writeCursor = Location;
+        m_lastActivityTime = DateTime.UtcNow;
 
-        // Constants
+        if (!preRead)
+            return;
 
-        /// <summary>
-        /// Time in seconds after which the block is considered inactive if no reads or writes were performed.
-        /// </summary>
-        private const int InactivityPeriod = 300;
-
-        // Fields
-        private readonly int m_index;
-        private readonly int m_historianID;
-        private readonly ArchiveFile m_parent;
-        private readonly byte[] m_readBuffer;
-        private long m_writeCursor;
-        private DateTime m_lastActivityTime;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered while reading <see cref="IDataPoint"/> from the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when an Exception is encountered while reading an IDataPoint from the ArchiveDataBlock.")]
-        public event EventHandler<EventArgs<Exception>> DataReadException;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered while writing <see cref="IDataPoint"/> to the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when an Exception is encountered while writing an IDataPoint to the ArchiveDataBlock.")]
-        public event EventHandler<EventArgs<Exception>> DataWriteException;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataBlock"/> class. 
-        /// </summary>
-        /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
-        /// <param name="index">0-based index of the <see cref="ArchiveDataBlock"/>.</param>
-        /// <param name="historianID">Historian identifier whose <see cref="ArchiveDataPoint"/> is stored in the <see cref="ArchiveDataBlock"/>.</param>
-        /// <param name="preRead">true to pre-read data to locate write cursor.</param>
-        internal ArchiveDataBlock(ArchiveFile parent, int index, int historianID, bool preRead = true)
+        // Scan through existing data to locate write cursor
+        // ReSharper disable once UnusedVariable
+        foreach (IDataPoint dataPoint in Read())
         {
-            m_parent = parent;
-            m_index = index;
-            m_historianID = historianID;
-            m_readBuffer = new byte[ArchiveDataPoint.FixedLength];
-            m_writeCursor = Location;
-            m_lastActivityTime = DateTime.UtcNow;
-
-            if (!preRead)
-                return;
-
-            // Scan through existing data to locate write cursor
-            // ReSharper disable once UnusedVariable
-            foreach (IDataPoint dataPoint in Read())
-            {
-            }
         }
+    }
 
-        #endregion
+    #endregion
 
-        #region [ Properties ]
+    #region [ Properties ]
 
-        /// <summary>
-        /// Gets the 0-based index of the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        public int Index => m_index;
+    /// <summary>
+    /// Gets the 0-based index of the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    public int Index { get; }
 
-        /// <summary>
-        /// Gets the start location (byte position) of the <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        public long Location => m_index * m_parent.DataBlockSize * 1024;
+    /// <summary>
+    /// Gets the start location (byte position) of the <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    public long Location => Index * m_parent.DataBlockSize * 1024;
 
-        /// <summary>
-        /// Gets the maximum number of <see cref="ArchiveDataPoint"/>s that can be stored in the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        public int Capacity => m_parent.DataBlockSize * 1024 / ArchiveDataPoint.FixedLength;
+    /// <summary>
+    /// Gets the maximum number of <see cref="ArchiveDataPoint"/>s that can be stored in the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    public int Capacity => m_parent.DataBlockSize * 1024 / ArchiveDataPoint.FixedLength;
 
-        /// <summary>
-        /// Gets the number of <see cref="ArchiveDataPoint"/>s that have been written to the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        public int SlotsUsed => (int)((m_writeCursor - Location) / ArchiveDataPoint.FixedLength);
+    /// <summary>
+    /// Gets the number of <see cref="ArchiveDataPoint"/>s that have been written to the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    public int SlotsUsed => (int)((m_writeCursor - Location) / ArchiveDataPoint.FixedLength);
 
-        /// <summary>
-        /// Gets the number of <see cref="ArchiveDataPoint"/>s that can to written to the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        public int SlotsAvailable => Capacity - SlotsUsed;
+    /// <summary>
+    /// Gets the number of <see cref="ArchiveDataPoint"/>s that can to written to the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    public int SlotsAvailable => Capacity - SlotsUsed;
 
-        /// <summary>
-        /// Gets a boolean value that indicates whether the <see cref="ArchiveDataBlock"/> is being actively used.
-        /// </summary>
-        public bool IsActive => DateTime.UtcNow.Subtract(m_lastActivityTime).TotalSeconds <= InactivityPeriod;
+    /// <summary>
+    /// Gets a boolean value that indicates whether the <see cref="ArchiveDataBlock"/> is being actively used.
+    /// </summary>
+    public bool IsActive => DateTime.UtcNow.Subtract(m_lastActivityTime).TotalSeconds <= InactivityPeriod;
 
-        #endregion
+    #endregion
 
-        #region [ Methods ]
+    #region [ Methods ]
 
-        /// <summary>
-        /// Reads existing <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        /// <returns>Returns <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveDataBlock"/>.</returns>
-        public IEnumerable<IDataPoint> Read()
+    /// <summary>
+    /// Reads existing <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    /// <returns>Returns <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveDataBlock"/>.</returns>
+    public IEnumerable<IDataPoint> Read()
+    {
+        lock (m_parent.FileData)
         {
-            ArchiveDataPoint dataPoint;
+            // We'll start reading from where the data block begins.
+            m_parent.FileData.Seek(Location, SeekOrigin.Begin);
 
-            lock (m_parent.FileData)
+            for (int i = 0; i < Capacity; i++)
             {
-                // We'll start reading from where the data block begins.
-                m_parent.FileData.Seek(Location, SeekOrigin.Begin);
+                // Read the data in the block.
+                m_lastActivityTime = DateTime.UtcNow;
+                m_parent.FileData.Read(m_readBuffer, 0, m_readBuffer.Length);
 
-                for (int i = 0; i < Capacity; i++)
+                // Attempt to parse archive data point
+                ArchiveDataPoint dataPoint;
+
+                try
                 {
-                    // Read the data in the block.
-                    m_lastActivityTime = DateTime.UtcNow;
-                    m_parent.FileData.Read(m_readBuffer, 0, m_readBuffer.Length);
-
-                    // Attempt to parse archive data point
-                    try
-                    {
-                        dataPoint = new ArchiveDataPoint(m_historianID, m_readBuffer, 0, m_readBuffer.Length);
-                    }
-                    catch (Exception ex)
-                    {
-                        dataPoint = null;
-                        OnDataReadException(ex);
-                    }
-
-                    if (dataPoint != null && !dataPoint.IsEmpty)
-                    {
-                        // There is data - use it.
-                        m_writeCursor = m_parent.FileData.Position;
-                        yield return dataPoint;
-                    }
-                    else
-                    {
-                        // Data is empty - stop reading.
-                        yield break;
-                    }
+                    dataPoint = new ArchiveDataPoint(m_historianID, m_readBuffer, 0, m_readBuffer.Length);
                 }
-            }
-        }
-
-        /// <summary>
-        /// Writes the <paramref name="dataPoint"/> to the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to write.</param>
-        /// <param name="suppressExceptions">Set to <c>true</c> to suppress write exceptions; defaults to <c>false</c>.</param>
-        /// <returns>
-        /// <c>true</c> if data point was written; otherwise, <c>false</c>.
-        /// </returns>
-        /// <remarks>
-        /// If <paramref name="suppressExceptions"/> is <c>false</c>, the default value, any encountered
-        /// exception will be thrown on the call stack.
-        /// </remarks>
-        public bool Write(IDataPoint dataPoint, bool suppressExceptions = false)
-        {
-            Exception ex;
-
-            if (Write(dataPoint, out ex))
-                return true;
-
-            if (suppressExceptions)
-                return false;
-
-            throw ex;
-        }
-
-        /// <summary>
-        /// Writes the <paramref name="dataPoint"/> to the <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to write.</param>
-        /// <param name="exception">Any <see cref="Exception"/> that may have been encountered while writing.</param>
-        /// <returns>
-        /// <c>true</c> if data point was written; otherwise, <c>false</c>.
-        /// </returns>
-        public bool Write(IDataPoint dataPoint, out Exception exception)
-        {
-            exception = null;
-
-            try
-            {
-                TimeTag value = dataPoint.Time;
-
-                // Do not attempt to write values with a bad timestamp, this will just throw an exception
-                if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
+                catch (Exception ex)
                 {
-                    exception = new TimeTagException("Skipping data write for point: Bad time tag, value must between 01/01/1995 and 01/19/2063");
+                    dataPoint = null;
+                    OnDataReadException(ex);
+                }
+
+                if (dataPoint is { IsEmpty: false })
+                {
+                    // There is data - use it.
+                    m_writeCursor = m_parent.FileData.Position;
+                    yield return dataPoint;
                 }
                 else
                 {
-                    if (SlotsAvailable > 0)
-                    {
-                        // We have enough space to write the provided point data to the data block.
-                        m_lastActivityTime = DateTime.UtcNow;
-
-                        lock (m_parent.FileData)
-                        {
-                            // Write the data.
-                            if (m_writeCursor != m_parent.FileData.Position)
-                                m_parent.FileData.Seek(m_writeCursor, SeekOrigin.Begin);
-
-                            dataPoint.CopyBinaryImageToStream(m_parent.FileData);
-
-                            // Update the write cursor.
-                            m_writeCursor = m_parent.FileData.Position;
-
-                            // Flush the data if configured.
-                            if (!m_parent.CacheWrites)
-                                m_parent.FileData.Flush();
-                        }
-                    }
-                    else
-                    {
-                        exception = new InvalidOperationException("Skipping data write for point: No slots available for writing new data");
-                    }
+                    // Data is empty - stop reading.
+                    yield break;
                 }
             }
-            catch (Exception ex)
-            {
-                exception = new InvalidOperationException($"Skipping data write for point: {ex.Message}", ex);
-            }
-
-            if ((object)exception == null)
-                return true;
-
-            OnDataWriteException(exception);
-
-            return false;
         }
-
-        /// <summary>
-        /// Resets the <see cref="ArchiveDataBlock"/> by overwriting existing <see cref="ArchiveDataPoint"/>s with empty <see cref="ArchiveDataPoint"/>s.
-        /// </summary>
-        public void Reset()
-        {
-            m_writeCursor = Location;
-
-            for (int i = 1; i <= Capacity; i++)
-                Write(new ArchiveDataPoint(m_historianID), true);
-
-            m_writeCursor = Location;
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataReadException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataReadException"/> event.</param>
-        protected virtual void OnDataReadException(Exception ex)
-        {
-            DataReadException?.Invoke(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataWriteException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataWriteException"/> event.</param>
-        protected virtual void OnDataWriteException(Exception ex)
-        {
-            DataWriteException?.Invoke(this, new EventArgs<Exception>(ex));
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Writes the <paramref name="dataPoint"/> to the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to write.</param>
+    /// <param name="suppressExceptions">Set to <c>true</c> to suppress write exceptions; defaults to <c>false</c>.</param>
+    /// <returns>
+    /// <c>true</c> if data point was written; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// If <paramref name="suppressExceptions"/> is <c>false</c>, the default value, any encountered
+    /// exception will be thrown on the call stack.
+    /// </remarks>
+    public bool Write(IDataPoint dataPoint, bool suppressExceptions = false)
+    {
+        if (Write(dataPoint, out Exception ex))
+            return true;
+
+        if (suppressExceptions)
+            return false;
+
+        throw ex;
+    }
+
+    /// <summary>
+    /// Writes the <paramref name="dataPoint"/> to the <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to write.</param>
+    /// <param name="exception">Any <see cref="Exception"/> that may have been encountered while writing.</param>
+    /// <returns>
+    /// <c>true</c> if data point was written; otherwise, <c>false</c>.
+    /// </returns>
+    public bool Write(IDataPoint dataPoint, out Exception exception)
+    {
+        exception = null;
+
+        try
+        {
+            TimeTag value = dataPoint.Time;
+
+            // Do not attempt to write values with a bad timestamp, this will just throw an exception
+            if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
+            {
+                exception = new TimeTagException("Skipping data write for point: Bad time tag, value must between 01/01/1995 and 01/19/2063");
+            }
+            else
+            {
+                if (SlotsAvailable > 0)
+                {
+                    // We have enough space to write the provided point data to the data block.
+                    m_lastActivityTime = DateTime.UtcNow;
+
+                    lock (m_parent.FileData)
+                    {
+                        // Write the data.
+                        if (m_writeCursor != m_parent.FileData.Position)
+                            m_parent.FileData.Seek(m_writeCursor, SeekOrigin.Begin);
+
+                        dataPoint.CopyBinaryImageToStream(m_parent.FileData);
+
+                        // Update the write cursor.
+                        m_writeCursor = m_parent.FileData.Position;
+
+                        // Flush the data if configured.
+                        if (!m_parent.CacheWrites)
+                            m_parent.FileData.Flush();
+                    }
+                }
+                else
+                {
+                    exception = new InvalidOperationException("Skipping data write for point: No slots available for writing new data");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            exception = new InvalidOperationException($"Skipping data write for point: {ex.Message}", ex);
+        }
+
+        if (exception is null)
+            return true;
+
+        OnDataWriteException(exception);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resets the <see cref="ArchiveDataBlock"/> by overwriting existing <see cref="ArchiveDataPoint"/>s with empty <see cref="ArchiveDataPoint"/>s.
+    /// </summary>
+    public void Reset()
+    {
+        m_writeCursor = Location;
+
+        for (int i = 1; i <= Capacity; i++)
+            Write(new ArchiveDataPoint(m_historianID), true);
+
+        m_writeCursor = Location;
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataReadException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataReadException"/> event.</param>
+    protected virtual void OnDataReadException(Exception ex)
+    {
+        DataReadException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataWriteException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataWriteException"/> event.</param>
+    protected virtual void OnDataWriteException(Exception ex)
+    {
+        DataWriteException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveDataBlock.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveDataBlock.cs
@@ -104,6 +104,7 @@ public class ArchiveDataBlock
     /// <param name="index">0-based index of the <see cref="ArchiveDataBlock"/>.</param>
     /// <param name="historianID">Historian identifier whose <see cref="ArchiveDataPoint"/> is stored in the <see cref="ArchiveDataBlock"/>.</param>
     /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    /// <param name="reverseQuery">true to search backwards from the end of the file.</param>
     internal ArchiveDataBlock(ArchiveFile parent, int index, int historianID, bool preRead = true)
     {
         m_parent = parent;
@@ -193,7 +194,7 @@ public class ArchiveDataBlock
 
                 if (dataPoint is { IsEmpty: false })
                 {
-                    // There is data - use it.
+                    // There is data, return it.
                     m_writeCursor = m_parent.FileData.Position;
                     yield return dataPoint;
                 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveDataBlockPointer.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveDataBlockPointer.cs
@@ -36,294 +36,257 @@
 using System;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a pointer to an <see cref="ArchiveDataBlock"/>.
+/// </summary>
+/// <seealso cref="ArchiveFile"/>
+/// <seealso cref="ArchiveDataBlock"/>
+public class ArchiveDataBlockPointer : IComparable, ISupportBinaryImage
 {
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a pointer to an <see cref="ArchiveDataBlock"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="ArchiveDataBlockPointer"/>.
     /// </summary>
-    /// <seealso cref="ArchiveFile"/>
-    /// <seealso cref="ArchiveDataBlock"/>
-    public class ArchiveDataBlockPointer : IComparable, ISupportBinaryImage
+    public const int FixedLength = 12;
+
+    // Fields
+    private int m_historianID;
+    private TimeTag m_startTime;
+    private readonly ArchiveFile m_parent;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataBlockPointer"/> class.
+    /// </summary>
+    /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
+    /// <param name="index">0-based index of the <see cref="ArchiveDataBlockPointer"/>.</param>
+    internal ArchiveDataBlockPointer(ArchiveFile parent, int index)
     {
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="ArchiveDataBlockPointer"/>.
-        /// </summary>
-        public const int FixedLength = 12;
-
-        // Fields
-        private readonly int m_index;
-        private int m_historianID;
-        private TimeTag m_startTime;
-        private readonly ArchiveFile m_parent;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataBlockPointer"/> class.
-        /// </summary>
-        /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
-        /// <param name="index">0-based index of the <see cref="ArchiveDataBlockPointer"/>.</param>
-        internal ArchiveDataBlockPointer(ArchiveFile parent, int index)
-        {
-            m_parent = parent;
-            m_index = index;
-            Reset();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataBlockPointer"/> class.
-        /// </summary>
-        /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
-        /// <param name="index">0-based index of the <see cref="ArchiveDataBlockPointer"/>.</param>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataBlockPointer"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        internal ArchiveDataBlockPointer(ArchiveFile parent, int index, byte[] buffer, int startIndex, int length)
-            : this(parent, index)
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the historian identifier of <see cref="ArchiveDataBlockPointer"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
-        public int HistorianID
-        {
-            get
-            {
-                return m_historianID;
-            }
-            set
-            {
-                if (value < 1 && value != -1)
-                    throw new ArgumentException("Value must be positive or -1");
-
-                m_historianID = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="TimeTag"/> of first <see cref="ArchiveDataPoint"/> in the <see cref="DataBlock"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
-        public TimeTag StartTime
-        {
-            get
-            {
-                return m_startTime;
-            }
-            set
-            {
-                if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
-                    throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
-
-                m_startTime = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 0-based index of the <see cref="ArchiveDataBlockPointer"/>.
-        /// </summary>
-        public int Index
-        {
-            get
-            {
-                return m_index;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArchiveDataBlock"/> corresponding to the <see cref="ArchiveDataBlockPointer"/>.
-        /// </summary>
-        public ArchiveDataBlock DataBlock
-        {
-            get
-            {
-                return GetDataBlock(true);
-            }
-        }
-
-        /// <summary>
-        /// Gets a boolean value that indicates whether the <see cref="DataBlock"/> has been allocated to contain <see cref="ArchiveDataPoint"/>s.
-        /// </summary>
-        public bool IsAllocated
-        {
-            get
-            {
-                return m_historianID != -1 && m_startTime.CompareTo(TimeTag.MinValue) != 0;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="ArchiveDataBlockPointer"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Gets the <see cref="ArchiveDataBlock"/> associated with this <see cref="ArchiveDataBlockPointer"/>.
-        /// </summary>
-        /// <param name="preRead">true to pre-read data to locate write cursor.</param>
-        /// <returns>The <see cref="ArchiveDataBlock"/> associated with this <see cref="ArchiveDataBlockPointer"/>.</returns>
-        public ArchiveDataBlock GetDataBlock(bool preRead)
-        {
-            return new ArchiveDataBlock(m_parent, m_index, m_historianID, preRead);
-        }
-
-        /// <summary>
-        /// Deallocates the <see cref="DataBlock"/> to store new <see cref="ArchiveDataPoint"/>s.
-        /// </summary>
-        public void Reset()
-        {
-            m_historianID = -1;
-            m_startTime = TimeTag.MinValue;
-        }
-
-        /// <summary>
-        /// Initializes <see cref="ArchiveDataBlockPointer"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataBlockPointer"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="ArchiveDataBlockPointer"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                HistorianID = LittleEndian.ToInt32(buffer, startIndex);
-                StartTime = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 4));
-
-                return FixedLength;
-            }
-
-            // Binary image does not have sufficient data.
-            return 0;
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="ArchiveDataBlockPointer"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes((double)m_startTime.Value), 0, buffer, startIndex + 4, 8);
-
-            return length;
-        }
-
-        /// <summary>
-        /// Compares the current <see cref="ArchiveDataBlockPointer"/> object to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="ArchiveDataBlockPointer"/> object is to be compared.</param>
-        /// <returns>
-        /// Negative value if the current <see cref="ArchiveDataBlockPointer"/> object is less than <paramref name="obj"/>, 
-        /// Zero if the current <see cref="ArchiveDataBlockPointer"/> object is equal to <paramref name="obj"/>, 
-        /// Positive value if the current <see cref="ArchiveDataBlockPointer"/> object is greater than <paramref name="obj"/>.
-        /// </returns>
-        public virtual int CompareTo(object obj)
-        {
-            ArchiveDataBlockPointer other = obj as ArchiveDataBlockPointer;
-
-            if ((object)other == null)
-                return 1;
-
-            int result = m_historianID.CompareTo(other.HistorianID);
-
-            if (result != 0)
-                return result;
-
-            return m_startTime.CompareTo(other.StartTime);
-        }
-
-        /// <summary>
-        /// Determines whether the current <see cref="ArchiveDataBlockPointer"/> object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="ArchiveDataBlockPointer"/> object is to be compared for equality.</param>
-        /// <returns>true if the current <see cref="ArchiveDataBlockPointer"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            return (CompareTo(obj) == 0);
-        }
-
-        /// <summary>
-        /// Returns the text representation of <see cref="ArchiveDataBlockPointer"/> object.
-        /// </summary>
-        /// <returns>A <see cref="string"/> value.</returns>
-        public override string ToString()
-        {
-            return string.Format("ID: {0}; Start time: {1}", m_historianID, m_startTime);
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current <see cref="ArchiveDataBlock"/> object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return m_historianID.GetHashCode();
-        }
-
-        #endregion
+        m_parent = parent;
+        Index = index;
+        Reset();
     }
 
     /// <summary>
-    /// Extension methods for the <see cref="ArchiveDataBlockPointer"/>.
+    /// Initializes a new instance of the <see cref="ArchiveDataBlockPointer"/> class.
     /// </summary>
-    public static class ArchiveDataBlockPointerExtensions
+    /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
+    /// <param name="index">0-based index of the <see cref="ArchiveDataBlockPointer"/>.</param>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataBlockPointer"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    internal ArchiveDataBlockPointer(ArchiveFile parent, int index, byte[] buffer, int startIndex, int length)
+        : this(parent, index)
     {
-        /// <summary>
-        /// Tests if the <paramref name="dataBlockPointer"/> matches the specified search criteria.
-        /// </summary>
-        /// <param name="dataBlockPointer"><see cref="ArchiveDataBlockPointer"/> to test.</param>
-        /// <param name="historianID">Desired historian ID.</param>
-        /// <param name="startTime">Desired start time.</param>
-        /// <param name="endTime">Desired end time.</param>
-        /// <returns><c>true</c> if the specified <paramref name="dataBlockPointer"/> is for <paramref name="historianID"/> and falls within the <paramref name="startTime"/> and <paramref name="endTime"/>; otherwise <c>false</c>.</returns>
-        public static bool Matches(this ArchiveDataBlockPointer dataBlockPointer, int historianID, TimeTag startTime, TimeTag endTime)
-        {
-            // Note: The StartTime value of the pointer is ignored if m_searchStartTime = TimeTag.MinValue and
-            //       m_searchEndTime = TimeTag.MaxValue. In this case only the PointID value is compared. This
-            //       comes in handy when the first or last pointer is to be found from the list of pointers for
-            //       a point ID in addition to all the pointers for a point ID.
-            if ((object)dataBlockPointer != null)
-                return dataBlockPointer.HistorianID == historianID &&
-                        (startTime.CompareTo(TimeTag.MinValue) == 0 || dataBlockPointer.StartTime.CompareTo(startTime) >= 0) &&
-                        (endTime.CompareTo(TimeTag.MaxValue) == 0 || dataBlockPointer.StartTime.CompareTo(endTime) <= 0);
+        ParseBinaryImage(buffer, startIndex, length);
+    }
 
-            return false;
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the historian identifier of <see cref="ArchiveDataBlockPointer"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
+    public int HistorianID
+    {
+        get => m_historianID;
+        set
+        {
+            if (value < 1 && value != -1)
+                throw new ArgumentException("Value must be positive or -1");
+
+            m_historianID = value;
         }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="TimeTag"/> of first <see cref="ArchiveDataPoint"/> in the <see cref="DataBlock"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
+    public TimeTag StartTime
+    {
+        get => m_startTime;
+        set
+        {
+            if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
+                throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
+
+            m_startTime = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the 0-based index of the <see cref="ArchiveDataBlockPointer"/>.
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    /// Gets the <see cref="ArchiveDataBlock"/> corresponding to the <see cref="ArchiveDataBlockPointer"/>.
+    /// </summary>
+    public ArchiveDataBlock DataBlock => GetDataBlock(true);
+
+    /// <summary>
+    /// Gets a boolean value that indicates whether the <see cref="DataBlock"/> has been allocated to contain <see cref="ArchiveDataPoint"/>s.
+    /// </summary>
+    public bool IsAllocated => m_historianID != -1 && m_startTime.CompareTo(TimeTag.MinValue) != 0;
+
+    /// <summary>
+    /// Gets the length of the <see cref="ArchiveDataBlockPointer"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Gets the <see cref="ArchiveDataBlock"/> associated with this <see cref="ArchiveDataBlockPointer"/>.
+    /// </summary>
+    /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    /// <returns>The <see cref="ArchiveDataBlock"/> associated with this <see cref="ArchiveDataBlockPointer"/>.</returns>
+    public ArchiveDataBlock GetDataBlock(bool preRead)
+    {
+        return new ArchiveDataBlock(m_parent, Index, m_historianID, preRead);
+    }
+
+    /// <summary>
+    /// Deallocates the <see cref="DataBlock"/> to store new <see cref="ArchiveDataPoint"/>s.
+    /// </summary>
+    public void Reset()
+    {
+        m_historianID = -1;
+        m_startTime = TimeTag.MinValue;
+    }
+
+    /// <summary>
+    /// Initializes <see cref="ArchiveDataBlockPointer"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataBlockPointer"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="ArchiveDataBlockPointer"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+
+        // Binary image has sufficient data.
+        HistorianID = LittleEndian.ToInt32(buffer, startIndex);
+        StartTime = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 4));
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="ArchiveDataBlockPointer"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes((double)m_startTime.Value), 0, buffer, startIndex + 4, 8);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Compares the current <see cref="ArchiveDataBlockPointer"/> object to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="ArchiveDataBlockPointer"/> object is to be compared.</param>
+    /// <returns>
+    /// Negative value if the current <see cref="ArchiveDataBlockPointer"/> object is less than <paramref name="obj"/>, 
+    /// Zero if the current <see cref="ArchiveDataBlockPointer"/> object is equal to <paramref name="obj"/>, 
+    /// Positive value if the current <see cref="ArchiveDataBlockPointer"/> object is greater than <paramref name="obj"/>.
+    /// </returns>
+    public virtual int CompareTo(object obj)
+    {
+        if (obj is not ArchiveDataBlockPointer other)
+            return 1;
+
+        int result = m_historianID.CompareTo(other.HistorianID);
+        return result == 0 ? m_startTime.CompareTo(other.StartTime) : result;
+    }
+
+    /// <summary>
+    /// Determines whether the current <see cref="ArchiveDataBlockPointer"/> object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="ArchiveDataBlockPointer"/> object is to be compared for equality.</param>
+    /// <returns>true if the current <see cref="ArchiveDataBlockPointer"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        return CompareTo(obj) == 0;
+    }
+
+    /// <summary>
+    /// Returns the text representation of <see cref="ArchiveDataBlockPointer"/> object.
+    /// </summary>
+    /// <returns>A <see cref="string"/> value.</returns>
+    public override string ToString()
+    {
+        return $"ID: {m_historianID}; Start time: {m_startTime}";
+    }
+
+    /// <summary>
+    /// Returns the hash code for the current <see cref="ArchiveDataBlock"/> object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        // ReSharper disable once NonReadonlyMemberInGetHashCode
+        return m_historianID.GetHashCode();
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Extension methods for the <see cref="ArchiveDataBlockPointer"/>.
+/// </summary>
+public static class ArchiveDataBlockPointerExtensions
+{
+    /// <summary>
+    /// Tests if the <paramref name="dataBlockPointer"/> matches the specified search criteria.
+    /// </summary>
+    /// <param name="dataBlockPointer"><see cref="ArchiveDataBlockPointer"/> to test.</param>
+    /// <param name="historianID">Desired historian ID.</param>
+    /// <param name="startTime">Desired start time.</param>
+    /// <param name="endTime">Desired end time.</param>
+    /// <returns><c>true</c> if the specified <paramref name="dataBlockPointer"/> is for <paramref name="historianID"/> and falls within the <paramref name="startTime"/> and <paramref name="endTime"/>; otherwise <c>false</c>.</returns>
+    public static bool Matches(this ArchiveDataBlockPointer dataBlockPointer, int historianID, TimeTag startTime, TimeTag endTime)
+    {
+        // Note: The StartTime value of the pointer is ignored if m_searchStartTime = TimeTag.MinValue and
+        //       m_searchEndTime = TimeTag.MaxValue. In this case only the PointID value is compared. This
+        //       comes in handy when the first or last pointer is to be found from the list of pointers for
+        //       a point ID in addition to all the pointers for a point ID.
+        if (dataBlockPointer is not null)
+        {
+            return dataBlockPointer.HistorianID == historianID &&
+                   (startTime.CompareTo(TimeTag.MinValue) == 0 || dataBlockPointer.StartTime.CompareTo(startTime) >= 0) &&
+                   (endTime.CompareTo(TimeTag.MaxValue) == 0 || dataBlockPointer.StartTime.CompareTo(endTime) <= 0);
+        }
+
+        return false;
     }
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveDataPoint.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveDataPoint.cs
@@ -45,450 +45,357 @@ using GSF.TimeSeries;
 
 // ReSharper disable VirtualMemberCallInConstructor
 // ReSharper disable NonReadonlyMemberInGetHashCode
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents time-series data stored in <see cref="ArchiveFile"/>.
+/// </summary>
+/// <seealso cref="ArchiveFile"/>
+/// <seealso cref="ArchiveFileAllocationTable"/>
+/// <seealso cref="ArchiveDataBlock"/>
+/// <seealso cref="ArchiveDataBlockPointer"/>
+public class ArchiveDataPoint : IDataPoint
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 4          0-3        Int32      Time                                                          *
+    // * 2          4-5        Int16      Flags (Quality & Milliseconds)                                *
+    // * 4          6-9        Single     Value                                                         *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents time-series data stored in <see cref="ArchiveFile"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="ArchiveDataPoint"/>.
     /// </summary>
-    /// <seealso cref="ArchiveFile"/>
-    /// <seealso cref="ArchiveFileAllocationTable"/>
-    /// <seealso cref="ArchiveDataBlock"/>
-    /// <seealso cref="ArchiveDataBlockPointer"/>
-    public class ArchiveDataPoint : IDataPoint
+    public const int FixedLength = 10;
+
+    /// <summary>
+    /// Specifies the bit-mask for <see cref="Quality"/> stored in <see cref="Flags"/>.
+    /// </summary>
+    protected const Bits QualityMask = Bits.Bit00 | Bits.Bit01 | Bits.Bit02 | Bits.Bit03 | Bits.Bit04;
+
+    /// <summary>
+    /// Specifies the bit-mask for <see cref="TimeTag"/> milliseconds stored in <see cref="Flags"/>.
+    /// </summary>
+    protected const Bits MillisecondMask = Bits.Bit05 | Bits.Bit06 | Bits.Bit07 | Bits.Bit08 | Bits.Bit09 | Bits.Bit10 | Bits.Bit11 | Bits.Bit12 | Bits.Bit13 | Bits.Bit14 | Bits.Bit15;
+
+    // Fields
+    private int m_historianID;
+    private TimeTag m_time;
+    private float m_value;
+    private int m_flags;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="ArchiveDataPoint"/>.</param>
+    public ArchiveDataPoint(int historianID)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 4          0-3        Int32      Time                                                          *
-        // * 2          4-5        Int16      Flags (Quality & Milliseconds)                                *
-        // * 4          6-9        Single     Value                                                         *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        public const int FixedLength = 10;
-
-        /// <summary>
-        /// Specifies the bit-mask for <see cref="Quality"/> stored in <see cref="Flags"/>.
-        /// </summary>
-        protected const Bits QualityMask = Bits.Bit00 | Bits.Bit01 | Bits.Bit02 | Bits.Bit03 | Bits.Bit04;
-
-        /// <summary>
-        /// Specifies the bit-mask for <see cref="TimeTag"/> milliseconds stored in <see cref="Flags"/>.
-        /// </summary>
-        protected const Bits MillisecondMask = Bits.Bit05 | Bits.Bit06 | Bits.Bit07 | Bits.Bit08 | Bits.Bit09 | Bits.Bit10 | Bits.Bit11 | Bits.Bit12 | Bits.Bit13 | Bits.Bit14 | Bits.Bit15;
-
-        // Fields
-        private int m_historianID;
-        private TimeTag m_time;
-        private float m_value;
-        private int m_flags;
-        private MetadataRecord m_metadata;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="ArchiveDataPoint"/>.</param>
-        public ArchiveDataPoint(int historianID)
-        {
-            m_time = TimeTag.MinValue;
-            this.HistorianID = historianID;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
-        /// </summary>
-        /// <param name="dataPoint">A time-series data point.</param>
-        public ArchiveDataPoint(IDataPoint dataPoint)
-            : this(dataPoint.HistorianID, dataPoint.Time, dataPoint.Value, dataPoint.Quality)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class from a <see cref="IMeasurement"/> value.
-        /// </summary>
-        /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
-        public ArchiveDataPoint(IMeasurement measurement)
-            : this(measurement, measurement.HistorianQuality())
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class from a <see cref="IMeasurement"/> value.
-        /// </summary>
-        /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
-        /// <param name="quality">Specific <see cref="Quality"/> value to apply to new <see cref="ArchiveDataPoint"/>.</param>
-        public ArchiveDataPoint(IMeasurement measurement, Quality quality)
-            : this((int)measurement.Key.ID)
-        {
-            this.Time = new TimeTag((DateTime)measurement.Timestamp);
-            this.Value = (float)measurement.AdjustedValue;
-            this.Quality = quality;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="ArchiveDataPoint"/>.</param>
-        /// <param name="time"><see cref="TimeTag"/> of <see cref="ArchiveDataPoint"/>.</param>
-        /// <param name="value">Floating-point value of <see cref="ArchiveDataPoint"/>.</param>
-        /// <param name="quality"><see cref="Quality"/> of <see cref="ArchiveDataPoint"/>.</param>
-        public ArchiveDataPoint(int historianID, TimeTag time, float value, Quality quality)
-            : this(historianID)
-        {
-            this.Time = time;
-            this.Value = value;
-            this.Quality = quality;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="ArchiveDataPoint"/>.</param>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataPoint"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public ArchiveDataPoint(int historianID, byte[] buffer, int startIndex, int length)
-            : this(historianID)
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the historian identifier of <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
-        public int HistorianID
-        {
-            get
-            {
-                return m_historianID;
-            }
-            set
-            {
-                if (value < 1 && value != -1)
-                    throw new ArgumentException("Value must be positive or -1");
-
-                m_historianID = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="TimeTag"/> of <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
-        public virtual TimeTag Time
-        {
-            get
-            {
-                return m_time;
-            }
-            set
-            {
-                if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
-                    throw new TimeTagException("Value must between 01/01/1995 and 01/19/2063");
-
-                m_time = value;
-                Flags = Flags.SetMaskedValue(MillisecondMask, m_time.ToDateTime().Millisecond << 5);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the floating-point value of <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        public virtual float Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Quality"/> of <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        public virtual Quality Quality
-        {
-            get
-            {
-                return (Quality)Flags.GetMaskedValue(QualityMask);
-            }
-            set
-            {
-                Flags = Flags.SetMaskedValue(QualityMask, (int)value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the associated <see cref="MetadataRecord"/> with this <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        public virtual MetadataRecord Metadata
-        {
-            get
-            {
-                return m_metadata;
-            }
-            set
-            {
-                m_metadata = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets a boolean value that indicates whether <see cref="ArchiveDataPoint"/> contains any data.
-        /// </summary>
-        public virtual bool IsEmpty
-        {
-            get
-            {
-                return ((m_time.CompareTo(TimeTag.MinValue) == 0) &&
-                        (m_value == default(float)) &&
-                        (Quality == Quality.Unknown));
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        public virtual int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the 32-bit word used for storing data of <see cref="ArchiveDataPoint"/>.
-        /// </summary>
-        protected virtual int Flags
-        {
-            get
-            {
-                return m_flags;
-            }
-            set
-            {
-                m_flags = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="ArchiveDataPoint"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataPoint"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="ArchiveDataPoint"/>.</returns>
-        public virtual int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                Flags = LittleEndian.ToInt16(buffer, startIndex + 4);
-                Value = LittleEndian.ToSingle(buffer, startIndex + 6);
-
-                TimeTag value = new TimeTag(LittleEndian.ToInt32(buffer, startIndex) +       // Seconds
-                        ((decimal)(m_flags.GetMaskedValue(MillisecondMask) >> 5) / 1000));   // Milliseconds
-
-                // Make sure to properly validate timestamps for newly initialized or possibly corrupted blocks
-                if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
-                    value = TimeTag.MinValue;
-
-                Time = value;
-
-                return FixedLength;
-            }
-            
-            // Binary image does not have sufficient data.
-            return 0;
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="ArchiveDataPoint"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes((int)m_time.Value), 0, buffer, startIndex, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes((short)m_flags), 0, buffer, startIndex + 4, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_value), 0, buffer, startIndex + 6, 4);
-
-            return length;
-        }
-
-        /// <summary>
-        /// Compares the current <see cref="ArchiveDataPoint"/> object to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="ArchiveDataPoint"/> object is to be compared.</param>
-        /// <returns>
-        /// Negative value if the current <see cref="ArchiveDataPoint"/> object is less than <paramref name="obj"/>, 
-        /// Zero if the current <see cref="ArchiveDataPoint"/> object is equal to <paramref name="obj"/>, 
-        /// Positive value if the current <see cref="ArchiveDataPoint"/> object is greater than <paramref name="obj"/>.
-        /// </returns>
-        public virtual int CompareTo(object obj)
-        {
-            ArchiveDataPoint other = obj as ArchiveDataPoint;
-            if (other == null)
-            {
-                return 1;
-            }
-            else
-            {
-                int result = m_historianID.CompareTo(other.HistorianID);
-                if (result != 0)
-                    return result;
-                else
-                    return m_time.CompareTo(other.Time);
-            }
-        }
-
-        /// <summary>
-        /// Determines whether the current <see cref="ArchiveDataPoint"/> object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="ArchiveDataPoint"/> object is to be compared for equality.</param>
-        /// <returns>true if the current <see cref="ArchiveDataPoint"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            return (CompareTo(obj) == 0);
-        }
-
-        /// <summary>
-        /// Returns the text representation of <see cref="ArchiveDataPoint"/> object.
-        /// </summary>
-        /// <returns>A <see cref="string"/> value.</returns>
-        public override string ToString()
-        {
-            return ToString(null, null);
-        }
-
-        /// <summary>
-        /// Returns the text representation of <see cref="ArchiveDataPoint"/> object in the specified <paramref name="format"/>.
-        /// </summary>
-        /// <param name="format">Format of text output (I for ID, T for Time, V for Value, Q for Quality).</param>
-        /// <returns>A <see cref="string"/> value.</returns>
-        public virtual string ToString(string format)
-        {
-            return ToString(format, null);
-        }
-
-        /// <summary>
-        /// Returns the text representation of <see cref="ArchiveDataPoint"/> object using the specified <paramref name="provider"/>.
-        /// </summary>
-        /// <param name="provider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information.</param>
-        /// <returns>A <see cref="string"/> value.</returns>
-        public virtual string ToString(IFormatProvider provider)
-        {
-            return ToString("", provider);
-        }
-
-        /// <summary>
-        /// Returns the text representation of <see cref="ArchiveDataPoint"/> object in the specified <paramref name="format"/> 
-        /// using the specified <paramref name="provider"/>.
-        /// </summary>
-        /// <param name="format">Format of text output (I for ID, T for Time, V for Value, Q for Quality).</param>
-        /// <param name="provider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information.</param>
-        /// <returns>A <see cref="string"/> value.</returns>
-        public virtual string ToString(string format, IFormatProvider provider)
-        {
-            if (provider == null)
-                provider = CultureInfo.InvariantCulture;
-
-            switch (format.ToUpperInvariant())
-            {
-                case "I":
-                case "ID":
-                    return m_historianID.ToString(provider);
-                case "T":
-                case "TIME":
-                    return m_time.ToString();
-                case "U":
-                case "UNIXTIME":
-                    return (new UnixTimeTag(m_time.ToDateTime())).Value.ToString("0.000", provider);
-                case "V":
-                case "VALUE":
-                    return m_value.ToString(provider);
-                case "Q":
-                case "QUALITY":
-                    return Quality.ToString();
-                case "N":
-                case "NAME":
-                    if (Metadata != null)
-                        return Metadata.Name;
-                    return "";
-                case "D":
-                case "DESCRIPTION":
-                    if (Metadata != null)
-                        return Metadata.Description;
-                    return "";
-                case "S":
-                case "SOURCE":
-                    if (Metadata != null)
-                        return Metadata.PlantCode;
-                    return "";
-                case "S1":
-                case "SYNONYM1":
-                    if (Metadata != null)
-                        return Metadata.Synonym1;
-                    return "";
-                case "S2":
-                case "SYNONYM2":
-                    if (Metadata != null)
-                        return Metadata.Synonym2;
-                    return "";
-                case "S3":
-                case "SYNONYM3":
-                    if (Metadata != null)
-                        return Metadata.Synonym3;
-                    return "";
-                default:
-                    throw new FormatException("Invalid format identifier specified for ArchiveDataPoint: " + format);
-            }
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current <see cref="ArchiveDataPoint"/> object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return m_historianID.GetHashCode();
-        }
-
-        #endregion
+        m_time = TimeTag.MinValue;
+        HistorianID = historianID;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
+    /// </summary>
+    /// <param name="dataPoint">A time-series data point.</param>
+    public ArchiveDataPoint(IDataPoint dataPoint)
+        : this(dataPoint.HistorianID, dataPoint.Time, dataPoint.Value, dataPoint.Quality)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class from a <see cref="IMeasurement"/> value.
+    /// </summary>
+    /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
+    public ArchiveDataPoint(IMeasurement measurement)
+        : this(measurement, measurement.HistorianQuality())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class from a <see cref="IMeasurement"/> value.
+    /// </summary>
+    /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
+    /// <param name="quality">Specific <see cref="Quality"/> value to apply to new <see cref="ArchiveDataPoint"/>.</param>
+    public ArchiveDataPoint(IMeasurement measurement, Quality quality)
+        : this((int)measurement.Key.ID)
+    {
+        Time = new TimeTag((DateTime)measurement.Timestamp);
+        Value = (float)measurement.AdjustedValue;
+        Quality = quality;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="ArchiveDataPoint"/>.</param>
+    /// <param name="time"><see cref="TimeTag"/> of <see cref="ArchiveDataPoint"/>.</param>
+    /// <param name="value">Floating-point value of <see cref="ArchiveDataPoint"/>.</param>
+    /// <param name="quality"><see cref="Quality"/> of <see cref="ArchiveDataPoint"/>.</param>
+    public ArchiveDataPoint(int historianID, TimeTag time, float value, Quality quality)
+        : this(historianID)
+    {
+        Time = time;
+        Value = value;
+        Quality = quality;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveDataPoint"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="ArchiveDataPoint"/>.</param>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataPoint"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public ArchiveDataPoint(int historianID, byte[] buffer, int startIndex, int length)
+        : this(historianID)
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the historian identifier of <see cref="ArchiveDataPoint"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
+    public int HistorianID
+    {
+        get => m_historianID;
+        set
+        {
+            if (value < 1 && value != -1)
+                throw new ArgumentException("Value must be positive or -1");
+
+            m_historianID = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="TimeTag"/> of <see cref="ArchiveDataPoint"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
+    public virtual TimeTag Time
+    {
+        get => m_time;
+        set
+        {
+            if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
+                throw new TimeTagException("Value must between 01/01/1995 and 01/19/2063");
+
+            m_time = value;
+            Flags = Flags.SetMaskedValue(MillisecondMask, m_time.ToDateTime().Millisecond << 5);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the floating-point value of <see cref="ArchiveDataPoint"/>.
+    /// </summary>
+    public virtual float Value
+    {
+        get => m_value;
+        set => m_value = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Quality"/> of <see cref="ArchiveDataPoint"/>.
+    /// </summary>
+    public virtual Quality Quality
+    {
+        get => (Quality)Flags.GetMaskedValue(QualityMask);
+        set => Flags = Flags.SetMaskedValue(QualityMask, (int)value);
+    }
+
+    /// <summary>
+    /// Gets or sets the associated <see cref="MetadataRecord"/> with this <see cref="ArchiveDataPoint"/>.
+    /// </summary>
+    public virtual MetadataRecord Metadata { get; set; }
+
+    /// <summary>
+    /// Gets a boolean value that indicates whether <see cref="ArchiveDataPoint"/> contains any data.
+    /// </summary>
+    public virtual bool IsEmpty =>
+        m_time.CompareTo(TimeTag.MinValue) == 0 &&
+        m_value == 0 &&
+        Quality == Quality.Unknown;
+
+    /// <summary>
+    /// Gets the length of the <see cref="ArchiveDataPoint"/>.
+    /// </summary>
+    public virtual int BinaryLength => FixedLength;
+
+    /// <summary>
+    /// Gets or sets the 32-bit word used for storing data of <see cref="ArchiveDataPoint"/>.
+    /// </summary>
+    protected virtual int Flags
+    {
+        get => m_flags;
+        set => m_flags = value;
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="ArchiveDataPoint"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="ArchiveDataPoint"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="ArchiveDataPoint"/>.</returns>
+    public virtual int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+
+        // Binary image has sufficient data.
+        Flags = LittleEndian.ToInt16(buffer, startIndex + 4);
+        Value = LittleEndian.ToSingle(buffer, startIndex + 6);
+
+        TimeTag value = new(LittleEndian.ToInt32(buffer, startIndex) +                      // Seconds
+                           (decimal)(m_flags.GetMaskedValue(MillisecondMask) >> 5) / 1000); // Milliseconds
+
+        // Make sure to properly validate timestamps for newly initialized or possibly corrupted blocks
+        if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
+            value = TimeTag.MinValue;
+
+        Time = value;
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="ArchiveDataPoint"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes((int)m_time.Value), 0, buffer, startIndex, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes((short)m_flags), 0, buffer, startIndex + 4, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_value), 0, buffer, startIndex + 6, 4);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Compares the current <see cref="ArchiveDataPoint"/> object to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="ArchiveDataPoint"/> object is to be compared.</param>
+    /// <returns>
+    /// Negative value if the current <see cref="ArchiveDataPoint"/> object is less than <paramref name="obj"/>, 
+    /// Zero if the current <see cref="ArchiveDataPoint"/> object is equal to <paramref name="obj"/>, 
+    /// Positive value if the current <see cref="ArchiveDataPoint"/> object is greater than <paramref name="obj"/>.
+    /// </returns>
+    public virtual int CompareTo(object obj)
+    {
+        if (obj is not ArchiveDataPoint other)
+            return 1;
+
+        int result = m_historianID.CompareTo(other.HistorianID);
+        return result == 0 ? m_time.CompareTo(other.Time) : result;
+    }
+
+    /// <summary>
+    /// Determines whether the current <see cref="ArchiveDataPoint"/> object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="ArchiveDataPoint"/> object is to be compared for equality.</param>
+    /// <returns>true if the current <see cref="ArchiveDataPoint"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        return CompareTo(obj) == 0;
+    }
+
+    /// <summary>
+    /// Returns the text representation of <see cref="ArchiveDataPoint"/> object.
+    /// </summary>
+    /// <returns>A <see cref="string"/> value.</returns>
+    public override string ToString()
+    {
+        return ToString(null, null);
+    }
+
+    /// <summary>
+    /// Returns the text representation of <see cref="ArchiveDataPoint"/> object in the specified <paramref name="format"/>.
+    /// </summary>
+    /// <param name="format">Format of text output (I for ID, T for Time, V for Value, Q for Quality).</param>
+    /// <returns>A <see cref="string"/> value.</returns>
+    public virtual string ToString(string format)
+    {
+        return ToString(format, null);
+    }
+
+    /// <summary>
+    /// Returns the text representation of <see cref="ArchiveDataPoint"/> object using the specified <paramref name="provider"/>.
+    /// </summary>
+    /// <param name="provider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information.</param>
+    /// <returns>A <see cref="string"/> value.</returns>
+    public virtual string ToString(IFormatProvider provider)
+    {
+        return ToString("", provider);
+    }
+
+    /// <summary>
+    /// Returns the text representation of <see cref="ArchiveDataPoint"/> object in the specified <paramref name="format"/> 
+    /// using the specified <paramref name="provider"/>.
+    /// </summary>
+    /// <param name="format">Format of text output (I for ID, T for Time, V for Value, Q for Quality).</param>
+    /// <param name="provider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information.</param>
+    /// <returns>A <see cref="string"/> value.</returns>
+    public virtual string ToString(string format, IFormatProvider provider)
+    {
+        provider ??= CultureInfo.InvariantCulture;
+
+        return format.ToUpperInvariant() switch
+        {
+            "I" or "ID" => m_historianID.ToString(provider),
+            "T" or "TIME" => m_time.ToString(),
+            "U" or "UNIXTIME" => new UnixTimeTag(m_time.ToDateTime()).Value.ToString("0.000", provider),
+            "V" or "VALUE" => m_value.ToString(provider),
+            "Q" or "QUALITY" => Quality.ToString(),
+            "N" or "NAME" => Metadata is null ? "" : Metadata.Name,
+            "D" or "DESCRIPTION" => Metadata is null ? "" : Metadata.Description,
+            "S" or "SOURCE" => Metadata is null ? "" : Metadata.PlantCode,
+            "S1" or "SYNONYM1" => Metadata is null ? "" : Metadata.Synonym1,
+            "S2" or "SYNONYM2" => Metadata is null ? "" : Metadata.Synonym2,
+            "S3" or "SYNONYM3" => Metadata is null ? "" : Metadata.Synonym3,
+            _ => throw new FormatException($"Invalid format identifier specified for ArchiveDataPoint: {format}")
+        };
+    }
+
+    /// <summary>
+    /// Returns the hash code for the current <see cref="ArchiveDataPoint"/> object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        return m_historianID.GetHashCode();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveFile.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveFile.cs
@@ -1657,6 +1657,10 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
     /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(int historianID, string startTime, string endTime, bool timeSorted = true)
     {
         return ReadData(historianID, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
@@ -1670,6 +1674,10 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
     /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, string endTime, bool timeSorted = true)
     {
         return ReadData(historianIDs, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
@@ -1707,6 +1715,10 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
     /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, DateTime endTime, bool timeSorted = true)
     {
         return ReadData(historianID, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
@@ -1720,6 +1732,10 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
     /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, DateTime endTime, bool timeSorted = true)
     {
         return ReadData(historianIDs, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
@@ -1757,6 +1773,10 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
     /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(int historianID, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
     {
         return ReadData([historianID], startTime, endTime, timeSorted);
@@ -1770,6 +1790,10 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
     /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
     {
         return ReadData(historianIDs, startTime, endTime, null, timeSorted);
@@ -1789,9 +1813,14 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
         if (m_fileType != ArchiveFileType.Active)
             throw new InvalidOperationException("Data can only be directly read from files that are Active");
 
-        // Ensure that the start and end time are valid.
+        bool reverseQuery = false;
+
+        // If start time is greater than end time, assuming reverse query is requested
         if (startTime.CompareTo(endTime) > 0)
-            throw new ArgumentException("End Time precedes Start Time in the specified time span");
+        {
+            reverseQuery = true;
+            (startTime, endTime) = (endTime, startTime); // Swap start and end time
+        }
 
         List<Info> dataFiles = [];
         bool pendingRollover = false;
@@ -1861,9 +1890,9 @@ public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportIniti
                 IArchiveFileScanner scanner;
 
                 if (timeSorted)
-                    scanner = new TimeSortedArchiveFileScanner();
+                    scanner = new TimeSortedArchiveFileScanner(reverseQuery);
                 else
-                    scanner = new ArchiveFileScanner();
+                    scanner = new ArchiveFileScanner(reverseQuery);
 
                 scanner.FileAllocationTable = file.Fat;
                 scanner.HistorianIDs = historianIDs;

--- a/Source/Libraries/GSF.Historian/Files/ArchiveFile.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveFile.cs
@@ -51,17 +51,17 @@
 //  10/14/2009 - Pinal C. Patel
 //       Re-coded the way current data was being written for maximum write throughput.
 //       Fixed DivideByZero exception in Statistics property.
-//       Fixed a issue in quality-based alarm processing.
+//       Fixed an issue in quality-based alarm processing.
 //       Removed unused/unnecessary event raised during the write process.
 //  11/06/2009 - Pinal C. Patel
 //       Modified Read() and Write() methods to wait on the rollover process.
 //  12/01/2009 - Pinal C. Patel
 //       Removed unused RolloverOnFull property.
-//       Fixed a issue in the rollover process that is encountered only when dependency files are 
+//       Fixed an issue in the rollover process that is encountered only when dependency files are 
 //       configured to not load records in memory.
 //  12/02/2009 - Pinal C. Patel
 //       Modified Status property to show the total number of historic archive files.
-//       Fixed a issue in the update of historic archive file list.
+//       Fixed an issue in the update of historic archive file list.
 //  12/03/2009 - Pinal C. Patel
 //       Updated Read() to incorporate changes made to ArchiveFileAllocationTable.FindDataBlocks().
 //  12/08/2009 - Pinal C. Patel
@@ -76,7 +76,7 @@
 //  10/11/2010 - Mihir Brahmbhatt
 //       Updated header and license agreement.
 //  11/18/2010 - J. Ritchie Carroll
-//       Added a exception handler for reading (exposed via DataReadException event) to make sure
+//       Added an exception handler for reading (exposed via DataReadException event) to make sure
 //       bad data or corruption in an archive file does not stop the read process.
 //  11/30/2011 - J. Ritchie Carroll
 //       Modified to support buffer optimized ISupportBinaryImage.
@@ -106,3463 +106,3177 @@ using GSF.IO;
 using GSF.Parsing;
 using Timer = System.Timers.Timer;
 
-namespace GSF.Historian.Files
+// ReSharper disable CompareOfFloatsByEqualityOperator
+// ReSharper disable InconsistentlySynchronizedField
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace GSF.Historian.Files;
+
+#region [ Enumerations ]
+
+/// <summary>
+/// Indicates the type of <see cref="ArchiveFile"/>.
+/// </summary>
+public enum ArchiveFileType
 {
-    #region [ Enumerations ]
+    /// <summary>
+    /// <see cref="ArchiveFile"/> is being used for archiving current data.
+    /// </summary>
+    Active,
+    /// <summary>
+    /// <see cref="ArchiveFile"/> to be used in the rollover process.
+    /// </summary>
+    Standby,
+    /// <summary>
+    /// <see cref="ArchiveFile"/> is full and is not to be used for current data.
+    /// </summary>
+    Historic
+}
+
+#endregion
+
+/// <summary>
+/// Represents a file that contains <see cref="ArchiveDataPoint"/>s.
+/// </summary>
+/// <seealso cref="ArchiveDataPoint"/>
+/// <seealso cref="ArchiveFileAllocationTable"/>
+[ToolboxBitmap(typeof(ArchiveFile))]
+public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportInitialize, IProvideStatus, IPersistSettings
+{
+    #region [ Members ]
+
+    // Nested Types
 
     /// <summary>
-    /// Indicates the type of <see cref="ArchiveFile"/>.
+    /// Represents information about an <see cref="ArchiveFile"/>.
     /// </summary>
-    public enum ArchiveFileType
+    private class Info : IComparable
     {
+        public Info(string fileName)
+        {
+            FileName = fileName;
+        }
+
         /// <summary>
-        /// <see cref="ArchiveFile"/> is being used for archiving current data.
+        /// Name of the <see cref="ArchiveFile"/>.
         /// </summary>
-        Active,
+        public readonly string FileName;
+
         /// <summary>
-        /// <see cref="ArchiveFile"/> to be used in the rollover process.
+        /// Start <see cref="TimeTag"/> of the <see cref="ArchiveFile"/>.
         /// </summary>
-        Standby,
+        public TimeTag StartTimeTag;
+
         /// <summary>
-        /// <see cref="ArchiveFile"/> is full and is not to be used for current data.
+        /// End <see cref="TimeTag"/> of the <see cref="ArchiveFile"/>.
         /// </summary>
-        Historic
+        public TimeTag EndTimeTag;
+
+        public int CompareTo(object obj)
+        {
+            if (obj is not Info other)
+                return 1;
+
+            int result = StartTimeTag.CompareTo(other.StartTimeTag);
+            return result == 0 ? EndTimeTag.CompareTo(other.EndTimeTag) : result;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is not Info other)
+                return false;
+
+            // We will only compare file name for equality because the result will be incorrect if one of
+            // the ArchiveFileInfo instance is created from the filename by GetHistoricFileInfo() function.
+            return string.Compare(FilePath.GetFileName(FileName), FilePath.GetFileName(other.FileName), StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        public override int GetHashCode()
+        {
+            return FileName.GetHashCode();
+        }
+    }
+
+    // Constants
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="FileName"/> property.
+    /// </summary>
+    public const string DefaultFileName = $"ArchiveFile{FileExtension}";
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="FileType"/> property.
+    /// </summary>
+    public const ArchiveFileType DefaultFileType = ArchiveFileType.Active;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="FileSize"/> property.
+    /// </summary>
+    public const int DefaultFileSize = 1500;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="FileAccessMode"/> property.
+    /// </summary>
+    public const FileAccess DefaultFileAccessMode = FileAccess.ReadWrite;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="DataBlockSize"/> property.
+    /// </summary>
+    public const int DefaultDataBlockSize = 8;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="RolloverPreparationThreshold"/> property.
+    /// </summary>
+    public const double DefaultRolloverPreparationThreshold = 75.0D;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="ArchiveOffloadCount"/> property.
+    /// </summary>
+    public const int DefaultArchiveOffloadCount = 5;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="ArchiveOffloadLocation"/> property.
+    /// </summary>
+    public const string DefaultArchiveOffloadLocation = "";
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="ArchiveOffloadThreshold"/> property.
+    /// </summary>
+    public const double DefaultArchiveOffloadThreshold = 90.0D;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="ArchiveOffloadMaxAge"/> property.
+    /// </summary>
+    public const int DefaultArchiveOffloadMaxAge = -1;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="MaxHistoricArchiveFiles"/> property.
+    /// </summary>
+    public const int DefaultMaxHistoricArchiveFiles = -1;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="LeadTimeTolerance"/> property.
+    /// </summary>
+    public const int DefaultLeadTimeTolerance = 15;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="CompressData"/> property.
+    /// </summary>
+    public const bool DefaultCompressData = true;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="DiscardOutOfSequenceData"/> property.
+    /// </summary>
+    public const bool DefaultDiscardOutOfSequenceData = true;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="CacheWrites"/> property.
+    /// </summary>
+    public const bool DefaultCacheWrites = false;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="ConserveMemory"/> property.
+    /// </summary>
+    public const bool DefaultConserveMemory = true;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="MonitorNewArchiveFiles"/> property.
+    /// </summary>
+    public const bool DefaultMonitorNewArchiveFiles = false;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="PersistSettings"/> property.
+    /// </summary>
+    public const bool DefaultPersistSettings = false;
+
+    /// <summary>
+    /// Specifies the default value for the <see cref="SettingsCategory"/> property.
+    /// </summary>
+    public const string DefaultSettingsCategory = nameof(ArchiveFile);
+
+    /// <summary>
+    /// Specifies the extension for current and historic <see cref="ArchiveFile"/>.
+    /// </summary>
+    private const string FileExtension = ".d";
+
+    /// <summary>
+    /// Specifies the extension for a standby <see cref="ArchiveFile"/>.
+    /// </summary>
+    private const string StandbyFileExtension = ".standby";
+
+    /// <summary>
+    /// Specifies the interval (in milliseconds) for the memory conservation process to run.
+    /// </summary>
+    private const int DataBlockCheckInterval = 60000;
+
+    // Events
+
+    /// <summary>
+    /// Occurs when the active <see cref="ArchiveFile"/> if full.
+    /// </summary>
+    [Category(nameof(File))]
+    [Description("Occurs when the active ArchiveFile if full.")]
+    public event EventHandler FileFull;
+
+    /// <summary>
+    /// Occurs when the process of offloading historic <see cref="ArchiveFile"/>s is started.
+    /// </summary>
+    [Category("Archive")]
+    [Description("Occurs when the process of offloading historic ArchiveFiles is started.")]
+    public event EventHandler OffloadStart;
+
+    /// <summary>
+    /// Occurs when the process of offloading historic <see cref="ArchiveFile"/>s is complete.
+    /// </summary>
+    [Category("Archive")]
+    [Description("Occurs when the process of offloading historic ArchiveFiles is complete.")]
+    public event EventHandler OffloadComplete;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered during the historic <see cref="ArchiveFile"/> offload process.
+    /// </summary>
+    [Category("Archive")]
+    [Description("Occurs when an Exception is encountered during the historic ArchiveFile offload process.")]
+    public event EventHandler<EventArgs<Exception>> OffloadException;
+
+    /// <summary>
+    /// Occurs when an historic <see cref="ArchiveFile"/> is being offloaded.
+    /// </summary>
+    [Category("Archive")]
+    [Description("Occurs when an historic ArchiveFile is being offloaded.")]
+    public event EventHandler<EventArgs<ProcessProgress<int>>> OffloadProgress;
+
+    /// <summary>
+    /// Occurs when <see cref="Rollover()"/> to a new <see cref="ArchiveFile"/> is started.
+    /// </summary>
+    [Category(nameof(Rollover))]
+    [Description("Occurs when Rollover to a new ArchiveFile is started.")]
+    public event EventHandler RolloverStart;
+
+    /// <summary>
+    /// Occurs when <see cref="Rollover()"/> to a new <see cref="ArchiveFile"/> is complete.
+    /// </summary>
+    [Category(nameof(Rollover))]
+    [Description("Occurs when Rollover to a new ArchiveFile is complete.")]
+    public event EventHandler RolloverComplete;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered during the <see cref="Rollover()"/> process.
+    /// </summary>
+    [Category(nameof(Rollover))]
+    [Description("Occurs when an Exception is encountered during the Rollover() process.")]
+    public event EventHandler<EventArgs<Exception>> RolloverException;
+
+    /// <summary>
+    /// Occurs when the process of creating a standby <see cref="ArchiveFile"/> is started.
+    /// </summary>
+    [Category(nameof(Rollover))]
+    [Description("Occurs when the process of creating a standby ArchiveFile is started.")]
+    public event EventHandler RolloverPreparationStart;
+
+    /// <summary>
+    /// Occurs when the process of creating a standby <see cref="ArchiveFile"/> is complete.
+    /// </summary>
+    [Category(nameof(Rollover))]
+    [Description("Occurs when the process of creating a standby ArchiveFile is complete.")]
+    public event EventHandler RolloverPreparationComplete;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered during the standby <see cref="ArchiveFile"/> creation process.
+    /// </summary>
+    [Category(nameof(Rollover))]
+    [Description("Occurs when an Exception is encountered during the standby ArchiveFile creation process.")]
+    public event EventHandler<EventArgs<Exception>> RolloverPreparationException;
+
+    /// <summary>
+    /// Occurs when the process of building historic <see cref="ArchiveFile"/> list is started.
+    /// </summary>
+    [Category(nameof(File))]
+    [Description("Occurs when the process of building historic ArchiveFile list is started.")]
+    public event EventHandler HistoricFileListBuildStart;
+
+    /// <summary>
+    /// Occurs when the process of building historic <see cref="ArchiveFile"/> list is complete.
+    /// </summary>
+    [Category(nameof(File))]
+    [Description("Occurs when the process of building historic ArchiveFile list is complete.")]
+    public event EventHandler HistoricFileListBuildComplete;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered in historic <see cref="ArchiveFile"/> list building process.
+    /// </summary>
+    [Category(nameof(File))]
+    [Description("Occurs when an Exception is encountered in historic ArchiveFile list building process.")]
+    public event EventHandler<EventArgs<Exception>> HistoricFileListBuildException;
+
+    /// <summary>
+    /// Occurs when the historic <see cref="ArchiveFile"/> list is updated to reflect addition or deletion of historic <see cref="ArchiveFile"/>s.
+    /// </summary>
+    [Category(nameof(File))]
+    [Description("Occurs when the historic ArchiveFile list is updated to reflect addition or deletion of historic ArchiveFiles.")]
+    public event EventHandler HistoricFileListUpdated;
+
+    /// <summary>
+    /// Occurs when <see cref="IDataPoint"/> is received for which a <see cref="StateRecord"/> or <see cref="MetadataRecord"/> does not exist or is marked as disabled.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when IDataPoint is received for which a StateRecord or MetadataRecord does not exist or is marked as disabled.")]
+    public event EventHandler<EventArgs<IDataPoint>> OrphanDataReceived;
+
+    /// <summary>
+    /// Occurs when <see cref="IDataPoint"/> is received with <see cref="TimeTag"/> ahead of the local clock by more than the <see cref="LeadTimeTolerance"/>.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when IDataPoint is received with TimeTag ahead of the local clock by more than the LeadTimeTolerance.")]
+    public event EventHandler<EventArgs<IDataPoint>> FutureDataReceived;
+
+    /// <summary>
+    /// Occurs when <see cref="IDataPoint"/> that belongs to a historic <see cref="ArchiveFile"/> is received for archival.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when IDataPoint that belongs to a historic ArchiveFile is received for archival.")]
+    public event EventHandler<EventArgs<IDataPoint>> HistoricDataReceived;
+
+    /// <summary>
+    /// Occurs when misaligned (by time) <see cref="IDataPoint"/> is received for archival.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when misaligned (by time) IDataPoint is received for archival.")]
+    public event EventHandler<EventArgs<IDataPoint>> OutOfSequenceDataReceived;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered while reading <see cref="IDataPoint"/> from the current or historic <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when an Exception is encountered while reading IDataPoint from the current or historic ArchiveFile.")]
+    public event EventHandler<EventArgs<Exception>> DataReadException;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered while writing <see cref="IDataPoint"/> to the current or historic <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Category(nameof(Data))]
+    [Description("Occurs when an Exception is encountered while writing IDataPoint to the current or historic ArchiveFile.")]
+    public event EventHandler<EventArgs<Exception>> DataWriteException;
+
+    /// <summary>
+    /// Occurs when <see cref="IDataPoint"/> triggers an alarm notification.
+    /// </summary>
+    [Category(nameof(File))]
+    [Description("Occurs when IDataPoint triggers an alarm notification.")]
+    public event EventHandler<EventArgs<StateRecord>> ProcessAlarmNotification;
+
+    /// <summary>
+    /// Occurs when associated Metadata file is updated.
+    /// </summary>
+    [Category("Metadata")]
+    [Description("Occurs when associated Metadata file is updated.")]
+    public event EventHandler MetadataUpdated;
+
+    // Fields
+
+    // Component
+    private string m_fileName;
+    private ArchiveFileType m_fileType;
+    private double m_fileSize;
+    private FileAccess m_fileAccessMode;
+    private int m_dataBlockSize;
+    private double m_rolloverPreparationThreshold;
+    private int m_archiveOffloadCount;
+    private double m_archiveOffloadThreshold;
+    private int m_maxHistoricArchiveFiles;
+    private double m_leadTimeTolerance;
+    private bool m_conserveMemory;
+
+    // Operational
+    private bool m_initialized;
+    private List<ArchiveDataBlock> m_dataBlocks;
+    private List<Info> m_historicArchiveFiles;
+    private readonly Dictionary<int, decimal> m_delayedAlarmProcessing;
+    private volatile bool m_rolloverInProgress;
+    private long m_activeFileReaders;
+
+    // Threading
+    private Thread m_rolloverPreparationThread;
+    private Thread m_buildHistoricFileListThread;
+
+    // Components
+    private MetadataFile m_metadataFile;
+    private readonly Timer m_conserveMemoryTimer;
+    private readonly ProcessQueue<IDataPoint> m_currentDataQueue;
+    private readonly ProcessQueue<IDataPoint> m_historicDataQueue;
+    private readonly ProcessQueue<IDataPoint> m_outOfSequenceDataQueue;
+    private SafeFileWatcher m_currentLocationFileWatcher;
+    private SafeFileWatcher m_offloadLocationFileWatcher;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveFile"/> class.
+    /// </summary>
+    public ArchiveFile()
+    {
+        m_fileName = DefaultFileName;
+        m_fileType = DefaultFileType;
+        m_fileSize = DefaultFileSize;
+        m_fileAccessMode = DefaultFileAccessMode;
+        m_dataBlockSize = DefaultDataBlockSize;
+        m_rolloverPreparationThreshold = DefaultRolloverPreparationThreshold;
+        ArchiveOffloadLocation = DefaultArchiveOffloadLocation;
+        m_archiveOffloadCount = DefaultArchiveOffloadCount;
+        m_archiveOffloadThreshold = DefaultArchiveOffloadThreshold;
+        ArchiveOffloadMaxAge = DefaultArchiveOffloadMaxAge;
+        m_maxHistoricArchiveFiles = DefaultMaxHistoricArchiveFiles;
+        m_leadTimeTolerance = DefaultLeadTimeTolerance;
+        CompressData = DefaultCompressData;
+        DiscardOutOfSequenceData = DefaultDiscardOutOfSequenceData;
+        CacheWrites = DefaultCacheWrites;
+        m_conserveMemory = DefaultConserveMemory;
+        MonitorNewArchiveFiles = DefaultMonitorNewArchiveFiles;
+        PersistSettings = DefaultPersistSettings;
+        Name = DefaultSettingsCategory;
+
+        m_delayedAlarmProcessing = new Dictionary<int, decimal>();
+        RolloverWaitHandle = new ManualResetEvent(true);
+        m_rolloverPreparationThread = new Thread(PrepareForRollover);
+        m_buildHistoricFileListThread = new Thread(BuildHistoricFileList);
+
+        m_conserveMemoryTimer = new Timer();
+        m_conserveMemoryTimer.Elapsed += ConserveMemoryTimer_Elapsed;
+
+        m_currentDataQueue = ProcessQueue<IDataPoint>.CreateRealTimeQueue(WriteToCurrentArchiveFile);
+        m_currentDataQueue.ProcessException += CurrentDataQueue_ProcessException;
+
+        m_historicDataQueue = ProcessQueue<IDataPoint>.CreateRealTimeQueue(WriteToHistoricArchiveFile);
+        m_historicDataQueue.ProcessException += HistoricDataQueue_ProcessException;
+
+        m_outOfSequenceDataQueue = ProcessQueue<IDataPoint>.CreateRealTimeQueue(InsertInCurrentArchiveFile);
+        m_outOfSequenceDataQueue.ProcessException += OutOfSequenceDataQueue_ProcessException;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveFile"/> class.
+    /// </summary>
+    /// <param name="container"><see cref="IContainer"/> object that contains the <see cref="ArchiveFile"/>.</param>
+    public ArchiveFile(IContainer container)
+        : this()
+    {
+        container?.Add(this);
     }
 
     #endregion
 
+    #region [ Properties ]
+
     /// <summary>
-    /// Represents a file that contains <see cref="ArchiveDataPoint"/>s.
+    /// Gets or sets the name of the <see cref="ArchiveFile"/>.
     /// </summary>
-    /// <seealso cref="ArchiveDataPoint"/>
-    /// <seealso cref="ArchiveFileAllocationTable"/>
-    [ToolboxBitmap(typeof(ArchiveFile))]
-    public class ArchiveFile : Component, IArchive, ISupportLifecycle, ISupportInitialize, IProvideStatus, IPersistSettings
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    /// <exception cref="ArgumentException">The value being assigned contains an invalid file extension.</exception>
+    [Category(nameof(Configuration))]
+    [DefaultValue(DefaultFileName)]
+    [Description("Name of the ArchiveFile.")]
+    public string FileName
     {
-        #region [ Members ]
-
-        // Nested Types
-
-        /// <summary>
-        /// Represents information about an <see cref="ArchiveFile"/>.
-        /// </summary>
-        private class Info : IComparable
-        {
-            public Info(string fileName)
-            {
-                FileName = fileName;
-            }
-
-            /// <summary>
-            /// Name of the <see cref="ArchiveFile"/>.
-            /// </summary>
-            public readonly string FileName;
-
-            /// <summary>
-            /// Start <see cref="TimeTag"/> of the <see cref="ArchiveFile"/>.
-            /// </summary>
-            public TimeTag StartTimeTag;
-
-            /// <summary>
-            /// End <see cref="TimeTag"/> of the <see cref="ArchiveFile"/>.
-            /// </summary>
-            public TimeTag EndTimeTag;
-
-            public int CompareTo(object obj)
-            {
-                Info other = obj as Info;
-
-                if ((object)other == null)
-                    return 1;
-
-                int result = StartTimeTag.CompareTo(other.StartTimeTag);
-
-                if (result != 0)
-                    return result;
-
-                return EndTimeTag.CompareTo(other.EndTimeTag);
-            }
-
-            public override bool Equals(object obj)
-            {
-                Info other = obj as Info;
-
-                if ((object)other == null)
-                    return false;
-
-                // We will only compare file name for equality because the result will be incorrect if one of
-                // the ArchiveFileInfo instance is created from the filename by GetHistoricFileInfo() function.
-                return string.Compare(FilePath.GetFileName(FileName), FilePath.GetFileName(other.FileName), StringComparison.OrdinalIgnoreCase) == 0;
-            }
-
-            public override int GetHashCode()
-            {
-                return FileName.GetHashCode();
-            }
-        }
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="FileName"/> property.
-        /// </summary>
-        public const string DefaultFileName = "ArchiveFile" + FileExtension;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="FileType"/> property.
-        /// </summary>
-        public const ArchiveFileType DefaultFileType = ArchiveFileType.Active;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="FileSize"/> property.
-        /// </summary>
-        public const int DefaultFileSize = 1500;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="FileAccessMode"/> property.
-        /// </summary>
-        public const FileAccess DefaultFileAccessMode = FileAccess.ReadWrite;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="DataBlockSize"/> property.
-        /// </summary>
-        public const int DefaultDataBlockSize = 8;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="RolloverPreparationThreshold"/> property.
-        /// </summary>
-        public const double DefaultRolloverPreparationThreshold = 75.0D;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="ArchiveOffloadCount"/> property.
-        /// </summary>
-        public const int DefaultArchiveOffloadCount = 5;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="ArchiveOffloadLocation"/> property.
-        /// </summary>
-        public const string DefaultArchiveOffloadLocation = "";
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="ArchiveOffloadThreshold"/> property.
-        /// </summary>
-        public const double DefaultArchiveOffloadThreshold = 90.0D;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="ArchiveOffloadMaxAge"/> property.
-        /// </summary>
-        public const int DefaultArchiveOffloadMaxAge = -1;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="MaxHistoricArchiveFiles"/> property.
-        /// </summary>
-        public const int DefaultMaxHistoricArchiveFiles = -1;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="LeadTimeTolerance"/> property.
-        /// </summary>
-        public const int DefaultLeadTimeTolerance = 15;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="CompressData"/> property.
-        /// </summary>
-        public const bool DefaultCompressData = true;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="DiscardOutOfSequenceData"/> property.
-        /// </summary>
-        public const bool DefaultDiscardOutOfSequenceData = true;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="CacheWrites"/> property.
-        /// </summary>
-        public const bool DefaultCacheWrites = false;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="ConserveMemory"/> property.
-        /// </summary>
-        public const bool DefaultConserveMemory = true;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="MonitorNewArchiveFiles"/> property.
-        /// </summary>
-        public const bool DefaultMonitorNewArchiveFiles = false;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="PersistSettings"/> property.
-        /// </summary>
-        public const bool DefaultPersistSettings = false;
-
-        /// <summary>
-        /// Specifies the default value for the <see cref="SettingsCategory"/> property.
-        /// </summary>
-        public const string DefaultSettingsCategory = "ArchiveFile";
-
-        /// <summary>
-        /// Specifies the extension for current and historic <see cref="ArchiveFile"/>.
-        /// </summary>
-        private const string FileExtension = ".d";
-
-        /// <summary>
-        /// Specifies the extension for a standby <see cref="ArchiveFile"/>.
-        /// </summary>
-        private const string StandbyFileExtension = ".standby";
-
-        /// <summary>
-        /// Specifies the interval (in milliseconds) for the memory conservation process to run.
-        /// </summary>
-        private const int DataBlockCheckInterval = 60000;
-
-        // Events
-
-        /// <summary>
-        /// Occurs when the active <see cref="ArchiveFile"/> if full.
-        /// </summary>
-        [Category("File"),
-        Description("Occurs when the active ArchiveFile if full.")]
-        public event EventHandler FileFull;
-
-        /// <summary>
-        /// Occurs when the process of offloading historic <see cref="ArchiveFile"/>s is started.
-        /// </summary>
-        [Category("Archive"),
-        Description("Occurs when the process of offloading historic ArchiveFiles is started.")]
-        public event EventHandler OffloadStart;
-
-        /// <summary>
-        /// Occurs when the process of offloading historic <see cref="ArchiveFile"/>s is complete.
-        /// </summary>
-        [Category("Archive"),
-        Description("Occurs when the process of offloading historic ArchiveFiles is complete.")]
-        public event EventHandler OffloadComplete;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered during the historic <see cref="ArchiveFile"/> offload process.
-        /// </summary>
-        [Category("Archive"),
-        Description("Occurs when an Exception is encountered during the historic ArchiveFile offload process.")]
-        public event EventHandler<EventArgs<Exception>> OffloadException;
-
-        /// <summary>
-        /// Occurs when an historic <see cref="ArchiveFile"/> is being offloaded.
-        /// </summary>
-        [Category("Archive"),
-        Description("Occurs when an historic ArchiveFile is being offloaded.")]
-        public event EventHandler<EventArgs<ProcessProgress<int>>> OffloadProgress;
-
-        /// <summary>
-        /// Occurs when <see cref="Rollover()"/> to a new <see cref="ArchiveFile"/> is started.
-        /// </summary>
-        [Category("Rollover"),
-        Description("Occurs when Rollover to a new ArchiveFile is started.")]
-        public event EventHandler RolloverStart;
-
-        /// <summary>
-        /// Occurs when <see cref="Rollover()"/> to a new <see cref="ArchiveFile"/> is complete.
-        /// </summary>
-        [Category("Rollover"),
-        Description("Occurs when Rollover to a new ArchiveFile is complete.")]
-        public event EventHandler RolloverComplete;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered during the <see cref="Rollover()"/> process.
-        /// </summary>
-        [Category("Rollover"),
-        Description("Occurs when an Exception is encountered during the Rollover() process.")]
-        public event EventHandler<EventArgs<Exception>> RolloverException;
-
-        /// <summary>
-        /// Occurs when the process of creating a standby <see cref="ArchiveFile"/> is started.
-        /// </summary>
-        [Category("Rollover"),
-        Description("Occurs when the process of creating a standby ArchiveFile is started.")]
-        public event EventHandler RolloverPreparationStart;
-
-        /// <summary>
-        /// Occurs when the process of creating a standby <see cref="ArchiveFile"/> is complete.
-        /// </summary>
-        [Category("Rollover"),
-        Description("Occurs when the process of creating a standby ArchiveFile is complete.")]
-        public event EventHandler RolloverPreparationComplete;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered during the standby <see cref="ArchiveFile"/> creation process.
-        /// </summary>
-        [Category("Rollover"),
-        Description("Occurs when an Exception is encountered during the standby ArchiveFile creation process.")]
-        public event EventHandler<EventArgs<Exception>> RolloverPreparationException;
-
-        /// <summary>
-        /// Occurs when the process of building historic <see cref="ArchiveFile"/> list is started.
-        /// </summary>
-        [Category("File"),
-        Description("Occurs when the process of building historic ArchiveFile list is started.")]
-        public event EventHandler HistoricFileListBuildStart;
-
-        /// <summary>
-        /// Occurs when the process of building historic <see cref="ArchiveFile"/> list is complete.
-        /// </summary>
-        [Category("File"),
-        Description("Occurs when the process of building historic ArchiveFile list is complete.")]
-        public event EventHandler HistoricFileListBuildComplete;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered in historic <see cref="ArchiveFile"/> list building process.
-        /// </summary>
-        [Category("File"),
-        Description("Occurs when an Exception is encountered in historic ArchiveFile list building process.")]
-        public event EventHandler<EventArgs<Exception>> HistoricFileListBuildException;
-
-        /// <summary>
-        /// Occurs when the historic <see cref="ArchiveFile"/> list is updated to reflect addition or deletion of historic <see cref="ArchiveFile"/>s.
-        /// </summary>
-        [Category("File"),
-        Description("Occurs when the historic ArchiveFile list is updated to reflect addition or deletion of historic ArchiveFiles.")]
-        public event EventHandler HistoricFileListUpdated;
-
-        /// <summary>
-        /// Occurs when <see cref="IDataPoint"/> is received for which a <see cref="StateRecord"/> or <see cref="MetadataRecord"/> does not exist or is marked as disabled.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when IDataPoint is received for which a StateRecord or MetadataRecord does not exist or is marked as disabled.")]
-        public event EventHandler<EventArgs<IDataPoint>> OrphanDataReceived;
-
-        /// <summary>
-        /// Occurs when <see cref="IDataPoint"/> is received with <see cref="TimeTag"/> ahead of the local clock by more than the <see cref="LeadTimeTolerance"/>.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when IDataPoint is received with TimeTag ahead of the local clock by more than the LeadTimeTolerance.")]
-        public event EventHandler<EventArgs<IDataPoint>> FutureDataReceived;
-
-        /// <summary>
-        /// Occurs when <see cref="IDataPoint"/> that belongs to a historic <see cref="ArchiveFile"/> is received for archival.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when IDataPoint that belongs to a historic ArchiveFile is received for archival.")]
-        public event EventHandler<EventArgs<IDataPoint>> HistoricDataReceived;
-
-        /// <summary>
-        /// Occurs when misaligned (by time) <see cref="IDataPoint"/> is received for archival.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when misaligned (by time) IDataPoint is received for archival.")]
-        public event EventHandler<EventArgs<IDataPoint>> OutOfSequenceDataReceived;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered while reading <see cref="IDataPoint"/> from the current or historic <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when an Exception is encountered while reading IDataPoint from the current or historic ArchiveFile.")]
-        public event EventHandler<EventArgs<Exception>> DataReadException;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered while writing <see cref="IDataPoint"/> to the current or historic <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Category("Data"),
-        Description("Occurs when an Exception is encountered while writing IDataPoint to the current or historic ArchiveFile.")]
-        public event EventHandler<EventArgs<Exception>> DataWriteException;
-
-        /// <summary>
-        /// Occurs when <see cref="IDataPoint"/> triggers an alarm notification.
-        /// </summary>
-        [Category("File"),
-        Description("Occurs when IDataPoint triggers an alarm notification.")]
-        public event EventHandler<EventArgs<StateRecord>> ProcessAlarmNotification;
-
-        /// <summary>
-        /// Occurs when associated Metadata file is updated.
-        /// </summary>
-        [Category("Metadata"),
-        Description("Occurs when associated Metadata file is updated.")]
-        public event EventHandler MetadataUpdated;
-
-        // Fields
-
-        // Component
-        private string m_fileName;
-        private ArchiveFileType m_fileType;
-        private double m_fileSize;
-        private FileAccess m_fileAccessMode;
-        private int m_dataBlockSize;
-        private double m_rolloverPreparationThreshold;
-        private string m_archiveOffloadLocation;
-        private int m_archiveOffloadCount;
-        private double m_archiveOffloadThreshold;
-        private int m_archiveOffloadMaxAge;
-        private int m_maxHistoricArchiveFiles;
-        private double m_leadTimeTolerance;
-        private bool m_compressData;
-        private bool m_discardOutOfSequenceData;
-        private bool m_cacheWrites;
-        private bool m_conserveMemory;
-        private bool m_monitorNewArchiveFiles;
-        private bool m_persistSettings;
-        private string m_settingsCategory;
-        private ArchiveFileAllocationTable m_fat;
-
-        // Operational
-        private bool m_disposed;
-        private bool m_initialized;
-        private FileStream m_fileStream;
-        private List<ArchiveDataBlock> m_dataBlocks;
-        private List<Info> m_historicArchiveFiles;
-        private readonly Dictionary<int, decimal> m_delayedAlarmProcessing;
-        private volatile bool m_rolloverInProgress;
-        private long m_activeFileReaders;
-
-        // Threading
-        private Thread m_rolloverPreparationThread;
-        private Thread m_buildHistoricFileListThread;
-        private readonly ManualResetEvent m_rolloverWaitHandle;
-
-        // Components
-        private StateFile m_stateFile;
-        private IntercomFile m_intercomFile;
-        private MetadataFile m_metadataFile;
-        private readonly Timer m_conserveMemoryTimer;
-        private readonly ProcessQueue<IDataPoint> m_currentDataQueue;
-        private readonly ProcessQueue<IDataPoint> m_historicDataQueue;
-        private readonly ProcessQueue<IDataPoint> m_outOfSequenceDataQueue;
-        private SafeFileWatcher m_currentLocationFileWatcher;
-        private SafeFileWatcher m_offloadLocationFileWatcher;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveFile"/> class.
-        /// </summary>
-        public ArchiveFile()
-        {
-            m_fileName = DefaultFileName;
-            m_fileType = DefaultFileType;
-            m_fileSize = DefaultFileSize;
-            m_fileAccessMode = DefaultFileAccessMode;
-            m_dataBlockSize = DefaultDataBlockSize;
-            m_rolloverPreparationThreshold = DefaultRolloverPreparationThreshold;
-            m_archiveOffloadLocation = DefaultArchiveOffloadLocation;
-            m_archiveOffloadCount = DefaultArchiveOffloadCount;
-            m_archiveOffloadThreshold = DefaultArchiveOffloadThreshold;
-            m_archiveOffloadMaxAge = DefaultArchiveOffloadMaxAge;
-            m_maxHistoricArchiveFiles = DefaultMaxHistoricArchiveFiles;
-            m_leadTimeTolerance = DefaultLeadTimeTolerance;
-            m_compressData = DefaultCompressData;
-            m_discardOutOfSequenceData = DefaultDiscardOutOfSequenceData;
-            m_cacheWrites = DefaultCacheWrites;
-            m_conserveMemory = DefaultConserveMemory;
-            m_monitorNewArchiveFiles = DefaultMonitorNewArchiveFiles;
-            m_persistSettings = DefaultPersistSettings;
-            m_settingsCategory = DefaultSettingsCategory;
-
-            m_delayedAlarmProcessing = new Dictionary<int, decimal>();
-            m_rolloverWaitHandle = new ManualResetEvent(true);
-            m_rolloverPreparationThread = new Thread(PrepareForRollover);
-            m_buildHistoricFileListThread = new Thread(BuildHistoricFileList);
-
-            m_conserveMemoryTimer = new Timer();
-            m_conserveMemoryTimer.Elapsed += ConserveMemoryTimer_Elapsed;
-
-            m_currentDataQueue = ProcessQueue<IDataPoint>.CreateRealTimeQueue(WriteToCurrentArchiveFile);
-            m_currentDataQueue.ProcessException += CurrentDataQueue_ProcessException;
-
-            m_historicDataQueue = ProcessQueue<IDataPoint>.CreateRealTimeQueue(WriteToHistoricArchiveFile);
-            m_historicDataQueue.ProcessException += HistoricDataQueue_ProcessException;
-
-            m_outOfSequenceDataQueue = ProcessQueue<IDataPoint>.CreateRealTimeQueue(InsertInCurrentArchiveFile);
-            m_outOfSequenceDataQueue.ProcessException += OutOfSequenceDataQueue_ProcessException;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveFile"/> class.
-        /// </summary>
-        /// <param name="container"><see cref="IContainer"/> object that contains the <see cref="ArchiveFile"/>.</param>
-        public ArchiveFile(IContainer container)
-            : this()
-        {
-            if ((object)container != null)
-                container.Add(this);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the name of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        /// <exception cref="ArgumentException">The value being assigned contains an invalid file extension.</exception>
-        [Category("Configuration"),
-        DefaultValue(DefaultFileName),
-        Description("Name of the ArchiveFile.")]
-        public string FileName
-        {
-            get
-            {
-                return m_fileName;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                if (string.Compare(FilePath.GetExtension(value), FileExtension, StringComparison.OrdinalIgnoreCase) != 0 &&
-                    string.Compare(FilePath.GetExtension(value), StandbyFileExtension, StringComparison.OrdinalIgnoreCase) != 0)
-                    throw (new ArgumentException(string.Format("{0} must have an extension of {1} or {2}.", GetType().Name, FileExtension, StandbyFileExtension)));
-
-                m_fileName = value;
-                ReOpen();
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ArchiveFileType"/> of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Category("Configuration"),
-        DefaultValue(DefaultFileType),
-        Description("Type of the ArchiveFile.")]
-        public ArchiveFileType FileType
-        {
-            get
-            {
-                return m_fileType;
-            }
-            set
-            {
-                m_fileType = value;
-                ReOpen();
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the size (in MB) of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
-        [Category("Configuration"),
-        DefaultValue(DefaultFileSize),
-        Description("Size (in MB) of the ArchiveFile.")]
-        public double FileSize
-        {
-            get
-            {
-                return m_fileSize;
-            }
-            set
-            {
-                if (value <= 0)
-                    throw new ArgumentException("Value must be positive");
-
-                m_fileSize = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="FileAccess"/> value to use when opening the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Category("Configuration"),
-        DefaultValue(DefaultFileAccessMode),
-        Description("System.IO.FileAccess value to use when opening the ArchiveFile.")]
-        public FileAccess FileAccessMode
-        {
-            get
-            {
-                return m_fileAccessMode;
-            }
-            set
-            {
-                m_fileAccessMode = value;
-                ReOpen();
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the size (in KB) of the <see cref="ArchiveDataBlock"/>s.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
-        [Category("Configuration"),
-        DefaultValue(DefaultDataBlockSize),
-        Description("Size (in KB) of the ArchiveDataBlocks.")]
-        public int DataBlockSize
-        {
-            get
-            {
-                // This is the only redundant property between the ArchiveFile component and the FAT, so
-                // we ensure that this information is synched at least at run time if not at design time.
-                if ((object)m_fat == null)
-                    return m_dataBlockSize; // Design time.
-
-                return m_fat.DataBlockSize; // Run time.
-            }
-            set
-            {
-                if (value < 1)
-                    throw new ArgumentException("Value must be positive");
-
-                m_dataBlockSize = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="ArchiveFile"/> usage (in %) that will trigger the creation of an empty <see cref="ArchiveFile"/> for rollover.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 1 and 95.</exception>
-        [Category("Rollover"),
-        DefaultValue(DefaultRolloverPreparationThreshold),
-        Description("ArchiveFile usage (in %) that will trigger the creation of an empty ArchiveFile for rollover.")]
-        public double RolloverPreparationThreshold
-        {
-            get
-            {
-                return m_rolloverPreparationThreshold;
-            }
-            set
-            {
-                if (value < 1.0D || value > 95.0D)
-                    throw new ArgumentOutOfRangeException(nameof(value), "RolloverPreparationThreshold value must be between 1 and 95");
-
-                m_rolloverPreparationThreshold = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of historic <see cref="ArchiveFile"/>s to be offloaded to the <see cref="ArchiveOffloadLocation"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
-        [Category("Archive"),
-        DefaultValue(DefaultArchiveOffloadCount),
-        Description("Number of historic ArchiveFiles to be offloaded to the ArchiveOffloadLocation.")]
-        public int ArchiveOffloadCount
-        {
-            get
-            {
-                return m_archiveOffloadCount;
-            }
-            set
-            {
-                if (value < 1)
-                    throw new ArgumentException("Value must be positive");
-
-                m_archiveOffloadCount = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the path to the directory where historic <see cref="ArchiveFile"/>s are to be offloaded to make space in the primary archive location.
-        /// Set to *DELETE* to remove historic files instead of moving them to an offload location.
-        /// </summary>
-        [Category("Archive"),
-        DefaultValue(DefaultArchiveOffloadLocation),
-        Description("Path to the directory where historic ArchiveFiles are to be offloaded to make space in the primary archive location. Set to *DELETE* to remove files instead of offloading.")]
-        public string ArchiveOffloadLocation
-        {
-            get
-            {
-                return m_archiveOffloadLocation;
-            }
-            set
-            {
-                m_archiveOffloadLocation = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the free disk space (in %) of the primary archive location that triggers the offload of historic <see cref="ArchiveFile"/>s.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">The value being assigned is not between 0 and 99.</exception>
-        [Category("Archive"),
-        DefaultValue(DefaultArchiveOffloadThreshold),
-        Description("Free disk space (in %) of the primary archive location that triggers the offload of historic ArchiveFiles.")]
-        public double ArchiveOffloadThreshold
-        {
-            get
-            {
-                return m_archiveOffloadThreshold;
-            }
-            set
-            {
-                if (value <= 0.0D || value > 99.0D)
-                    throw new ArgumentOutOfRangeException(nameof(value), "ArchiveOffloadThreshold value must be between 0 and 99");
-
-                m_archiveOffloadThreshold = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the maximum number of days before an archive file triggers the offload of historic <see cref="ArchiveFile"/>s.
-        /// </summary>
-        [Category("Archive"),
-        DefaultValue(DefaultArchiveOffloadMaxAge),
-        Description("Maximum number of days before an archive file will be offloaded.")]
-        public int ArchiveOffloadMaxAge
-        {
-            get
-            {
-                return m_archiveOffloadMaxAge;
-            }
-            set
-            {
-                m_archiveOffloadMaxAge = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the maximum number of historic <see cref="ArchiveFile"/>s to be kept at both the primary and offload locations combined.
-        /// </summary>
-        /// <remarks>
-        /// Set <see cref="MaxHistoricArchiveFiles"/> to -1 to keep historic <see cref="ArchiveFile"/>s indefinitely.
-        /// </remarks>
-        [Category("Archive"),
-        DefaultValue(DefaultMaxHistoricArchiveFiles),
-        Description("Gets or sets the maximum number of historic ArchiveFiles to be kept at both the primary and offload locations combined.")]
-        public int MaxHistoricArchiveFiles
-        {
-            get
-            {
-                return m_maxHistoricArchiveFiles;
-            }
-            set
-            {
-                if (value < 1)
-                    m_maxHistoricArchiveFiles = -1;
-                else
-                    m_maxHistoricArchiveFiles = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of minutes by which incoming <see cref="ArchiveDataPoint"/> can be ahead of local system clock and still be considered valid.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not zero or positive.</exception>
-        [Category("Data"),
-        DefaultValue(DefaultLeadTimeTolerance),
-        Description("Number of minutes by which incoming ArchiveDataPoint can be ahead of local system clock and still be considered valid.")]
-        public double LeadTimeTolerance
-        {
-            get
-            {
-                return m_leadTimeTolerance;
-            }
-            set
-            {
-                if (value < 0)
-                    throw new ArgumentException("Value must be zero or positive");
-
-                m_leadTimeTolerance = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or set a boolean value that indicates whether incoming <see cref="ArchiveDataPoint"/>s are to be compressed to save space.
-        /// </summary>
-        [Category("Data"),
-        DefaultValue(DefaultCompressData),
-        Description("Indicates whether incoming ArchiveDataPoints are to be compressed to save space.")]
-        public bool CompressData
-        {
-            get
-            {
-                return m_compressData;
-            }
-            set
-            {
-                m_compressData = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether incoming <see cref="ArchiveDataPoint"/>s with out-of-sequence <see cref="TimeTag"/> are to be discarded.
-        /// </summary>
-        [Category("Data"),
-        DefaultValue(DefaultDiscardOutOfSequenceData),
-        Description("Indicates whether incoming ArchiveDataPoints with out-of-sequence TimeTag are to be discarded.")]
-        public bool DiscardOutOfSequenceData
-        {
-            get
-            {
-                return m_discardOutOfSequenceData;
-            }
-            set
-            {
-                m_discardOutOfSequenceData = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether writes to the disk are to be cached for performance efficiency.
-        /// </summary>
-        [Category("Performance"),
-        DefaultValue(DefaultCacheWrites),
-        Description("indicates whether writes to the disk are to be cached for performance efficiency.")]
-        public bool CacheWrites
-        {
-            get
-            {
-                return m_cacheWrites;
-            }
-            set
-            {
-                m_cacheWrites = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether memory usage is to be kept low for performance efficiency.
-        /// </summary>
-        [Category("Performance"),
-        DefaultValue(DefaultConserveMemory),
-        Description("Indicates whether memory usage is to be kept low for performance efficiency.")]
-        public bool ConserveMemory
-        {
-            get
-            {
-                return m_conserveMemory;
-            }
-            set
-            {
-                m_conserveMemory = value;
-                ReOpen();
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether to monitor and load newly encountered archive files.
-        /// </summary>
-        [Category("Data"),
-        DefaultValue(DefaultMonitorNewArchiveFiles),
-        Description("Indicates whether to monitor and load newly encountered archive files.")]
-        public bool MonitorNewArchiveFiles
-        {
-            get
-            {
-                return m_monitorNewArchiveFiles;
-            }
-            set
-            {
-                m_monitorNewArchiveFiles = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="StateFile"/> used by the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Category("Dependencies"),
-        Description("StateFile used by the ArchiveFile.")]
-        public StateFile StateFile
-        {
-            get
-            {
-                return m_stateFile;
-            }
-            set
-            {
-                m_stateFile = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataFile"/> used by the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Category("Dependencies"),
-        Description("MetadataFile used by the ArchiveFile.")]
-        public MetadataFile MetadataFile
-        {
-            get
-            {
-                return m_metadataFile;
-            }
-            set
-            {
-                if ((object)m_metadataFile != null)
-                {
-                    // Detach events from any existing instance
-                    m_metadataFile.FileModified -= MetadataFile_FileModified;
-                }
-
-                m_metadataFile = value;
-
-                if ((object)m_metadataFile != null)
-                {
-                    // Attach events to new instance
-                    m_metadataFile.FileModified += MetadataFile_FileModified;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="IntercomFile"/> used by the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Category("Dependencies"),
-        Description("IntercomFile used by the ArchiveFile.")]
-        public IntercomFile IntercomFile
-        {
-            get
-            {
-                return m_intercomFile;
-            }
-            set
-            {
-                m_intercomFile = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the settings of <see cref="ArchiveFile"/> are to be saved to the config file.
-        /// </summary>
-        [Category("Persistence"),
-        DefaultValue(DefaultPersistSettings),
-        Description("Indicates whether the settings of ArchiveFile are to be saved to the config file.")]
-        public bool PersistSettings
-        {
-            get
-            {
-                return m_persistSettings;
-            }
-            set
-            {
-                m_persistSettings = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the category under which the settings of <see cref="ArchiveFile"/> are to be saved to the config file if the <see cref="PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        [Category("Persistence"),
-        DefaultValue(DefaultSettingsCategory),
-        Description("Category under which the settings of ArchiveFile are to be saved to the config file if the PersistSettings property is set to true.")]
-        public string SettingsCategory
-        {
-            get
-            {
-                return m_settingsCategory;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_settingsCategory = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="ArchiveFile"/> is currently enabled.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Enabled"/> property is not be set by user-code directly.
-        /// </remarks>
-        [Browsable(false),
-        EditorBrowsable(EditorBrowsableState.Never),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool Enabled
-        {
-            get
-            {
-                return IsOpen;
-            }
-            set
-            {
-                if (value && !Enabled)
-                    Open();
-                else if (!value && Enabled)
-                    Close();
-            }
-        }
-
-        /// <summary>
-        /// Gets a flag that indicates whether the object has been disposed.
-        /// </summary>
-        [Browsable(false),
-        EditorBrowsable(EditorBrowsableState.Never),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool IsDisposed
-        {
-            get
-            {
-                return m_disposed;
-            }
-        }
-
-        /// <summary>
-        /// Gets the unique identifier of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Browsable(false)]
-        public string Name
-        {
-            get
-            {
-                return m_settingsCategory;
-            }
-        }
-
-        /// <summary>
-        /// Gets the descriptive status of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Browsable(false)]
-        public string Status
-        {
-            get
-            {
-                StringBuilder status = new StringBuilder();
-
-                status.Append("                 File name: ");
-                status.Append(FilePath.TrimFileName(m_fileName, 30));
-                status.AppendLine();
-                status.Append("                File state: ");
-                status.Append(IsOpen ? "Open" : "Closed");
-                status.AppendLine();
-                status.Append("          File access mode: ");
-                status.Append(m_fileAccessMode);
-                status.AppendLine();
-
-                if (IsOpen)
-                {
-                    ArchiveFileStatistics statistics = Statistics;
-
-                    status.Append("                File usage: ");
-                    status.Append(statistics.FileUsage.ToString("0.00") + "%");
-                    status.AppendLine();
-                    status.Append("          Compression rate: ");
-                    status.Append(statistics.CompressionRate.ToString("0.00") + "%");
-                    status.AppendLine();
-                    status.Append("      Data points received: ");
-                    status.Append(m_fat.DataPointsReceived);
-                    status.AppendLine();
-                    status.Append("      Data points archived: ");
-                    status.Append(m_fat.DataPointsArchived);
-                    status.AppendLine();
-                    status.Append("       Average write speed: ");
-                    status.Append(statistics.AverageWriteSpeed + " per Second");
-                    status.AppendLine();
-                    status.Append("          Averaging window: ");
-                    status.Append(statistics.AveragingWindow.ToString(3));
-                    status.AppendLine();
-
-                    if ((object)m_historicArchiveFiles != null)
-                    {
-                        status.Append("    Historic archive files: ");
-
-                        lock (m_historicArchiveFiles)
-                        {
-                            status.Append(m_historicArchiveFiles.Count);
-                        }
-
-                        status.AppendLine();
-                    }
-                }
-
-                return status.ToString();
-            }
-        }
-
-        /// <summary>
-        /// Gets a boolean value that indicates whether the <see cref="ArchiveFile"/> is currently open.
-        /// </summary>
-        [Browsable(false)]
-        public bool IsOpen
-        {
-            get
-            {
-                return ((object)m_fileStream != null && (object)m_fat != null);
-            }
-        }
-
-        /// <summary>
-        /// Gets the underlying <see cref="FileStream"/> of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Browsable(false)]
-        public FileStream FileData
-        {
-            get
-            {
-                return m_fileStream;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArchiveFileAllocationTable"/> of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Browsable(false)]
-        public ArchiveFileAllocationTable Fat
-        {
-            get
-            {
-                return m_fat;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArchiveFileStatistics"/> object of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        [Browsable(false)]
-        public ArchiveFileStatistics Statistics
-        {
-            get
-            {
-                ArchiveFileStatistics statistics = new ArchiveFileStatistics();
-
-                if (IsOpen)
-                {
-                    // Calculate file usage.
-                    IntercomRecord system = m_intercomFile.Read(1);
-
-                    if (m_fileType == ArchiveFileType.Active && (object)system != null)
-                        statistics.FileUsage = ((float)system.DataBlocksUsed / (float)m_fat.DataBlockCount) * 100;
-                    else
-                        statistics.FileUsage = ((float)m_fat.DataBlocksUsed / (float)m_fat.DataBlockCount) * 100;
-
-                    // Calculate compression rate.
-                    if (m_fat.DataPointsReceived >= 1)
-                        statistics.CompressionRate = ((float)(m_fat.DataPointsReceived - m_fat.DataPointsArchived) / (float)m_fat.DataPointsReceived) * 100;
-
-                    if (m_currentDataQueue.RunTime >= 1.0D)
-                    {
-                        statistics.AveragingWindow = m_currentDataQueue.RunTime;
-
-                        statistics.AverageWriteSpeed =
-                            (int)((m_currentDataQueue.CurrentStatistics.TotalProcessedItems -
-                            (m_historicDataQueue.CurrentStatistics.TotalProcessedItems +
-                            m_historicDataQueue.CurrentStatistics.QueueCount +
-                            m_historicDataQueue.CurrentStatistics.ItemsBeingProcessed +
-                            m_outOfSequenceDataQueue.CurrentStatistics.TotalProcessedItems +
-                            m_outOfSequenceDataQueue.CurrentStatistics.QueueCount +
-                            m_outOfSequenceDataQueue.CurrentStatistics.ItemsBeingProcessed)) / (long)statistics.AveragingWindow);
-                    }
-                }
-
-                return statistics;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ProcessQueueStatistics"/> for the internal current data write <see cref="ProcessQueue{T}"/>.
-        /// </summary>
-        [Browsable(false)]
-        public ProcessQueueStatistics CurrentWriteStatistics
-        {
-            get
-            {
-                return m_currentDataQueue.CurrentStatistics;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ProcessQueueStatistics"/> for the internal historic data write <see cref="ProcessQueue{T}"/>.
-        /// </summary>
-        [Browsable(false)]
-        public ProcessQueueStatistics HistoricWriteStatistics
-        {
-            get
-            {
-                return m_historicDataQueue.CurrentStatistics;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ProcessQueueStatistics"/> for the internal out-of-sequence data write <see cref="ProcessQueue{T}"/>.
-        /// </summary>
-        [Browsable(false)]
-        public ProcessQueueStatistics OutOfSequenceWriteStatistics
-        {
-            get
-            {
-                return m_outOfSequenceDataQueue.CurrentStatistics;
-            }
-        }
-
-        /// <summary>
-        /// Gets wait handle used to synchronize roll-over access.
-        /// </summary>
-        protected internal ManualResetEvent RolloverWaitHandle
-        {
-            get
-            {
-                return m_rolloverWaitHandle;
-            }
-        }
-
-        /// <summary>
-        /// Gets the name of the standby <see cref="ArchiveFile"/>.
-        /// </summary>
-        private string StandbyArchiveFileName
-        {
-            get
-            {
-                return Path.ChangeExtension(m_fileName, StandbyFileExtension);
-            }
-        }
-
-        /// <summary>
-        /// Gets the name to be used when promoting an active <see cref="ArchiveFile"/> to historic <see cref="ArchiveFile"/>.
-        /// </summary>
-        private string HistoryArchiveFileName
-        {
-            get
-            {
-                return FilePath.GetDirectoryName(m_fileName) + (FilePath.GetFileNameWithoutExtension(m_fileName) + "_" + m_fat.FileStartTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + "_to_" + m_fat.FileEndTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + FileExtension).Replace(':', '!');
-            }
-        }
-
-        /// <summary>
-        /// Gets the pattern to be used when searching for historic <see cref="ArchiveFile"/>s.
-        /// </summary>
-        private string HistoricFilesSearchPattern
-        {
-            get
-            {
-                return FilePath.GetFileNameWithoutExtension(m_fileName) + "_*_to_*" + FileExtension;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Initialize()"/> is to be called by user-code directly only if the <see cref="ArchiveFile"/> is not consumed through the designer surface of the IDE.
-        /// </remarks>
-        public void Initialize()
-        {
-            if (!m_initialized)
-            {
-                LoadSettings();         // Load settings from the config file.
-
-                m_initialized = true;   // Initialize only once.
-
-                if (m_monitorNewArchiveFiles)
-                {
-                    m_currentLocationFileWatcher = new SafeFileWatcher();
-                    m_currentLocationFileWatcher.IncludeSubdirectories = true;
-                    m_currentLocationFileWatcher.Renamed += FileWatcher_Renamed;
-                    m_currentLocationFileWatcher.Deleted += FileWatcher_Deleted;
-                    m_currentLocationFileWatcher.Created += FileWatcher_Created;
-
-                    m_offloadLocationFileWatcher = new SafeFileWatcher();
-                    m_offloadLocationFileWatcher.IncludeSubdirectories = true;
-                    m_offloadLocationFileWatcher.Renamed += FileWatcher_Renamed;
-                    m_offloadLocationFileWatcher.Deleted += FileWatcher_Deleted;
-                    m_offloadLocationFileWatcher.Created += FileWatcher_Created;
-                }
-            }
-        }
-        /// <summary>
-        /// Performs necessary operations before the <see cref="ArchiveFile"/> properties are initialized.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="BeginInit()"/> should never be called by user-code directly. This method exists solely for use 
-        /// by the designer if the <see cref="ArchiveFile"/> is consumed through the designer surface of the IDE.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void BeginInit()
-        {
-            if (!DesignMode)
-            {
-                try
-                {
-                    //if ((object)m_currentLocationFileWatcher != null)
-                    //    m_currentLocationFileWatcher.BeginInit();
-
-                    //if ((object)m_offloadLocationFileWatcher != null)
-                    //    m_offloadLocationFileWatcher.BeginInit();
-                }
-                catch
-                {
-                    // Prevent the IDE from crashing when component is in design mode.
-                }
-            }
-        }
-
-        /// <summary>
-        /// Performs necessary operations after the <see cref="ArchiveFile"/> properties are initialized.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EndInit()"/> should never be called by user-code directly. This method exists solely for use 
-        /// by the designer if the <see cref="ArchiveFile"/> is consumed through the designer surface of the IDE.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void EndInit()
-        {
-            if (!DesignMode)
-            {
-                try
-                {
-                    Initialize();
-
-                    //m_currentLocationFileWatcher.EndInit();
-                    //m_offloadLocationFileWatcher.EndInit();
-                }
-                catch
-                {
-                    // Prevent the IDE from crashing when component is in design mode.
-                }
-            }
-        }
-
-        /// <summary>
-        /// Saves settings for the <see cref="ArchiveFile"/> to the config file if the <see cref="PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
-        public void SaveSettings()
-        {
-            if (m_persistSettings)
-            {
-                // Ensure that settings category is specified.
-                if (string.IsNullOrEmpty(m_settingsCategory))
-                    throw new ConfigurationErrorsException("SettingsCategory property has not been set");
-
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[m_settingsCategory];
-
-                settings["FileName", true].Update(m_fileName);
-                settings["FileType", true].Update(m_fileType);
-                settings["FileSize", true].Update(m_fileSize);
-                settings["DataBlockSize", true].Update(m_dataBlockSize);
-                settings["RolloverPreparationThreshold", true].Update(m_rolloverPreparationThreshold);
-                settings["ArchiveOffloadLocation", true].Update(m_archiveOffloadLocation);
-                settings["ArchiveOffloadCount", true].Update(m_archiveOffloadCount);
-                settings["ArchiveOffloadThreshold", true].Update(m_archiveOffloadThreshold);
-                settings["ArchiveOffloadMaxAge", true].Update(m_archiveOffloadMaxAge);
-                settings["MaxHistoricArchiveFiles", true].Update(m_maxHistoricArchiveFiles);
-                settings["LeadTimeTolerance", true].Update(m_leadTimeTolerance);
-                settings["CompressData", true].Update(m_compressData);
-                settings["DiscardOutOfSequenceData", true].Update(m_discardOutOfSequenceData);
-                settings["CacheWrites", true].Update(m_cacheWrites);
-                settings["ConserveMemory", true].Update(m_conserveMemory);
-                settings["MonitorNewArchiveFiles", true].Update(m_monitorNewArchiveFiles);
-
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved settings for the <see cref="ArchiveFile"/> from the config file if the <see cref="PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
-        public void LoadSettings()
-        {
-            if (m_persistSettings)
-            {
-                // Ensure that settings category is specified.
-                if (string.IsNullOrEmpty(m_settingsCategory))
-                    throw new ConfigurationErrorsException("SettingsCategory property has not been set");
-
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[m_settingsCategory];
-
-                settings.Add("FileName", m_fileName, "Name of the file including its path.");
-                settings.Add("FileType", m_fileType, "Type (Active; Standby; Historic) of the file.");
-                settings.Add("FileSize", m_fileSize, "Size (in MB) of the file. Typical size = 100.");
-                settings.Add("DataBlockSize", m_dataBlockSize, "Size (in KB) of the data blocks in the file.");
-                settings.Add("RolloverPreparationThreshold", m_rolloverPreparationThreshold, "Percentage file full when the rollover preparation should begin.");
-                settings.Add("ArchiveOffloadLocation", m_archiveOffloadLocation, "Path to the location where historic files are to be moved when disk start getting full. Set to *DELETE* to remove files instead of offloading.");
-                settings.Add("ArchiveOffloadCount", m_archiveOffloadCount, "Number of files that are to be moved to the offload location when the disk starts getting full.");
-                settings.Add("ArchiveOffloadThreshold", m_archiveOffloadThreshold, "Percentage disk full when the historic files should be moved to the offload location.");
-                settings.Add("ArchiveOffloadMaxAge", m_archiveOffloadMaxAge, "Maximum number of days before an archive file will be offloaded.");
-                settings.Add("MaxHistoricArchiveFiles", m_maxHistoricArchiveFiles, "Maximum number of historic files to be kept at both the primary and offload locations combined.");
-                settings.Add("LeadTimeTolerance", m_leadTimeTolerance, "Number of minutes by which incoming data points can be ahead of local system clock and still be considered valid.");
-                settings.Add("CompressData", m_compressData, "True if compression (swinging door - lossy) is to be performed on the incoming data points; otherwise False.");
-                settings.Add("DiscardOutOfSequenceData", m_discardOutOfSequenceData, "True if out-of-sequence data points are to be discarded; otherwise False.");
-                settings.Add("CacheWrites", m_cacheWrites, "True if writes are to be cached for performance; otherwise False.");
-                settings.Add("ConserveMemory", m_conserveMemory, "True if attempts are to be made to conserve memory; otherwise False.");
-                settings.Add("MonitorNewArchiveFiles", m_monitorNewArchiveFiles, "True to monitor and load newly encountered archive files; otherwise False.");
-
-                FileName = settings["FileName"].ValueAs(m_fileName);
-                FileType = settings["FileType"].ValueAs(m_fileType);
-                FileSize = settings["FileSize"].ValueAs(m_fileSize);
-                DataBlockSize = settings["DataBlockSize"].ValueAs(m_dataBlockSize);
-                RolloverPreparationThreshold = settings["RolloverPreparationThreshold"].ValueAs(m_rolloverPreparationThreshold);
-                ArchiveOffloadLocation = settings["ArchiveOffloadLocation"].ValueAs(m_archiveOffloadLocation);
-                ArchiveOffloadCount = settings["ArchiveOffloadCount"].ValueAs(m_archiveOffloadCount);
-                ArchiveOffloadThreshold = settings["ArchiveOffloadThreshold"].ValueAs(m_archiveOffloadThreshold);
-                ArchiveOffloadMaxAge = settings["ArchiveOffloadMaxAge"].ValueAs(m_archiveOffloadMaxAge);
-                MaxHistoricArchiveFiles = settings["MaxHistoricArchiveFiles"].ValueAs(m_maxHistoricArchiveFiles);
-                LeadTimeTolerance = settings["LeadTimeTolerance"].ValueAs(m_leadTimeTolerance);
-                CompressData = settings["CompressData"].ValueAs(m_compressData);
-                DiscardOutOfSequenceData = settings["DiscardOutOfSequenceData"].ValueAs(m_discardOutOfSequenceData);
-                CacheWrites = settings["CacheWrites"].ValueAs(m_cacheWrites);
-                ConserveMemory = settings["ConserveMemory"].ValueAs(m_conserveMemory);
-            }
-        }
-
-        /// <summary>
-        /// Opens the <see cref="ArchiveFile"/> for use.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">One or all of the <see cref="StateFile"/>, <see cref="IntercomFile"/> or <see cref="MetadataFile"/> properties are not set.</exception>
-        public void Open()
-        {
-            if (!IsOpen)
-            {
-                // Check for the existence of dependencies.
-                if ((object)m_stateFile == null || (object)m_intercomFile == null || (object)m_metadataFile == null)
-                    throw (new InvalidOperationException("One or more of the dependency files are not specified."));
-
-                // Validate file type against its name.
-                if (Path.GetExtension(m_fileName).ToNonNullString().ToLower() == StandbyFileExtension)
-                    m_fileType = ArchiveFileType.Standby;
-                else if (Regex.IsMatch(m_fileName.ToLower(), string.Format(".+_.+_to_.+\\{0}$", FileExtension)))
-                    m_fileType = ArchiveFileType.Historic;
-                else
-                    m_fileType = ArchiveFileType.Active;
-
-                // Get the absolute path for the file name.
-                m_fileName = FilePath.GetAbsolutePath(m_fileName);
-
-                // Create the directory if it does not exist.
-                if (!Directory.Exists(FilePath.GetDirectoryName(m_fileName)))
-                    Directory.CreateDirectory(FilePath.GetDirectoryName(m_fileName));
-
-                // Validate a roll-over is not in progress when opening archive as read-only
-                if (m_fileType == ArchiveFileType.Active && m_fileAccessMode == FileAccess.Read)
-                {
-                    // Open intercom file if closed.
-                    if (!m_intercomFile.IsOpen)
-                        m_intercomFile.Open();
-
-                    m_intercomFile.Load();
-                    IntercomRecord record = m_intercomFile.Read(1);
-                    int waitCount = 0;
-
-                    while ((object)record != null && record.RolloverInProgress && waitCount < 30)
-                    {
-                        Thread.Sleep(1000);
-                        m_intercomFile.Load();
-                        record = m_intercomFile.Read(1);
-                        waitCount++;
-                    }
-                }
-
-                OpenStream();
-
-                // Open state file if closed.
-                if (!m_stateFile.IsOpen)
-                    m_stateFile.Open();
-
-                // Open intercom file if closed.
-                if (!m_intercomFile.IsOpen)
-                    m_intercomFile.Open();
-
-                // Open metadata file if closed.
-                if (!m_metadataFile.IsOpen)
-                    m_metadataFile.Open();
-
-                // Don't proceed further for standby and historic files.
-                if (m_fileType != ArchiveFileType.Active)
-                    return;
-
-                // Start internal process queues.
-                m_currentDataQueue.Start();
-                m_historicDataQueue.Start();
-                m_outOfSequenceDataQueue.Start();
-
-                // Create data block lookup list.
-                if (m_stateFile.RecordsInMemory > 0)
-                    m_dataBlocks = new List<ArchiveDataBlock>(new ArchiveDataBlock[m_stateFile.RecordsInMemory]);
-                else
-                    m_dataBlocks = new List<ArchiveDataBlock>(new ArchiveDataBlock[m_stateFile.RecordsOnDisk]);
-
-                // Validate the dependency files.
-                SyncStateFile(null);
-
-                if (m_intercomFile.FileAccessMode != FileAccess.Read)
-                {
-                    // Ensure that "rollover in progress" is not set.
-                    IntercomRecord system = m_intercomFile.Read(1);
-
-                    if ((object)system == null)
-                        system = new IntercomRecord(1);
-
-                    system.RolloverInProgress = false;
-                    m_intercomFile.Write(1, system);
-                }
-
-                // Start the memory conservation process.
-                if (m_conserveMemory)
-                {
-                    m_conserveMemoryTimer.Interval = DataBlockCheckInterval;
-                    m_conserveMemoryTimer.Start();
-                }
-
-                if (m_fileType == ArchiveFileType.Active)
-                {
-                    // Start preparing the list of historic files.
-                    m_buildHistoricFileListThread = new Thread(BuildHistoricFileList);
-                    m_buildHistoricFileListThread.Priority = ThreadPriority.Lowest;
-                    m_buildHistoricFileListThread.Start();
-
-                    // Start file watchers to monitor file system changes.
-                    if (m_monitorNewArchiveFiles)
-                    {
-                        if ((object)m_currentLocationFileWatcher != null)
-                        {
-                            m_currentLocationFileWatcher.Filter = HistoricFilesSearchPattern;
-                            m_currentLocationFileWatcher.Path = FilePath.GetDirectoryName(m_fileName);
-                            m_currentLocationFileWatcher.EnableRaisingEvents = true;
-                        }
-
-                        if (Directory.Exists(m_archiveOffloadLocation) && (object)m_offloadLocationFileWatcher != null)
-                        {
-                            m_offloadLocationFileWatcher.Filter = HistoricFilesSearchPattern;
-                            m_offloadLocationFileWatcher.Path = m_archiveOffloadLocation;
-                            m_offloadLocationFileWatcher.EnableRaisingEvents = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Closes the <see cref="ArchiveFile"/> if it <see cref="IsOpen"/>.
-        /// </summary>
-        public void Close()
-        {
-            if (IsOpen)
-            {
-                // Abort all asynchronous processing.
-                m_rolloverPreparationThread.Abort();
-                m_buildHistoricFileListThread.Abort();
-
-                // Stop all timer based processing.
-                m_conserveMemoryTimer.Stop();
-
-                // Stop the historic and out-of-sequence data queues.
-                m_currentDataQueue.Flush();
-                m_historicDataQueue.Flush();
-                m_outOfSequenceDataQueue.Flush();
-
-                CloseStream();
-
-                if ((object)m_dataBlocks != null)
-                {
-                    lock (m_dataBlocks)
-                    {
-                        m_dataBlocks.Clear();
-                    }
-                    m_dataBlocks = null;
-                }
-
-                // Stop watching for historic archive files.
-                if ((object)m_currentLocationFileWatcher != null)
-                    m_currentLocationFileWatcher.EnableRaisingEvents = false;
-
-                if ((object)m_offloadLocationFileWatcher != null)
-                    m_offloadLocationFileWatcher.EnableRaisingEvents = false;
-
-                // Clear the list of historic archive files.
-                if ((object)m_historicArchiveFiles != null)
-                {
-                    lock (m_historicArchiveFiles)
-                    {
-                        m_historicArchiveFiles.Clear();
-                    }
-                    m_historicArchiveFiles = null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Saves the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException"><see cref="ArchiveFile"/> is not open.</exception>
-        public void Save()
-        {
-            if (IsOpen)
-            {
-                m_fat.Save();
-            }
-            else
-            {
-                throw new InvalidOperationException(string.Format("\"{0}\" is not open", m_fileName));
-            }
-        }
-
-        /// <summary>
-        /// Performs rollover of active <see cref="ArchiveFile"/> to a new <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException"><see cref="ArchiveFile"/> is not <see cref="ArchiveFileType.Active"/>.</exception>
-        public void Rollover()
-        {
-            if (m_fileType != ArchiveFileType.Active)
-                throw new InvalidOperationException("Cannot rollover a file that is not active");
-
-            try
-            {
-                // Notify internal components about the rollover.
-                m_rolloverWaitHandle.Reset();
-
-                // Raise roll-over start event - this also sets m_rolloverInProgress flag
-                OnRolloverStart();
-
-                // Notify external components about the rollover.
-                IntercomRecord system = m_intercomFile.Read(1);
-                system.DataBlocksUsed = 0;
-                system.RolloverInProgress = true;
-                system.LatestDataID = -1;
-                system.LatestDataTime = TimeTag.MinValue;
-                m_intercomFile.Write(1, system);
-                m_intercomFile.Save();
-
-                // Figure out the end date for this file.
-                StateRecord state;
-                TimeTag endTime = m_fat.FileEndTime;
-
-                for (int i = 1; i <= m_stateFile.RecordsOnDisk; i++)
-                {
-                    state = m_stateFile.Read(i);
-                    state.ActiveDataBlockIndex = -1;
-                    state.ActiveDataBlockSlot = 1;
-
-                    if (state.ArchivedData.Time.CompareTo(endTime) > 0)
-                        endTime = state.ArchivedData.Time;
-
-                    m_stateFile.Write(state.HistorianID, state);
-                }
-
-                m_fat.FileEndTime = endTime;
-
-                m_stateFile.Save();
-                Save();
-
-                // Wait for any pending readers to release
-                WaitForReadersRelease();
-
-                // Clear all of the cached data blocks.
-                lock (m_dataBlocks)
-                {
-                    for (int i = 0; i < m_dataBlocks.Count; i++)
-                    {
-                        m_dataBlocks[i] = null;
-                    }
-                }
-
-                string historyFileName = HistoryArchiveFileName;
-                string standbyFileName = StandbyArchiveFileName;
-
-                CloseStream();
-
-                // CRITICAL: Exception can be encountered if exclusive lock to the current file cannot be obtained.
-                if (File.Exists(m_fileName))
-                {
-                    try
-                    {
-                        FilePath.WaitForWriteLock(m_fileName, 60);  // Wait for an exclusive lock on the file.
-                        MoveFile(m_fileName, historyFileName);      // Make the active archive file historic.
-
-                        if (File.Exists(standbyFileName))
-                        {
-                            // We have a "standby" archive file for us to use, so we'll use it. It is possible that
-                            // the "standby" file may not be available for use if it could not be created due to
-                            // insufficient disk space during the "rollover preparation stage". If that's the case,
-                            // Open() below will try to create a new archive file, but will only succeed if there
-                            // is enough disk space.
-                            MoveFile(standbyFileName, m_fileName); // Make the standby archive file active.
-                        }
-                    }
-                    catch
-                    {
-                        OpenStream();
-                        throw;
-                    }
-                }
-
-                // CRITICAL: Exception can be encountered if a "standby" archive is not present for us to use and
-                //           we cannot create a new archive file probably because there isn't enough disk space.
-                try
-                {
-                    OpenStream();
-
-                    m_fat.FileStartTime = endTime;
-                    m_fat.Save();
-
-                    // Notify server that rollover is complete.
-                    system.RolloverInProgress = false;
-                    m_intercomFile.Write(1, system);
-                    m_intercomFile.Save();
-
-                    // Raise roll-over complete event - this also resets m_rolloverInProgress flag
-                    OnRolloverComplete();
-
-                    // Notify other threads that rollover is complete.
-                    m_rolloverWaitHandle.Set();
-                }
-                catch
-                {
-                    CloseStream(); // Close the file if we fail to open it.
-                    DeleteFile(m_fileName);
-                    throw; // Rethrow the exception so that the exception event can be raised.
-                }
-            }
-            catch (Exception ex)
-            {
-                // Raise roll-over exception event if there is an error - this will also reset m_rolloverInProgress flag
-                OnRolloverException(ex);
-            }
-        }
-
-        /// <summary>
-        /// Requests a resynchronization of the state file.
-        /// </summary>
-        public void SynchronizeStateFile()
-        {
-            ThreadPool.QueueUserWorkItem(SyncStateFile);
-        }
-
-        /// <summary>
-        /// Writes the specified <paramref name="dataPoint"/> to the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to be written.</param>
-        public void WriteData(IDataPoint dataPoint)
-        {
-            // Yeild to archive rollover process.
-            m_rolloverWaitHandle.WaitOne();
-
-            // Ensure that the current file is open.
-            if (!IsOpen)
-                throw new InvalidOperationException(string.Format("\"{0}\" file is not open", m_fileName));
-
-            // Ensure that the current file is active.
-            if (m_fileType != ArchiveFileType.Active)
-                throw new InvalidOperationException("Data can only be directly written to files that are Active");
-
-            m_currentDataQueue.Add(dataPoint);
-        }
-
-        /// <summary>
-        /// Writes the specified <paramref name="dataPoints"/> to the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="dataPoints"><see cref="ArchiveDataPoint"/> points to be written.</param>
-        public void WriteData(IEnumerable<IDataPoint> dataPoints)
-        {
-            foreach (IDataPoint dataPoint in dataPoints)
-            {
-                WriteData(dataPoint);
-            }
-        }
-
-        /// <summary>
-        /// Writes <paramref name="metadata"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="metadata"><see cref="MetadataRecord"/> data.</param>
-        public void WriteMetaData(int historianID, byte[] metadata)
-        {
-            MetadataFile.Write(historianID, new MetadataRecord(historianID, MetadataFile.LegacyMode, metadata, 0, metadata.Length));
-            MetadataFile.Save();
-        }
-
-        /// <summary>
-        /// Writes <paramref name="statedata"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="statedata"><see cref="StateRecord"/> data.</param>
-        public void WriteStateData(int historianID, byte[] statedata)
-        {
-            StateFile.Write(historianID, new StateRecord(historianID, statedata, 0, statedata.Length));
-            StateFile.Save();
-        }
-
-        /// <summary>
-        /// Reads all <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(int historianID, bool timeSorted = true)
-        {
-            return ReadData(historianID, TimeTag.MinValue, timeSorted);
-        }
-
-        /// <summary>
-        /// Reads all <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/> for the specified <paramref name="historianIDs"/>.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, bool timeSorted = true)
-        {
-            return ReadData(historianIDs, TimeTag.MinValue, timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(int historianID, string startTime, bool timeSorted = true)
-        {
-            return ReadData(historianID, startTime, TimeTag.MinValue.ToString(), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, bool timeSorted = true)
-        {
-            return ReadData(historianIDs, startTime, TimeTag.MinValue.ToString(), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(int historianID, string startTime, string endTime, bool timeSorted = true)
-        {
-            return ReadData(historianID, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, string endTime, bool timeSorted = true)
-        {
-            return ReadData(historianIDs, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, bool timeSorted = true)
-        {
-            return ReadData(historianID, startTime, TimeTag.MinValue.ToDateTime(), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, bool timeSorted = true)
-        {
-            return ReadData(historianIDs, startTime, TimeTag.MinValue.ToDateTime(), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, DateTime endTime, bool timeSorted = true)
-        {
-            return ReadData(historianID, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, DateTime endTime, bool timeSorted = true)
-        {
-            return ReadData(historianIDs, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(int historianID, TimeTag startTime, bool timeSorted = true)
-        {
-            return ReadData(historianID, startTime, TimeTag.MaxValue, timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, bool timeSorted = true)
-        {
-            return ReadData(historianIDs, startTime, TimeTag.MaxValue, timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(int historianID, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
-        {
-            return ReadData(new[] { historianID }, startTime, endTime, timeSorted);
-        }
-
-        /// <summary>
-        /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
-        public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
-        {
-            return ReadData(historianIDs, startTime, endTime, null, timeSorted);
-        }
-
-        // Read data implementation
-        private IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, TimeTag endTime, IDataPoint resumeFrom, bool timeSorted)
-        {
-            // Yield to archive rollover process.
-            m_rolloverWaitHandle.WaitOne();
-
-            // Ensure that the current file is open.
-            if (!IsOpen)
-                throw new InvalidOperationException(string.Format("\"{0}\" file is not open", m_fileName));
-
-            // Ensure that the current file is active.
-            if (m_fileType != ArchiveFileType.Active)
-                throw new InvalidOperationException("Data can only be directly read from files that are Active");
-
-            // Ensure that the start and end time are valid.
-            if (startTime.CompareTo(endTime) > 0)
-                throw new ArgumentException("End Time precedes Start Time in the specified time span");
-
-            List<Info> dataFiles = new List<Info>();
-            bool pendingRollover = false;
-            bool usingActiveFile = false;
-
-            if (startTime.CompareTo(m_fat.FileStartTime) < 0)
-            {
-                // Data is to be read from historic file(s) - make sure that the list has been built
-                if (m_buildHistoricFileListThread.IsAlive)
-                    m_buildHistoricFileListThread.Join();
-
-                lock (m_historicArchiveFiles)
-                {
-                    dataFiles.AddRange(m_historicArchiveFiles.FindAll(info => FindHistoricArchiveFileForRead(info, startTime, endTime)));
-                }
-            }
-
-            if (endTime.CompareTo(m_fat.FileStartTime) >= 0)
-            {
-                // Data is to be read from the active file.
-                Info activeFileInfo = new Info(m_fileName)
-                {
-                    StartTimeTag = m_fat.FileStartTime,
-                    EndTimeTag = m_fat.FileEndTime
-                };
-
-                dataFiles.Add(activeFileInfo);
-            }
-
-            // Read data from all qualifying files.
-            foreach (Info dataFile in dataFiles)
-            {
-                ArchiveFile file = null;
-
-                try
-                {
-                    if (string.Compare(dataFile.FileName, m_fileName, StringComparison.OrdinalIgnoreCase) == 0)
-                    {
-                        // Read data from current file.
-                        usingActiveFile = true;
-                        file = this;
-
-                        // Atomically increment total number of readers for active file
-                        Interlocked.Increment(ref m_activeFileReaders);
-
-                        // Handle race conditions between rollover
-                        // and incrementing the active readers
-                        while (m_rolloverInProgress)
-                        {
-                            Interlocked.Decrement(ref m_activeFileReaders);
-                            m_rolloverWaitHandle.WaitOne();
-                            Interlocked.Increment(ref m_activeFileReaders);
-                        }
-                    }
-                    else
-                    {
-                        // Read data from historic file.
-                        usingActiveFile = false;
-                        file = new ArchiveFile();
-                        file.FileName = dataFile.FileName;
-                        file.StateFile = m_stateFile;
-                        file.IntercomFile = m_intercomFile;
-                        file.MetadataFile = m_metadataFile;
-                        file.FileAccessMode = FileAccess.Read;
-                        file.Open();
-                    }
-
-                    // Create new data point scanner for the desired points in this file and given time range
-                    IArchiveFileScanner scanner;
-
-                    if (timeSorted)
-                        scanner = new TimeSortedArchiveFileScanner();
-                    else
-                        scanner = new ArchiveFileScanner();
-
-                    scanner.FileAllocationTable = file.Fat;
-                    scanner.HistorianIDs = historianIDs;
-                    scanner.StartTime = startTime;
-                    scanner.EndTime = endTime;
-                    scanner.ResumeFrom = resumeFrom;
-                    scanner.DataReadExceptionHandler = (sender, e) => OnDataReadException(e.Argument);
-
-                    // Reset resumeFrom to scan from beginning after picking up where left off from roll over
-                    resumeFrom = null;
-
-                    // Return data points
-                    foreach (IDataPoint dataPoint in scanner.Read())
-                    {
-                        yield return dataPoint;
-
-                        // If a rollover needs to happen, we need to relinquish read lock and close file
-                        if (m_rolloverInProgress)
-                        {
-                            resumeFrom = dataPoint;
-                            pendingRollover = true;
-                            break;
-                        }
-                    }
-                }
-                finally
-                {
-                    if (usingActiveFile)
-                    {
-                        // Atomically decrement active file reader count to signal in-process code that read is complete or yielded
-                        Interlocked.Decrement(ref m_activeFileReaders);
-                    }
-                    else if ((object)file != null)
-                    {
-                        file.Dispose();
-                    }
-                }
-
-                if (pendingRollover)
-                    break;
-            }
-
-            if (pendingRollover)
-            {
-                // Recurse into this function with an updated start time and last read point ID so that read can
-                // resume right where it left off - recursed function call will wait until rollover is complete
-                foreach (IDataPoint dataPoint in ReadData(historianIDs, startTime, endTime, resumeFrom, timeSorted))
-                {
-                    yield return dataPoint;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Reads <see cref="MetadataRecord"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing <see cref="MetadataRecord"/> of <see cref="MetadataRecord"/> if found; otherwise null.</returns>
-        public byte[] ReadMetaData(int historianID)
-        {
-            MetadataRecord record = MetadataFile.Read(historianID);
-
-            if ((object)record == null)
-                return null;
-
-            return record.BinaryImage();
-        }
-
-        /// <summary>
-        /// Reads <see cref="StateRecord"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing <see cref="StateRecord"/> of <see cref="StateRecord"/> if found; otherwise null.</returns>
-        public byte[] ReadStateData(int historianID)
-        {
-            StateRecord record = StateFile.Read(historianID);
-
-            if ((object)record == null)
-                return null;
-
-            return record.BinaryImage();
-        }
-
-        /// <summary>
-        /// Reads <see cref="MetadataRecordSummary"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing <see cref="MetadataRecordSummary"/> of <see cref="MetadataRecordSummary"/> if found; otherwise null.</returns>
-        public byte[] ReadMetaDataSummary(int historianID)
-        {
-            MetadataRecord record = MetadataFile.Read(historianID);
-
-            if ((object)record == null)
-                return null;
-
-            return record.Summary.BinaryImage();
-        }
-
-        /// <summary>
-        /// Reads <see cref="StateRecordSummary"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing <see cref="StateRecordSummary"/> of <see cref="StateRecordSummary"/> if found; otherwise null.</returns>
-        public byte[] ReadStateDataSummary(int historianID)
-        {
-            StateRecord record = StateFile.Read(historianID);
-
-            if ((object)record == null)
-                return null;
-
-            return record.Summary.BinaryImage();
-        }
-
-        /// <summary>
-        /// Waits for all readers to relinquish read locks on active file.
-        /// </summary>
-        /// <returns>True if readers released read locks in timely fashion.</returns>
-        protected internal bool WaitForReadersRelease()
-        {
-            int waitCount = 0;
-
-            // Wait up to five seconds for readers to release
-            while (Interlocked.Read(ref m_activeFileReaders) > 0 && waitCount < 5)
-            {
-                Thread.Sleep(1000);
-                waitCount++;
-            }
-
-            bool allReleased = (Interlocked.Read(ref m_activeFileReaders) <= 0);
-
-            return allReleased;
-        }
-
-        /// <summary>
-        /// Raises the <see cref="FileFull"/> event.
-        /// </summary>
-        protected virtual void OnFileFull()
-        {
-            if ((object)FileFull != null)
-                FileFull(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="RolloverStart"/> event.
-        /// </summary>
-        protected internal virtual void OnRolloverStart()
-        {
-            m_rolloverInProgress = true;
-
-            if ((object)RolloverStart != null)
-                RolloverStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="RolloverComplete"/> event.
-        /// </summary>
-        protected internal virtual void OnRolloverComplete()
-        {
-            m_rolloverInProgress = false;
-
-            if ((object)RolloverComplete != null)
-                RolloverComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="RolloverException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="RolloverException"/> event.</param>
-        protected internal virtual void OnRolloverException(Exception ex)
-        {
-            m_rolloverInProgress = false;
-
-            if ((object)RolloverException != null)
-                RolloverException(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="OffloadStart"/> event.
-        /// </summary>
-        protected virtual void OnOffloadStart()
-        {
-            if ((object)OffloadStart != null)
-                OffloadStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="OffloadComplete"/> event.
-        /// </summary>
-        protected virtual void OnOffloadComplete()
-        {
-            if ((object)OffloadComplete != null)
-                OffloadComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="OffloadException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="OffloadException"/> event.</param>
-        protected virtual void OnOffloadException(Exception ex)
-        {
-            if ((object)OffloadException != null)
-                OffloadException(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="OffloadProgress"/> event.
-        /// </summary>
-        /// <param name="offloadProgress"><see cref="ProcessProgress{T}"/> to send to <see cref="OffloadProgress"/> event.</param>
-        protected virtual void OnOffloadProgress(ProcessProgress<int> offloadProgress)
-        {
-            if ((object)OffloadProgress != null)
-                OffloadProgress(this, new EventArgs<ProcessProgress<int>>(offloadProgress));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="RolloverPreparationStart"/> event.
-        /// </summary>
-        protected virtual void OnRolloverPreparationStart()
-        {
-            if ((object)RolloverPreparationStart != null)
-                RolloverPreparationStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="RolloverPreparationComplete"/> event.
-        /// </summary>
-        protected virtual void OnRolloverPreparationComplete()
-        {
-            if ((object)RolloverPreparationComplete != null)
-                RolloverPreparationComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="RolloverPreparationException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="RolloverPreparationException"/> event.</param>
-        protected virtual void OnRolloverPreparationException(Exception ex)
-        {
-            if ((object)RolloverPreparationException != null)
-                RolloverPreparationException(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="HistoricFileListBuildStart"/> event.
-        /// </summary>
-        protected virtual void OnHistoricFileListBuildStart()
-        {
-            if ((object)HistoricFileListBuildStart != null)
-                HistoricFileListBuildStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="HistoricFileListBuildComplete"/> event.
-        /// </summary>
-        protected virtual void OnHistoricFileListBuildComplete()
-        {
-            if ((object)HistoricFileListBuildComplete != null)
-                HistoricFileListBuildComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raise the <see cref="HistoricFileListBuildException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="HistoricFileListBuildException"/> event.</param>
-        protected virtual void OnHistoricFileListBuildException(Exception ex)
-        {
-            if ((object)HistoricFileListBuildException != null)
-                HistoricFileListBuildException(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="HistoricFileListUpdated"/> event.
-        /// </summary>
-        protected virtual void OnHistoricFileListUpdated()
-        {
-            if ((object)HistoricFileListUpdated != null)
-                HistoricFileListUpdated(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="OrphanDataReceived"/> event.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="OrphanDataReceived"/> event.</param>
-        protected virtual void OnOrphanDataReceived(IDataPoint dataPoint)
-        {
-            if ((object)OrphanDataReceived != null)
-                OrphanDataReceived(this, new EventArgs<IDataPoint>(dataPoint));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="FutureDataReceived"/> event.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="FutureDataReceived"/> event.</param>
-        protected virtual void OnFutureDataReceived(IDataPoint dataPoint)
-        {
-            if ((object)FutureDataReceived != null)
-                FutureDataReceived(this, new EventArgs<IDataPoint>(dataPoint));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="HistoricDataReceived"/> event.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="HistoricDataReceived"/> event.</param>
-        protected virtual void OnHistoricDataReceived(IDataPoint dataPoint)
-        {
-            if ((object)HistoricDataReceived != null)
-                HistoricDataReceived(this, new EventArgs<IDataPoint>(dataPoint));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="OutOfSequenceDataReceived"/> event.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="OutOfSequenceDataReceived"/> event.</param>
-        protected virtual void OnOutOfSequenceDataReceived(IDataPoint dataPoint)
-        {
-            if ((object)OutOfSequenceDataReceived != null)
-                OutOfSequenceDataReceived(this, new EventArgs<IDataPoint>(dataPoint));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataReadException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataReadException"/> event.</param>
-        protected virtual void OnDataReadException(Exception ex)
-        {
-            if ((object)DataReadException != null)
-                DataReadException(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="DataWriteException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataWriteException"/> event.</param>
-        protected virtual void OnDataWriteException(Exception ex)
-        {
-            if ((object)DataWriteException != null)
-                DataWriteException(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ProcessAlarmNotification"/> event.
-        /// </summary>
-        /// <param name="pointState"><see cref="StateRecord"/> to send to <see cref="ProcessAlarmNotification"/> event.</param>
-        protected virtual void OnProcessAlarmNotification(StateRecord pointState)
-        {
-            if ((object)ProcessAlarmNotification != null)
-                ProcessAlarmNotification(this, new EventArgs<StateRecord>(pointState));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="MetadataUpdated"/> event.
-        /// </summary>
-        protected virtual void OnMetadataUpdated()
-        {
-            if ((object)MetadataUpdated != null)
-                MetadataUpdated(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="ArchiveFile"/> and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (!m_disposed)
-            {
-                try
-                {
-                    // This will be done regardless of whether the object is finalized or disposed.
-                    if (disposing)
-                    {
-                        // This will be done only when the object is disposed by calling Dispose().
-                        Close();
-                        SaveSettings();
-
-                        if ((object)m_rolloverWaitHandle != null)
-                            m_rolloverWaitHandle.Close();
-
-                        if ((object)m_conserveMemoryTimer != null)
-                        {
-                            m_conserveMemoryTimer.Elapsed -= ConserveMemoryTimer_Elapsed;
-                            m_conserveMemoryTimer.Dispose();
-                        }
-
-                        if ((object)m_currentDataQueue != null)
-                        {
-                            m_currentDataQueue.ProcessException -= CurrentDataQueue_ProcessException;
-                            m_currentDataQueue.Dispose();
-                        }
-
-                        if ((object)m_historicDataQueue != null)
-                        {
-                            m_historicDataQueue.ProcessException -= HistoricDataQueue_ProcessException;
-                            m_historicDataQueue.Dispose();
-                        }
-
-                        if ((object)m_outOfSequenceDataQueue != null)
-                        {
-                            m_outOfSequenceDataQueue.ProcessException -= OutOfSequenceDataQueue_ProcessException;
-                            m_outOfSequenceDataQueue.Dispose();
-                        }
-
-                        if ((object)m_currentLocationFileWatcher != null)
-                        {
-                            m_currentLocationFileWatcher.Renamed -= FileWatcher_Renamed;
-                            m_currentLocationFileWatcher.Deleted -= FileWatcher_Deleted;
-                            m_currentLocationFileWatcher.Created -= FileWatcher_Created;
-                            m_currentLocationFileWatcher.Dispose();
-                        }
-
-                        if ((object)m_offloadLocationFileWatcher != null)
-                        {
-                            m_offloadLocationFileWatcher.Renamed -= FileWatcher_Renamed;
-                            m_offloadLocationFileWatcher.Deleted -= FileWatcher_Deleted;
-                            m_offloadLocationFileWatcher.Created -= FileWatcher_Created;
-                            m_offloadLocationFileWatcher.Dispose();
-                        }
-
-                        // Detach from all of the dependency files.
-                        StateFile = null;
-                        MetadataFile = null;
-                        IntercomFile = null;
-                    }
-                }
-                finally
-                {
-                    m_disposed = true;          // Prevent duplicate dispose.
-                    base.Dispose(disposing);    // Call base class Dispose().
-                }
-            }
-        }
-
-        #region [ Helper Methods ]
-
-        private void ReOpen()
-        {
-            if (IsOpen)
-            {
-                Close();
+        get => m_fileName;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            if (string.Compare(FilePath.GetExtension(value), FileExtension, StringComparison.OrdinalIgnoreCase) != 0 &&
+                string.Compare(FilePath.GetExtension(value), StandbyFileExtension, StringComparison.OrdinalIgnoreCase) != 0)
+                throw new ArgumentException($"{GetType().Name} must have an extension of {FileExtension} or {StandbyFileExtension}.");
+
+            m_fileName = value;
+            ReOpen();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ArchiveFileType"/> of the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Category(nameof(Configuration))]
+    [DefaultValue(DefaultFileType)]
+    [Description("Type of the ArchiveFile.")]
+    public ArchiveFileType FileType
+    {
+        get => m_fileType;
+        set
+        {
+            m_fileType = value;
+            ReOpen();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the size (in MB) of the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
+    [Category(nameof(Configuration))]
+    [DefaultValue(DefaultFileSize)]
+    [Description("Size (in MB) of the ArchiveFile.")]
+    public double FileSize
+    {
+        get => m_fileSize;
+        set
+        {
+            if (value <= 0)
+                throw new ArgumentException("Value must be positive");
+
+            m_fileSize = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="FileAccess"/> value to use when opening the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Category(nameof(Configuration))]
+    [DefaultValue(DefaultFileAccessMode)]
+    [Description("System.IO.FileAccess value to use when opening the ArchiveFile.")]
+    public FileAccess FileAccessMode
+    {
+        get => m_fileAccessMode;
+        set
+        {
+            m_fileAccessMode = value;
+            ReOpen();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the size (in KB) of the <see cref="ArchiveDataBlock"/>s.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
+    [Category(nameof(Configuration))]
+    [DefaultValue(DefaultDataBlockSize)]
+    [Description("Size (in KB) of the ArchiveDataBlocks.")]
+    public int DataBlockSize
+    {
+        get
+        {
+            // This is the only redundant property between the ArchiveFile component and the FAT, so
+            // we ensure that this information is synced at least at run time if not at design time.
+            if (Fat is null)
+                return m_dataBlockSize; // Design time.
+
+            return Fat.DataBlockSize; // Run time.
+        }
+        set
+        {
+            if (value < 1)
+                throw new ArgumentException("Value must be positive");
+
+            m_dataBlockSize = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ArchiveFile"/> usage (in %) that will trigger the creation of an empty <see cref="ArchiveFile"/> for rollover.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 1 and 95.</exception>
+    [Category(nameof(Rollover))]
+    [DefaultValue(DefaultRolloverPreparationThreshold)]
+    [Description("ArchiveFile usage (in %) that will trigger the creation of an empty ArchiveFile for rollover.")]
+    public double RolloverPreparationThreshold
+    {
+        get => m_rolloverPreparationThreshold;
+        set
+        {
+            if (value is < 1.0D or > 95.0D)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(RolloverPreparationThreshold)} value must be between 1 and 95");
+
+            m_rolloverPreparationThreshold = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number of historic <see cref="ArchiveFile"/>s to be offloaded to the <see cref="ArchiveOffloadLocation"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
+    [Category("Archive")]
+    [DefaultValue(DefaultArchiveOffloadCount)]
+    [Description("Number of historic ArchiveFiles to be offloaded to the ArchiveOffloadLocation.")]
+    public int ArchiveOffloadCount
+    {
+        get => m_archiveOffloadCount;
+        set
+        {
+            if (value < 1)
+                throw new ArgumentException("Value must be positive");
+
+            m_archiveOffloadCount = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the path to the directory where historic <see cref="ArchiveFile"/>s are to be offloaded to make space in the primary archive location.
+    /// Set to *DELETE* to remove historic files instead of moving them to an offload location.
+    /// </summary>
+    [Category("Archive")]
+    [DefaultValue(DefaultArchiveOffloadLocation)]
+    [Description("Path to the directory where historic ArchiveFiles are to be offloaded to make space in the primary archive location. Set to *DELETE* to remove files instead of offloading.")]
+    public string ArchiveOffloadLocation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the free disk space (in %) of the primary archive location that triggers the offload of historic <see cref="ArchiveFile"/>s.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">The value being assigned is not between 0 and 99.</exception>
+    [Category("Archive")]
+    [DefaultValue(DefaultArchiveOffloadThreshold)]
+    [Description("Free disk space (in %) of the primary archive location that triggers the offload of historic ArchiveFiles.")]
+    public double ArchiveOffloadThreshold
+    {
+        get => m_archiveOffloadThreshold;
+        set
+        {
+            if (value is <= 0.0D or > 99.0D)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(ArchiveOffloadThreshold)} value must be between 0 and 99");
+
+            m_archiveOffloadThreshold = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum number of days before an archive file triggers the offload of historic <see cref="ArchiveFile"/>s.
+    /// </summary>
+    [Category("Archive")]
+    [DefaultValue(DefaultArchiveOffloadMaxAge)]
+    [Description("Maximum number of days before an archive file will be offloaded.")]
+    public int ArchiveOffloadMaxAge { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of historic <see cref="ArchiveFile"/>s to be kept at both the primary and offload locations combined.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="MaxHistoricArchiveFiles"/> to -1 to keep historic <see cref="ArchiveFile"/>s indefinitely.
+    /// </remarks>
+    [Category("Archive")]
+    [DefaultValue(DefaultMaxHistoricArchiveFiles)]
+    [Description("Gets or sets the maximum number of historic ArchiveFiles to be kept at both the primary and offload locations combined.")]
+    public int MaxHistoricArchiveFiles
+    {
+        get => m_maxHistoricArchiveFiles;
+        set => m_maxHistoricArchiveFiles = value < 1 ? -1 : value;
+    }
+
+    /// <summary>
+    /// Gets or sets the number of minutes by which incoming <see cref="ArchiveDataPoint"/> can be ahead of local system clock and still be considered valid.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not zero or positive.</exception>
+    [Category(nameof(Data))]
+    [DefaultValue(DefaultLeadTimeTolerance)]
+    [Description("Number of minutes by which incoming ArchiveDataPoint can be ahead of local system clock and still be considered valid.")]
+    public double LeadTimeTolerance
+    {
+        get => m_leadTimeTolerance;
+        set
+        {
+            if (value < 0)
+                throw new ArgumentException("Value must be zero or positive");
+
+            m_leadTimeTolerance = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or set a boolean value that indicates whether incoming <see cref="ArchiveDataPoint"/>s are to be compressed to save space.
+    /// </summary>
+    [Category(nameof(Data))]
+    [DefaultValue(DefaultCompressData)]
+    [Description("Indicates whether incoming ArchiveDataPoints are to be compressed to save space.")]
+    public bool CompressData { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether incoming <see cref="ArchiveDataPoint"/>s with out-of-sequence <see cref="TimeTag"/> are to be discarded.
+    /// </summary>
+    [Category(nameof(Data))]
+    [DefaultValue(DefaultDiscardOutOfSequenceData)]
+    [Description("Indicates whether incoming ArchiveDataPoints with out-of-sequence TimeTag are to be discarded.")]
+    public bool DiscardOutOfSequenceData { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether writes to the disk are to be cached for performance efficiency.
+    /// </summary>
+    [Category("Performance")]
+    [DefaultValue(DefaultCacheWrites)]
+    [Description("indicates whether writes to the disk are to be cached for performance efficiency.")]
+    public bool CacheWrites { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether memory usage is to be kept low for performance efficiency.
+    /// </summary>
+    [Category("Performance")]
+    [DefaultValue(DefaultConserveMemory)]
+    [Description("Indicates whether memory usage is to be kept low for performance efficiency.")]
+    public bool ConserveMemory
+    {
+        get => m_conserveMemory;
+        set
+        {
+            m_conserveMemory = value;
+            ReOpen();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether to monitor and load newly encountered archive files.
+    /// </summary>
+    [Category(nameof(Data))]
+    [DefaultValue(DefaultMonitorNewArchiveFiles)]
+    [Description("Indicates whether to monitor and load newly encountered archive files.")]
+    public bool MonitorNewArchiveFiles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="StateFile"/> used by the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Category("Dependencies")]
+    [Description("StateFile used by the ArchiveFile.")]
+    public StateFile StateFile { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataFile"/> used by the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Category("Dependencies")]
+    [Description("MetadataFile used by the ArchiveFile.")]
+    public MetadataFile MetadataFile
+    {
+        get => m_metadataFile;
+        set
+        {
+            // Detach events from any existing instance
+            if (m_metadataFile is not null)
+                m_metadataFile.FileModified -= MetadataFile_FileModified;
+
+            m_metadataFile = value;
+
+            // Attach events to new instance
+            if (m_metadataFile is not null)
+                m_metadataFile.FileModified += MetadataFile_FileModified;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="IntercomFile"/> used by the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Category("Dependencies")]
+    [Description("IntercomFile used by the ArchiveFile.")]
+    public IntercomFile IntercomFile { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the settings of <see cref="ArchiveFile"/> are to be saved to the config file.
+    /// </summary>
+    [Category("Persistence")]
+    [DefaultValue(DefaultPersistSettings)]
+    [Description("Indicates whether the settings of ArchiveFile are to be saved to the config file.")]
+    public bool PersistSettings { get; set; }
+
+    /// <summary>
+    /// Gets or sets the category under which the settings of <see cref="ArchiveFile"/> are to be saved to the config file if the <see cref="PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    [Category("Persistence")]
+    [DefaultValue(DefaultSettingsCategory)]
+    [Description("Category under which the settings of ArchiveFile are to be saved to the config file if the PersistSettings property is set to true.")]
+    public string SettingsCategory
+    {
+        get => Name;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            Name = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="ArchiveFile"/> is currently enabled.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Enabled"/> property is not be set by user-code directly.
+    /// </remarks>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool Enabled
+    {
+        get => IsOpen;
+        set
+        {
+            if (value && !Enabled)
                 Open();
-            }
+            else if (!value && Enabled)
+                Close();
         }
+    }
 
-        internal void OpenStream()
+    /// <summary>
+    /// Gets a flag that indicates whether the object has been disposed.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool IsDisposed { get; private set; }
+
+    /// <summary>
+    /// Gets the unique identifier of the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Browsable(false)]
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Gets the descriptive status of the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Browsable(false)]
+    public string Status
+    {
+        get
+        {
+            StringBuilder status = new();
+
+            status.AppendLine($"                 File name: {FilePath.TrimFileName(m_fileName, 30)}");
+            status.AppendLine($"                File state: {(IsOpen ? nameof(Open) : "Closed")}");
+            status.AppendLine($"          File access mode: {m_fileAccessMode}");
+
+            if (IsOpen)
+            {
+                ArchiveFileStatistics statistics = Statistics;
+
+                status.AppendLine($"                File usage: {statistics.FileUsage:0.00}%");
+                status.AppendLine($"          Compression rate: {statistics.CompressionRate:0.00}%");
+                status.AppendLine($"      Data points received: {Fat.DataPointsReceived:N0}");
+                status.AppendLine($"      Data points archived: {Fat.DataPointsArchived:N0}");
+                status.AppendLine($"       Average write speed: {statistics.AverageWriteSpeed:N0} per Second");
+                status.AppendLine($"          Averaging window: {statistics.AveragingWindow.ToString(3)}");
+
+                // ReSharper disable once InconsistentlySynchronizedField
+                if (m_historicArchiveFiles is not null)
+                {
+                    status.Append("    Historic archive files: ");
+
+                    lock (m_historicArchiveFiles)
+                        status.Append(m_historicArchiveFiles.Count);
+
+                    status.AppendLine();
+                }
+            }
+
+            return status.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Gets a boolean value that indicates whether the <see cref="ArchiveFile"/> is currently open.
+    /// </summary>
+    [Browsable(false)]
+    public bool IsOpen => FileData is not null && Fat is not null;
+
+    /// <summary>
+    /// Gets the underlying <see cref="FileStream"/> of the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Browsable(false)]
+    public FileStream FileData { get; private set; }
+
+    /// <summary>
+    /// Gets the <see cref="ArchiveFileAllocationTable"/> of the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Browsable(false)]
+    public ArchiveFileAllocationTable Fat { get; private set; }
+
+    /// <summary>
+    /// Gets the <see cref="ArchiveFileStatistics"/> object of the <see cref="ArchiveFile"/>.
+    /// </summary>
+    [Browsable(false)]
+    public ArchiveFileStatistics Statistics
+    {
+        get
+        {
+            if (!IsOpen)
+                return new ArchiveFileStatistics();
+            
+            ArchiveFileStatistics statistics = new();
+
+            // Calculate file usage.
+            IntercomRecord system = IntercomFile.Read(1);
+
+            if (m_fileType == ArchiveFileType.Active && system is not null)
+                statistics.FileUsage = system.DataBlocksUsed / (float)Fat.DataBlockCount * 100;
+            else
+                statistics.FileUsage = Fat.DataBlocksUsed / (float)Fat.DataBlockCount * 100;
+
+            // Calculate compression rate.
+            if (Fat.DataPointsReceived >= 1)
+                statistics.CompressionRate = (Fat.DataPointsReceived - Fat.DataPointsArchived) / (float)Fat.DataPointsReceived * 100;
+
+            if (m_currentDataQueue.RunTime >= 1.0D)
+            {
+                statistics.AveragingWindow = m_currentDataQueue.RunTime;
+
+                statistics.AverageWriteSpeed = (int)(
+                    (m_currentDataQueue.CurrentStatistics.TotalProcessedItems -
+                     (m_historicDataQueue.CurrentStatistics.TotalProcessedItems +
+                      m_historicDataQueue.CurrentStatistics.QueueCount +
+                      m_historicDataQueue.CurrentStatistics.ItemsBeingProcessed +
+                      m_outOfSequenceDataQueue.CurrentStatistics.TotalProcessedItems +
+                      m_outOfSequenceDataQueue.CurrentStatistics.QueueCount +
+                      m_outOfSequenceDataQueue.CurrentStatistics.ItemsBeingProcessed)) / (long)statistics.AveragingWindow);
+            }
+
+            return statistics;
+        }
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ProcessQueueStatistics"/> for the internal current data write <see cref="ProcessQueue{T}"/>.
+    /// </summary>
+    [Browsable(false)]
+    public ProcessQueueStatistics CurrentWriteStatistics => m_currentDataQueue.CurrentStatistics;
+
+    /// <summary>
+    /// Gets the <see cref="ProcessQueueStatistics"/> for the internal historic data write <see cref="ProcessQueue{T}"/>.
+    /// </summary>
+    [Browsable(false)]
+    public ProcessQueueStatistics HistoricWriteStatistics => m_historicDataQueue.CurrentStatistics;
+
+    /// <summary>
+    /// Gets the <see cref="ProcessQueueStatistics"/> for the internal out-of-sequence data write <see cref="ProcessQueue{T}"/>.
+    /// </summary>
+    [Browsable(false)]
+    public ProcessQueueStatistics OutOfSequenceWriteStatistics => m_outOfSequenceDataQueue.CurrentStatistics;
+
+    /// <summary>
+    /// Gets wait handle used to synchronize roll-over access.
+    /// </summary>
+    protected internal ManualResetEvent RolloverWaitHandle { get; }
+
+    /// <summary>
+    /// Gets the name of the standby <see cref="ArchiveFile"/>.
+    /// </summary>
+    private string StandbyArchiveFileName => Path.ChangeExtension(m_fileName, StandbyFileExtension);
+
+    /// <summary>
+    /// Gets the name to be used when promoting an active <see cref="ArchiveFile"/> to historic <see cref="ArchiveFile"/>.
+    /// </summary>
+    private string HistoryArchiveFileName => FilePath.GetDirectoryName(m_fileName) + (FilePath.GetFileNameWithoutExtension(m_fileName) + "_" + Fat.FileStartTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + "_to_" + Fat.FileEndTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + FileExtension).Replace(':', '!');
+
+    /// <summary>
+    /// Gets the pattern to be used when searching for historic <see cref="ArchiveFile"/>s.
+    /// </summary>
+    private string HistoricFilesSearchPattern => $"{FilePath.GetFileNameWithoutExtension(m_fileName)}_*_to_*{FileExtension}";
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Initialize()"/> is to be called by user-code directly only if the <see cref="ArchiveFile"/> is not consumed through the designer surface of the IDE.
+    /// </remarks>
+    public void Initialize()
+    {
+        if (m_initialized)
+            return;
+
+        LoadSettings();         // Load settings from the config file.
+
+        m_initialized = true;   // Initialize only once.
+
+        if (!MonitorNewArchiveFiles)
+            return;
+        
+        m_currentLocationFileWatcher = new SafeFileWatcher();
+        m_currentLocationFileWatcher.IncludeSubdirectories = true;
+        m_currentLocationFileWatcher.Renamed += FileWatcher_Renamed;
+        m_currentLocationFileWatcher.Deleted += FileWatcher_Deleted;
+        m_currentLocationFileWatcher.Created += FileWatcher_Created;
+
+        m_offloadLocationFileWatcher = new SafeFileWatcher();
+        m_offloadLocationFileWatcher.IncludeSubdirectories = true;
+        m_offloadLocationFileWatcher.Renamed += FileWatcher_Renamed;
+        m_offloadLocationFileWatcher.Deleted += FileWatcher_Deleted;
+        m_offloadLocationFileWatcher.Created += FileWatcher_Created;
+    }
+    /// <summary>
+    /// Performs necessary operations before the <see cref="ArchiveFile"/> properties are initialized.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BeginInit()"/> should never be called by user-code directly. This method exists solely for use 
+    /// by the designer if the <see cref="ArchiveFile"/> is consumed through the designer surface of the IDE.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void BeginInit()
+    {
+        if (!DesignMode)
         {
             try
             {
-                if (File.Exists(m_fileName))
-                {
-                    int attempts = 0;
+                //if (m_currentLocationFileWatcher is not null)
+                //    m_currentLocationFileWatcher.BeginInit();
 
-                    while (true)
-                    {
-                        try
-                        {
-                            attempts++;
-                            m_fileStream = new FileStream(m_fileName, FileMode.Open, m_fileAccessMode, FileShare.ReadWrite);
-                            m_fat = new ArchiveFileAllocationTable(this);
-                            break;
-                        }
-                        catch
-                        {
-                            m_fileStream?.Dispose();
-
-                            if (attempts >= 4)
-                                throw;
-
-                            Thread.Sleep(500);
-                        }
-                    }
-                }
-                else if (m_fileAccessMode == FileAccess.Read)
-                {
-                    // File does not exist, so we create a placeholder file in the temp directory
-                    m_fileStream = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
-                    m_fat = new ArchiveFileAllocationTable(this);
-                    m_fat.FileStartTime = TimeTag.MaxValue;
-                    m_fat.FileEndTime = TimeTag.MaxValue;
-
-                    // Manually call file monitoring event if file watchers are not enabled
-                    if (!m_monitorNewArchiveFiles)
-                        FileWatcher_Created(this, new FileSystemEventArgs(WatcherChangeTypes.Created, FilePath.GetAbsolutePath(m_fileName), FilePath.GetFileName(m_fileName)));
-                }
-                else
-                {
-                    // File does not exist, so we have to create it and initialize it.
-                    m_fileStream = new FileStream(m_fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
-                    m_fat = new ArchiveFileAllocationTable(this);
-                    m_fat.Save(true);
-
-                    // Manually call file monitoring event if file watchers are not enabled
-                    if (!m_monitorNewArchiveFiles)
-                        FileWatcher_Created(this, new FileSystemEventArgs(WatcherChangeTypes.Created, FilePath.GetAbsolutePath(m_fileName), FilePath.GetFileName(m_fileName)));
-                }
+                //if (m_offloadLocationFileWatcher is not null)
+                //    m_offloadLocationFileWatcher.BeginInit();
             }
             catch
             {
-                m_fileStream?.Dispose();
-                throw;
+                // Prevent the IDE from crashing when component is in design mode.
             }
         }
+    }
 
-        internal void CloseStream()
-        {
-            m_fat = null;
-
-            if ((object)m_fileStream != null)
-            {
-                lock (m_fileStream)
-                {
-                    m_fileStream.Flush();
-                    m_fileStream.Close();
-                    m_fileStream.Dispose();
-                }
-                m_fileStream = null;
-            }
-        }
-
-        private void SyncStateFile(object state)
-        {
-            lock (this)
-            {
-                if ((object)m_dataBlocks != null && m_stateFile.IsOpen && m_metadataFile.IsOpen &&
-                    m_stateFile.FileAccessMode != FileAccess.Read &&
-                    m_metadataFile.RecordsOnDisk > m_stateFile.RecordsOnDisk)
-                {
-                    // Since we have more number of records in the Metadata File than in the State File we'll synchronize
-                    // the number of records in both the files (very important) by writing a new record to the State
-                    // File with an ID same as the number of records on disk for Metadata File. Doing so will cause the
-                    // State File to grow in-memory or on-disk depending on how it's configured.
-                    m_stateFile.Write(m_metadataFile.RecordsOnDisk, new StateRecord(m_metadataFile.RecordsOnDisk));
-                    m_stateFile.Save();
-
-                    // We synchronize the block list with the number of state records physically present on the disk.
-                    lock (m_dataBlocks)
-                    {
-                        m_dataBlocks.AddRange(new ArchiveDataBlock[m_stateFile.RecordsOnDisk - m_dataBlocks.Count]);
-                    }
-                }
-            }
-        }
-
-        private void BuildHistoricFileList()
-        {
-            if ((object)m_historicArchiveFiles == null)
-            {
-                // The list of historic files has not been created, so we'll create it.
-                try
-                {
-                    m_historicArchiveFiles = new List<Info>();
-
-                    OnHistoricFileListBuildStart();
-
-                    // We can safely assume that we'll always get information about the historic file because, the
-                    // the search pattern ensures that we only can a list of historic archive files and not all files.
-                    Info historicFileInfo;
-
-                    // Prevent the historic file list from being updated by the file watchers.
-                    lock (m_historicArchiveFiles)
-                    {
-                        foreach (string historicFileName in Directory.GetFiles(FilePath.GetDirectoryName(m_fileName), HistoricFilesSearchPattern))
-                        {
-                            historicFileInfo = GetHistoricFileInfo(historicFileName);
-                            if ((object)historicFileInfo != null)
-                            {
-                                m_historicArchiveFiles.Add(historicFileInfo);
-                            }
-                        }
-
-                        if (Directory.Exists(m_archiveOffloadLocation))
-                        {
-                            foreach (string historicFileName in Directory.GetFiles(m_archiveOffloadLocation, HistoricFilesSearchPattern))
-                            {
-                                historicFileInfo = GetHistoricFileInfo(historicFileName);
-                                if ((object)historicFileInfo != null)
-                                {
-                                    m_historicArchiveFiles.Add(historicFileInfo);
-                                }
-                            }
-                        }
-                    }
-
-                    OnHistoricFileListBuildComplete();
-                }
-                catch (ThreadAbortException)
-                {
-                    // This thread must die now...
-                }
-                catch (Exception ex)
-                {
-                    OnHistoricFileListBuildException(ex);
-                }
-            }
-        }
-
-        [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Implementation is correct")]
-        private void PrepareForRollover()
+    /// <summary>
+    /// Performs necessary operations after the <see cref="ArchiveFile"/> properties are initialized.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EndInit()"/> should never be called by user-code directly. This method exists solely for use 
+    /// by the designer if the <see cref="ArchiveFile"/> is consumed through the designer surface of the IDE.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void EndInit()
+    {
+        if (!DesignMode)
         {
             try
             {
-                DriveInfo archiveDrive = new DriveInfo(Path.GetPathRoot(m_fileName).ToNonNullString());
+                Initialize();
 
-                // We'll start offloading historic files if we've reached the offload threshold.
-                if (m_archiveOffloadMaxAge > 0)
-                    OffloadMaxAgedFiles();
+                //m_currentLocationFileWatcher.EndInit();
+                //m_offloadLocationFileWatcher.EndInit();
+            }
+            catch
+            {
+                // Prevent the IDE from crashing when component is in design mode.
+            }
+        }
+    }
 
-                if (archiveDrive.AvailableFreeSpace < archiveDrive.TotalSize * (1 - (m_archiveOffloadThreshold / 100)))
-                    OffloadHistoricFiles();
+    /// <summary>
+    /// Saves settings for the <see cref="ArchiveFile"/> to the config file if the <see cref="PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
+    public void SaveSettings()
+    {
+        if (!PersistSettings)
+            return;
+        
+        // Ensure that settings category is specified.
+        if (string.IsNullOrEmpty(Name))
+            throw new ConfigurationErrorsException("SettingsCategory property has not been set");
 
-                // Maintain maximum number of historic files, if configured to do so
-                MaintainMaximumNumberOfHistoricFiles();
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[Name];
 
-                OnRolloverPreparationStart();
+        settings[nameof(FileName), true].Update(m_fileName);
+        settings[nameof(FileType), true].Update(m_fileType);
+        settings[nameof(FileSize), true].Update(m_fileSize);
+        settings[nameof(DataBlockSize), true].Update(m_dataBlockSize);
+        settings[nameof(RolloverPreparationThreshold), true].Update(m_rolloverPreparationThreshold);
+        settings[nameof(ArchiveOffloadLocation), true].Update(ArchiveOffloadLocation);
+        settings[nameof(ArchiveOffloadCount), true].Update(m_archiveOffloadCount);
+        settings[nameof(ArchiveOffloadThreshold), true].Update(m_archiveOffloadThreshold);
+        settings[nameof(ArchiveOffloadMaxAge), true].Update(ArchiveOffloadMaxAge);
+        settings[nameof(MaxHistoricArchiveFiles), true].Update(m_maxHistoricArchiveFiles);
+        settings[nameof(LeadTimeTolerance), true].Update(m_leadTimeTolerance);
+        settings[nameof(CompressData), true].Update(CompressData);
+        settings[nameof(DiscardOutOfSequenceData), true].Update(DiscardOutOfSequenceData);
+        settings[nameof(CacheWrites), true].Update(CacheWrites);
+        settings[nameof(ConserveMemory), true].Update(m_conserveMemory);
+        settings[nameof(MonitorNewArchiveFiles), true].Update(MonitorNewArchiveFiles);
 
-                // Opening and closing a new archive file in "standby" mode will create a "standby" archive file.
-                ArchiveFile standbyArchiveFile = new ArchiveFile();
-                standbyArchiveFile.FileName = StandbyArchiveFileName;
-                standbyArchiveFile.FileSize = m_fileSize;
-                standbyArchiveFile.DataBlockSize = m_dataBlockSize;
-                standbyArchiveFile.StateFile = m_stateFile;
-                standbyArchiveFile.IntercomFile = m_intercomFile;
-                standbyArchiveFile.MetadataFile = m_metadataFile;
+        config.Save();
+    }
 
+    /// <summary>
+    /// Loads saved settings for the <see cref="ArchiveFile"/> from the config file if the <see cref="PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="SettingsCategory"/> has a value of null or empty string.</exception>
+    public void LoadSettings()
+    {
+        if (!PersistSettings)
+            return;
+        
+        // Ensure that settings category is specified.
+        if (string.IsNullOrEmpty(Name))
+            throw new ConfigurationErrorsException("SettingsCategory property has not been set");
+
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[Name];
+
+        settings.Add(nameof(FileName), m_fileName, "Name of the file including its path.");
+        settings.Add(nameof(FileType), m_fileType, "Type (Active; Standby; Historic) of the file.");
+        settings.Add(nameof(FileSize), m_fileSize, "Size (in MB) of the file. Typical size = 100.");
+        settings.Add(nameof(DataBlockSize), m_dataBlockSize, "Size (in KB) of the data blocks in the file.");
+        settings.Add(nameof(RolloverPreparationThreshold), m_rolloverPreparationThreshold, "Percentage file full when the rollover preparation should begin.");
+        settings.Add(nameof(ArchiveOffloadLocation), ArchiveOffloadLocation, "Path to the location where historic files are to be moved when disk start getting full. Set to *DELETE* to remove files instead of offloading.");
+        settings.Add(nameof(ArchiveOffloadCount), m_archiveOffloadCount, "Number of files that are to be moved to the offload location when the disk starts getting full.");
+        settings.Add(nameof(ArchiveOffloadThreshold), m_archiveOffloadThreshold, "Percentage disk full when the historic files should be moved to the offload location.");
+        settings.Add(nameof(ArchiveOffloadMaxAge), ArchiveOffloadMaxAge, "Maximum number of days before an archive file will be offloaded.");
+        settings.Add(nameof(MaxHistoricArchiveFiles), m_maxHistoricArchiveFiles, "Maximum number of historic files to be kept at both the primary and offload locations combined.");
+        settings.Add(nameof(LeadTimeTolerance), m_leadTimeTolerance, "Number of minutes by which incoming data points can be ahead of local system clock and still be considered valid.");
+        settings.Add(nameof(CompressData), CompressData, "True if compression (swinging door - lossy) is to be performed on the incoming data points; otherwise False.");
+        settings.Add(nameof(DiscardOutOfSequenceData), DiscardOutOfSequenceData, "True if out-of-sequence data points are to be discarded; otherwise False.");
+        settings.Add(nameof(CacheWrites), CacheWrites, "True if writes are to be cached for performance; otherwise False.");
+        settings.Add(nameof(ConserveMemory), m_conserveMemory, "True if attempts are to be made to conserve memory; otherwise False.");
+        settings.Add(nameof(MonitorNewArchiveFiles), MonitorNewArchiveFiles, "True to monitor and load newly encountered archive files; otherwise False.");
+
+        FileName = settings[nameof(FileName)].ValueAs(m_fileName);
+        FileType = settings[nameof(FileType)].ValueAs(m_fileType);
+        FileSize = settings[nameof(FileSize)].ValueAs(m_fileSize);
+        DataBlockSize = settings[nameof(DataBlockSize)].ValueAs(m_dataBlockSize);
+        RolloverPreparationThreshold = settings[nameof(RolloverPreparationThreshold)].ValueAs(m_rolloverPreparationThreshold);
+        ArchiveOffloadLocation = settings[nameof(ArchiveOffloadLocation)].ValueAs(ArchiveOffloadLocation);
+        ArchiveOffloadCount = settings[nameof(ArchiveOffloadCount)].ValueAs(m_archiveOffloadCount);
+        ArchiveOffloadThreshold = settings[nameof(ArchiveOffloadThreshold)].ValueAs(m_archiveOffloadThreshold);
+        ArchiveOffloadMaxAge = settings[nameof(ArchiveOffloadMaxAge)].ValueAs(ArchiveOffloadMaxAge);
+        MaxHistoricArchiveFiles = settings[nameof(MaxHistoricArchiveFiles)].ValueAs(m_maxHistoricArchiveFiles);
+        LeadTimeTolerance = settings[nameof(LeadTimeTolerance)].ValueAs(m_leadTimeTolerance);
+        CompressData = settings[nameof(CompressData)].ValueAs(CompressData);
+        DiscardOutOfSequenceData = settings[nameof(DiscardOutOfSequenceData)].ValueAs(DiscardOutOfSequenceData);
+        CacheWrites = settings[nameof(CacheWrites)].ValueAs(CacheWrites);
+        ConserveMemory = settings[nameof(ConserveMemory)].ValueAs(m_conserveMemory);
+    }
+
+    /// <summary>
+    /// Opens the <see cref="ArchiveFile"/> for use.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">One or all of the <see cref="StateFile"/>, <see cref="IntercomFile"/> or <see cref="MetadataFile"/> properties are not set.</exception>
+    public void Open()
+    {
+        if (IsOpen)
+            return;
+
+        // Check for the existence of dependencies.
+        if (StateFile is null || IntercomFile is null || m_metadataFile is null || m_fileName is null)
+            throw new InvalidOperationException("One or more of the dependency files are not specified.");
+
+        // Validate file type against its name.
+        if (Path.GetExtension(m_fileName).ToNonNullString().ToLower() == StandbyFileExtension)
+            m_fileType = ArchiveFileType.Standby;
+        else if (Regex.IsMatch(m_fileName.ToLower(), $".+_.+_to_.+\\{FileExtension}$"))
+            m_fileType = ArchiveFileType.Historic;
+        else
+            m_fileType = ArchiveFileType.Active;
+
+        // Get the absolute path for the file name.
+        m_fileName = FilePath.GetAbsolutePath(m_fileName);
+
+        // Create the directory if it does not exist.
+        if (!Directory.Exists(FilePath.GetDirectoryName(m_fileName)))
+            Directory.CreateDirectory(FilePath.GetDirectoryName(m_fileName));
+
+        // Validate a roll-over is not in progress when opening archive as read-only
+        if (m_fileType == ArchiveFileType.Active && m_fileAccessMode == FileAccess.Read)
+        {
+            // Open intercom file if closed.
+            if (!IntercomFile.IsOpen)
+                IntercomFile.Open();
+
+            IntercomFile.Load();
+            IntercomRecord record = IntercomFile.Read(1);
+            int waitCount = 0;
+
+            while (record is not null && record.RolloverInProgress && waitCount < 30)
+            {
+                Thread.Sleep(1000);
+                IntercomFile.Load();
+                record = IntercomFile.Read(1);
+                waitCount++;
+            }
+        }
+
+        OpenStream();
+
+        // Open state file if closed.
+        if (!StateFile.IsOpen)
+            StateFile.Open();
+
+        // Open intercom file if closed.
+        if (!IntercomFile.IsOpen)
+            IntercomFile.Open();
+
+        // Open metadata file if closed.
+        if (!m_metadataFile.IsOpen)
+            m_metadataFile.Open();
+
+        // Don't proceed further for standby and historic files.
+        if (m_fileType != ArchiveFileType.Active)
+            return;
+
+        // Start internal process queues.
+        m_currentDataQueue.Start();
+        m_historicDataQueue.Start();
+        m_outOfSequenceDataQueue.Start();
+
+        // Create data block lookup list.
+        if (StateFile.RecordsInMemory > 0)
+            m_dataBlocks = [..new ArchiveDataBlock[StateFile.RecordsInMemory]];
+        else
+            m_dataBlocks = [..new ArchiveDataBlock[StateFile.RecordsOnDisk]];
+
+        // Validate the dependency files.
+        SyncStateFile(null);
+
+        if (IntercomFile.FileAccessMode != FileAccess.Read)
+        {
+            // Ensure that "rollover in progress" is not set.
+            IntercomRecord system = IntercomFile.Read(1) ?? new IntercomRecord(1);
+            system.RolloverInProgress = false;
+            IntercomFile.Write(1, system);
+        }
+
+        // Start the memory conservation process.
+        if (m_conserveMemory)
+        {
+            m_conserveMemoryTimer.Interval = DataBlockCheckInterval;
+            m_conserveMemoryTimer.Start();
+        }
+
+        if (m_fileType != ArchiveFileType.Active)
+            return;
+
+        // Start preparing the list of historic files.
+        m_buildHistoricFileListThread = new Thread(BuildHistoricFileList) { Priority = ThreadPriority.Lowest };
+        m_buildHistoricFileListThread.Start();
+
+        // Start file watchers to monitor file system changes.
+        if (!MonitorNewArchiveFiles)
+            return;
+
+        if (m_currentLocationFileWatcher is not null)
+        {
+            m_currentLocationFileWatcher.Filter = HistoricFilesSearchPattern;
+            m_currentLocationFileWatcher.Path = FilePath.GetDirectoryName(m_fileName);
+            m_currentLocationFileWatcher.EnableRaisingEvents = true;
+        }
+
+        if (Directory.Exists(ArchiveOffloadLocation) && m_offloadLocationFileWatcher is not null)
+        {
+            m_offloadLocationFileWatcher.Filter = HistoricFilesSearchPattern;
+            m_offloadLocationFileWatcher.Path = ArchiveOffloadLocation;
+            m_offloadLocationFileWatcher.EnableRaisingEvents = true;
+        }
+    }
+
+    /// <summary>
+    /// Closes the <see cref="ArchiveFile"/> if it <see cref="IsOpen"/>.
+    /// </summary>
+    public void Close()
+    {
+        if (!IsOpen)
+            return;
+
+        // Abort all asynchronous processing.
+        m_rolloverPreparationThread.Abort();
+        m_buildHistoricFileListThread.Abort();
+
+        // Stop all timer based processing.
+        m_conserveMemoryTimer.Stop();
+
+        // Stop the historic and out-of-sequence data queues.
+        m_currentDataQueue.Flush();
+        m_historicDataQueue.Flush();
+        m_outOfSequenceDataQueue.Flush();
+
+        CloseStream();
+
+        if (m_dataBlocks is not null)
+        {
+            lock (m_dataBlocks)
+                m_dataBlocks.Clear();
+            
+            m_dataBlocks = null;
+        }
+
+        // Stop watching for historic archive files.
+        if (m_currentLocationFileWatcher is not null)
+            m_currentLocationFileWatcher.EnableRaisingEvents = false;
+
+        if (m_offloadLocationFileWatcher is not null)
+            m_offloadLocationFileWatcher.EnableRaisingEvents = false;
+
+        // Clear the list of historic archive files.
+        if (m_historicArchiveFiles is not null)
+        {
+            lock (m_historicArchiveFiles)
+                m_historicArchiveFiles.Clear();
+            
+            m_historicArchiveFiles = null;
+        }
+    }
+
+    /// <summary>
+    /// Saves the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="ArchiveFile"/> is not open.</exception>
+    public void Save()
+    {
+        if (IsOpen)
+            Fat.Save();
+        else
+            throw new InvalidOperationException($"\"{m_fileName}\" is not open");
+    }
+
+    /// <summary>
+    /// Performs rollover of active <see cref="ArchiveFile"/> to a new <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="ArchiveFile"/> is not <see cref="ArchiveFileType.Active"/>.</exception>
+    public void Rollover()
+    {
+        if (m_fileType != ArchiveFileType.Active)
+            throw new InvalidOperationException("Cannot rollover a file that is not active");
+
+        try
+        {
+            // Notify internal components about the rollover.
+            RolloverWaitHandle.Reset();
+
+            // Raise roll-over start event - this also sets m_rolloverInProgress flag
+            OnRolloverStart();
+
+            // Notify external components about the rollover.
+            IntercomRecord system = IntercomFile.Read(1);
+            system.DataBlocksUsed = 0;
+            system.RolloverInProgress = true;
+            system.LatestDataID = -1;
+            system.LatestDataTime = TimeTag.MinValue;
+            IntercomFile.Write(1, system);
+            IntercomFile.Save();
+
+            // Figure out the end date for this file.
+            TimeTag endTime = Fat.FileEndTime;
+
+            for (int i = 1; i <= StateFile.RecordsOnDisk; i++)
+            {
+                StateRecord state = StateFile.Read(i);
+                state.ActiveDataBlockIndex = -1;
+                state.ActiveDataBlockSlot = 1;
+
+                if (state.ArchivedData.Time.CompareTo(endTime) > 0)
+                    endTime = state.ArchivedData.Time;
+
+                StateFile.Write(state.HistorianID, state);
+            }
+
+            Fat.FileEndTime = endTime;
+
+            StateFile.Save();
+            Save();
+
+            // Wait for any pending readers to release
+            WaitForReadersRelease();
+
+            // Clear all the cached data blocks.
+            lock (m_dataBlocks)
+            {
+                for (int i = 0; i < m_dataBlocks.Count; i++)
+                {
+                    m_dataBlocks[i] = null;
+                }
+            }
+
+            string historyFileName = HistoryArchiveFileName;
+            string standbyFileName = StandbyArchiveFileName;
+
+            CloseStream();
+
+            // CRITICAL: Exception can be encountered if exclusive lock to the current file cannot be obtained.
+            if (File.Exists(m_fileName))
+            {
                 try
                 {
-                    standbyArchiveFile.Open();
+                    FilePath.WaitForWriteLock(m_fileName, 60);  // Wait for an exclusive lock on the file.
+                    MoveFile(m_fileName, historyFileName);      // Make the active archive file historic.
+
+                    if (File.Exists(standbyFileName))
+                    {
+                        // We have a "standby" archive file for us to use, so we'll use it. It is possible that
+                        // the "standby" file may not be available for use if it could not be created due to
+                        // insufficient disk space during the "rollover preparation stage". If that's the case,
+                        // Open() below will try to create a new archive file, but will only succeed if there
+                        // is enough disk space.
+                        MoveFile(standbyFileName, m_fileName); // Make the standby archive file active.
+                    }
                 }
                 catch
                 {
-                    string standbyFileName = standbyArchiveFile.FileName;
-                    standbyArchiveFile.Close();
-
-                    // We didn't succeed in creating a "standby" archive file, so we'll delete it if it was created
-                    // partially (might happen if there isn't enough disk space or thread is aborted). This is to
-                    // ensure that this preparation processes is kicked off again until a valid "standby" archive
-                    // file is successfully created.
-                    DeleteFile(standbyFileName);
-
-                    throw; // Rethrow the exception so the appropriate action is taken.
-                }
-                finally
-                {
-                    standbyArchiveFile.Dispose();
-                }
-
-                OnRolloverPreparationComplete();
-            }
-            catch (ThreadAbortException)
-            {
-                // This thread must die now...
-            }
-            catch (Exception ex)
-            {
-                OnRolloverPreparationException(ex);
-            }
-        }
-
-        private void OffloadMaxAgedFiles()
-        {
-            if (Directory.Exists(m_archiveOffloadLocation))
-            {
-                // Wait until the historic file list has been built.
-                if (m_buildHistoricFileListThread.IsAlive)
-                    m_buildHistoricFileListThread.Join();
-
-                try
-                {
-                    OnOffloadStart();
-
-                    // The offload path that is specified is a valid one so we'll gather a list of all historic
-                    // files in the directory where the current (active) archive file is located.
-                    List<Info> newHistoricFiles;
-
-                    lock (m_historicArchiveFiles)
-                    {
-                        newHistoricFiles = m_historicArchiveFiles.FindAll(info => IsNewHistoricArchiveFile(info, m_fileName));
-                    }
-
-                    // Sorting the list will sort the historic files from oldest to newest.
-                    newHistoricFiles.Sort();
-
-                    List<Info> filesToOffload = new List<Info>();
-
-                    foreach (Info file in newHistoricFiles)
-                    {
-                        if ((DateTime.UtcNow - file.StartTimeTag.ToDateTime()).TotalDays > m_archiveOffloadMaxAge)
-                            filesToOffload.Add(file);
-                    }
-
-                    // We'll offload the specified number of oldest historic files to the offload location if the
-                    // number of historic files is more than the offload count or all of the historic files if the
-                    // offload count is smaller the available number of historic files.
-                    ProcessProgress<int> offloadProgress = new ProcessProgress<int>("FileOffload");
-
-                    offloadProgress.Total = filesToOffload.Count;
-
-                    for (int i = 0; i < offloadProgress.Total; i++)
-                    {
-                        // Don't attempt to offload active file
-                        if (string.Compare(filesToOffload[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) != 0)
-                        {
-                            string destinationFileName = FilePath.AddPathSuffix(m_archiveOffloadLocation) + FilePath.GetFileName(filesToOffload[i].FileName);
-
-                            try
-                            {
-                                DeleteFile(destinationFileName);
-                                MoveFile(filesToOffload[i].FileName, destinationFileName);
-                            }
-                            catch (Exception ex)
-                            {
-                                OnOffloadException(new InvalidOperationException(string.Format("Failed to offload historic file \"{0}\": {1}", FilePath.GetFileName(filesToOffload[i].FileName), ex.Message), ex));
-                            }
-
-                            offloadProgress.Complete++;
-                            offloadProgress.ProgressMessage = FilePath.GetFileName(filesToOffload[i].FileName);
-
-                            OnOffloadProgress(offloadProgress);
-                        }
-                    }
-
-                    OnOffloadComplete();
-                }
-                catch (ThreadAbortException)
-                {
+                    OpenStream();
                     throw;
                 }
-                catch (Exception ex)
-                {
-                    OnOffloadException(ex);
-                }
             }
-            else if (string.Compare(m_archiveOffloadLocation.ToNonNullString().Trim(), "*DELETE*", StringComparison.OrdinalIgnoreCase) == 0)
+
+            // CRITICAL: Exception can be encountered if a "standby" archive is not present for us to use, and
+            //           we cannot create a new archive file probably because there isn't enough disk space.
+            try
             {
-                // Handle case where user has requested historic files be deleted instead of offloaded
+                OpenStream();
 
-                // Wait until the historic file list has been built.
-                if (m_buildHistoricFileListThread.IsAlive)
-                    m_buildHistoricFileListThread.Join();
+                Fat.FileStartTime = endTime;
+                Fat.Save();
 
-                try
-                {
-                    OnOffloadStart();
+                // Notify server that rollover is complete.
+                system.RolloverInProgress = false;
+                IntercomFile.Write(1, system);
+                IntercomFile.Save();
 
-                    // Get a local copy of all the historic archive files.
-                    List<Info> allHistoricFiles;
+                // Raise roll-over complete event - this also resets m_rolloverInProgress flag
+                OnRolloverComplete();
 
-                    lock (m_historicArchiveFiles)
-                    {
-                        allHistoricFiles = new List<Info>(m_historicArchiveFiles);
-                    }
-
-                    // Start deleting historic files from oldest to newest.
-                    allHistoricFiles.Sort();
-
-                    List<Info> filesToDelete = new List<Info>();
-
-                    foreach (Info file in allHistoricFiles)
-                    {
-                        if ((DateTime.UtcNow - file.StartTimeTag.ToDateTime()).TotalDays > m_archiveOffloadMaxAge)
-                            filesToDelete.Add(file);
-                    }
-
-                    ProcessProgress<int> offloadProgress = new ProcessProgress<int>("FileOffload");
-                    offloadProgress.Total = filesToDelete.Count;
-
-                    for (int i = 0; i < filesToDelete.Count; i++)
-                    {
-                        // Don't attempt to offload active file
-                        if (string.Compare(filesToDelete[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) != 0)
-                        {
-                            try
-                            {
-                                DeleteFile(filesToDelete[i].FileName);
-                            }
-                            catch (Exception ex)
-                            {
-                                OnOffloadException(new InvalidOperationException(string.Format("Failed to remove historic file \"{0}\": {1}", FilePath.GetFileName(filesToDelete[i].FileName), ex.Message), ex));
-                            }
-                        }
-
-                        offloadProgress.Complete++;
-                        offloadProgress.ProgressMessage = FilePath.GetFileName(filesToDelete[i].FileName);
-
-                        OnOffloadProgress(offloadProgress);
-                    }
-
-                    OnOffloadComplete();
-                }
-                catch (ThreadAbortException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    OnOffloadException(ex);
-                }
+                // Notify other threads that rollover is complete.
+                RolloverWaitHandle.Set();
+            }
+            catch
+            {
+                CloseStream(); // Close the file if we fail to open it.
+                DeleteFile(m_fileName);
+                throw; // Rethrow the exception so that the exception event can be raised.
             }
         }
-
-        private void OffloadHistoricFiles()
+        catch (Exception ex)
         {
-            if (Directory.Exists(m_archiveOffloadLocation))
-            {
-                // Wait until the historic file list has been built.
-                if (m_buildHistoricFileListThread.IsAlive)
-                    m_buildHistoricFileListThread.Join();
+            // Raise roll-over exception event if there is an error - this will also reset m_rolloverInProgress flag
+            OnRolloverException(ex);
+        }
+    }
 
-                try
-                {
-                    OnOffloadStart();
+    /// <summary>
+    /// Requests a resynchronization of the state file.
+    /// </summary>
+    public void SynchronizeStateFile()
+    {
+        ThreadPool.QueueUserWorkItem(SyncStateFile);
+    }
 
-                    // The offload path that is specified is a valid one so we'll gather a list of all historic
-                    // files in the directory where the current (active) archive file is located.
-                    List<Info> newHistoricFiles;
+    /// <summary>
+    /// Writes the specified <paramref name="dataPoint"/> to the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to be written.</param>
+    public void WriteData(IDataPoint dataPoint)
+    {
+        // Yield to archive rollover process.
+        RolloverWaitHandle.WaitOne();
 
-                    lock (m_historicArchiveFiles)
-                    {
-                        newHistoricFiles = m_historicArchiveFiles.FindAll(info => IsNewHistoricArchiveFile(info, m_fileName));
-                    }
+        // Ensure that the current file is open.
+        if (!IsOpen)
+            throw new InvalidOperationException($"\"{m_fileName}\" file is not open");
 
-                    // Sorting the list will sort the historic files from oldest to newest.
-                    newHistoricFiles.Sort();
+        // Ensure that the current file is active.
+        if (m_fileType != ArchiveFileType.Active)
+            throw new InvalidOperationException("Data can only be directly written to files that are Active");
 
-                    // We'll offload the specified number of oldest historic files to the offload location if the
-                    // number of historic files is more than the offload count or all of the historic files if the
-                    // offload count is smaller the available number of historic files.
-                    ProcessProgress<int> offloadProgress = new ProcessProgress<int>("FileOffload");
+        m_currentDataQueue.Add(dataPoint);
+    }
 
-                    offloadProgress.Total = (newHistoricFiles.Count < m_archiveOffloadCount ? newHistoricFiles.Count : m_archiveOffloadCount);
+    /// <summary>
+    /// Writes the specified <paramref name="dataPoints"/> to the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="dataPoints"><see cref="ArchiveDataPoint"/> points to be written.</param>
+    public void WriteData(IEnumerable<IDataPoint> dataPoints)
+    {
+        foreach (IDataPoint dataPoint in dataPoints)
+            WriteData(dataPoint);
+    }
 
-                    for (int i = 0; i < offloadProgress.Total; i++)
-                    {
-                        // Don't attempt to offload active file
-                        if (string.Compare(newHistoricFiles[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) != 0)
-                        {
-                            string destinationFileName = FilePath.AddPathSuffix(m_archiveOffloadLocation) + FilePath.GetFileName(newHistoricFiles[i].FileName);
+    /// <summary>
+    /// Writes <paramref name="metadata"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="metadata"><see cref="MetadataRecord"/> data.</param>
+    public void WriteMetaData(int historianID, byte[] metadata)
+    {
+        MetadataFile.Write(historianID, new MetadataRecord(historianID, MetadataFile.LegacyMode, metadata, 0, metadata.Length));
+        MetadataFile.Save();
+    }
 
-                            try
-                            {
-                                DeleteFile(destinationFileName);
-                                MoveFile(newHistoricFiles[i].FileName, destinationFileName);
-                            }
-                            catch (Exception ex)
-                            {
-                                OnOffloadException(new InvalidOperationException(string.Format("Failed to offload historic file \"{0}\": {1}", FilePath.GetFileName(newHistoricFiles[i].FileName), ex.Message), ex));
-                            }
+    /// <summary>
+    /// Writes <paramref name="statedata"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="statedata"><see cref="StateRecord"/> data.</param>
+    public void WriteStateData(int historianID, byte[] statedata)
+    {
+        StateFile.Write(historianID, new StateRecord(historianID, statedata, 0, statedata.Length));
+        StateFile.Save();
+    }
 
-                            offloadProgress.Complete++;
-                            offloadProgress.ProgressMessage = FilePath.GetFileName(newHistoricFiles[i].FileName);
+    /// <summary>
+    /// Reads all <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(int historianID, bool timeSorted = true)
+    {
+        return ReadData(historianID, TimeTag.MinValue, timeSorted);
+    }
 
-                            OnOffloadProgress(offloadProgress);
-                        }
-                    }
+    /// <summary>
+    /// Reads all <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/> for the specified <paramref name="historianIDs"/>.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, bool timeSorted = true)
+    {
+        return ReadData(historianIDs, TimeTag.MinValue, timeSorted);
+    }
 
-                    OnOffloadComplete();
-                }
-                catch (ThreadAbortException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    OnOffloadException(ex);
-                }
-            }
-            else if (string.Compare(m_archiveOffloadLocation.ToNonNullString().Trim(), "*DELETE*", StringComparison.OrdinalIgnoreCase) == 0)
-            {
-                // Handle case where user has requested historic files be deleted instead of offloaded
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(int historianID, string startTime, bool timeSorted = true)
+    {
+        return ReadData(historianID, startTime, TimeTag.MinValue.ToString(), timeSorted);
+    }
 
-                // Wait until the historic file list has been built.
-                if (m_buildHistoricFileListThread.IsAlive)
-                    m_buildHistoricFileListThread.Join();
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, bool timeSorted = true)
+    {
+        return ReadData(historianIDs, startTime, TimeTag.MinValue.ToString(), timeSorted);
+    }
 
-                try
-                {
-                    OnOffloadStart();
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(int historianID, string startTime, string endTime, bool timeSorted = true)
+    {
+        return ReadData(historianID, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
+    }
 
-                    // Get a local copy of all the historic archive files.
-                    List<Info> allHistoricFiles;
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime"><see cref="String"/> representation of the start time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, string endTime, bool timeSorted = true)
+    {
+        return ReadData(historianIDs, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
+    }
 
-                    lock (m_historicArchiveFiles)
-                    {
-                        allHistoricFiles = new List<Info>(m_historicArchiveFiles);
-                    }
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, bool timeSorted = true)
+    {
+        return ReadData(historianID, startTime, TimeTag.MinValue.ToDateTime(), timeSorted);
+    }
 
-                    // Determine total number of files to remove
-                    int filesToDelete = Common.Min(m_archiveOffloadCount, allHistoricFiles.Count);
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, bool timeSorted = true)
+    {
+        return ReadData(historianIDs, startTime, TimeTag.MinValue.ToDateTime(), timeSorted);
+    }
 
-                    ProcessProgress<int> offloadProgress = new ProcessProgress<int>("FileOffload");
-                    offloadProgress.Total = filesToDelete;
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, DateTime endTime, bool timeSorted = true)
+    {
+        return ReadData(historianID, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
+    }
 
-                    // Start deleting historic files from oldest to newest.
-                    allHistoricFiles.Sort();
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, DateTime endTime, bool timeSorted = true)
+    {
+        return ReadData(historianIDs, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
+    }
 
-                    for (int i = 0; i < filesToDelete; i++)
-                    {
-                        // Don't attempt to offload active file
-                        if (string.Compare(allHistoricFiles[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) != 0)
-                        {
-                            try
-                            {
-                                DeleteFile(allHistoricFiles[i].FileName);
-                            }
-                            catch (Exception ex)
-                            {
-                                OnOffloadException(new InvalidOperationException(string.Format("Failed to remove historic file \"{0}\": {1}", FilePath.GetFileName(allHistoricFiles[i].FileName), ex.Message), ex));
-                            }
-                        }
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(int historianID, TimeTag startTime, bool timeSorted = true)
+    {
+        return ReadData(historianID, startTime, TimeTag.MaxValue, timeSorted);
+    }
 
-                        offloadProgress.Complete++;
-                        offloadProgress.ProgressMessage = FilePath.GetFileName(allHistoricFiles[i].FileName);
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, bool timeSorted = true)
+    {
+        return ReadData(historianIDs, startTime, TimeTag.MaxValue, timeSorted);
+    }
 
-                        OnOffloadProgress(offloadProgress);
-                    }
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(int historianID, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
+    {
+        return ReadData([historianID], startTime, endTime, timeSorted);
+    }
 
-                    OnOffloadComplete();
-                }
-                catch (ThreadAbortException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    OnOffloadException(ex);
-                }
-            }
+    /// <summary>
+    /// Reads <see cref="ArchiveDataPoint"/>s from the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="ArchiveDataPoint"/>s are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
+    {
+        return ReadData(historianIDs, startTime, endTime, null, timeSorted);
+    }
+
+    // Read data implementation
+    private IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, TimeTag endTime, IDataPoint resumeFrom, bool timeSorted)
+    {
+        // Yield to archive rollover process.
+        RolloverWaitHandle.WaitOne();
+
+        // Ensure that the current file is open.
+        if (!IsOpen)
+            throw new InvalidOperationException($"\"{m_fileName}\" file is not open");
+
+        // Ensure that the current file is active.
+        if (m_fileType != ArchiveFileType.Active)
+            throw new InvalidOperationException("Data can only be directly read from files that are Active");
+
+        // Ensure that the start and end time are valid.
+        if (startTime.CompareTo(endTime) > 0)
+            throw new ArgumentException("End Time precedes Start Time in the specified time span");
+
+        List<Info> dataFiles = [];
+        bool pendingRollover = false;
+        bool usingActiveFile = false;
+
+        if (startTime.CompareTo(Fat.FileStartTime) < 0)
+        {
+            // Data is to be read from historic file(s) - make sure that the list has been built
+            if (m_buildHistoricFileListThread.IsAlive)
+                m_buildHistoricFileListThread.Join();
+
+            lock (m_historicArchiveFiles)
+                dataFiles.AddRange(m_historicArchiveFiles.FindAll(info => FindHistoricArchiveFileForRead(info, startTime, endTime)));
         }
 
-        private void MaintainMaximumNumberOfHistoricFiles()
+        if (endTime.CompareTo(Fat.FileStartTime) >= 0)
         {
-            if (m_maxHistoricArchiveFiles >= 1)
+            // Data is to be read from the active file.
+            Info activeFileInfo = new(m_fileName)
             {
-                // Wait until the historic file list has been built.
-                if (m_buildHistoricFileListThread.IsAlive)
-                    m_buildHistoricFileListThread.Join();
+                StartTimeTag = Fat.FileStartTime,
+                EndTimeTag = Fat.FileEndTime
+            };
 
-                // Get a local copy of all the historic archive files.
-                List<Info> allHistoricFiles;
-
-                lock (m_historicArchiveFiles)
-                {
-                    allHistoricFiles = new List<Info>(m_historicArchiveFiles);
-                }
-
-                // Start deleting historic files from oldest to newest.
-                if (allHistoricFiles.Count > m_maxHistoricArchiveFiles)
-                {
-                    allHistoricFiles.Sort();
-
-                    while (allHistoricFiles.Count > m_maxHistoricArchiveFiles)
-                    {
-                        try
-                        {
-                            DeleteFile(allHistoricFiles[0].FileName);
-                        }
-                        catch (Exception ex)
-                        {
-                            OnOffloadException(new InvalidOperationException(string.Format("Failed during attempt to maintain maximum number of historic files - file \"{0}\" could not be deleted: {1}", FilePath.GetFileName(allHistoricFiles[0].FileName), ex.Message), ex));
-                        }
-                        finally
-                        {
-                            allHistoricFiles.RemoveAt(0);
-                        }
-                    }
-                }
-            }
+            dataFiles.Add(activeFileInfo);
         }
 
-        private Info GetHistoricFileInfo(string fileName)
+        // Read data from all qualifying files.
+        foreach (Info dataFile in dataFiles)
         {
-            Info fileInfo = null;
+            ArchiveFile file = null;
 
             try
             {
-                // Validate the file name to determine whether the given file is actually a historic file
-                if (!Regex.IsMatch(fileName, string.Format(".+_.+_to_.+\\{0}$", FileExtension)))
-                    return null;
-
-                if (File.Exists(fileName))
+                if (string.Compare(dataFile.FileName, m_fileName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    // We'll open the file and get relevant information about it.
-                    ArchiveFile historicArchiveFile = new ArchiveFile();
+                    // Read data from current file.
+                    usingActiveFile = true;
+                    file = this;
 
-                    historicArchiveFile.FileName = fileName;
-                    historicArchiveFile.StateFile = m_stateFile;
-                    historicArchiveFile.IntercomFile = m_intercomFile;
-                    historicArchiveFile.MetadataFile = m_metadataFile;
-                    historicArchiveFile.FileAccessMode = FileAccess.Read;
+                    // Atomically increment total number of readers for active file
+                    Interlocked.Increment(ref m_activeFileReaders);
 
-                    try
+                    // Handle race conditions between rollover
+                    // and incrementing the active readers
+                    while (m_rolloverInProgress)
                     {
-                        historicArchiveFile.Open();
-
-                        fileInfo = new Info(fileName)
-                        {
-                            StartTimeTag = historicArchiveFile.Fat.FileStartTime,
-                            EndTimeTag = historicArchiveFile.Fat.FileEndTime
-                        };
-                    }
-                    catch (Exception ex)
-                    {
-                        OnHistoricFileListBuildException(new InvalidOperationException(string.Format("Failed to open historic data file \"{0}\" due to exception: {1}", FilePath.GetFileName(fileName), ex.Message), ex));
-                    }
-                    finally
-                    {
-                        historicArchiveFile.Dispose();
+                        Interlocked.Decrement(ref m_activeFileReaders);
+                        RolloverWaitHandle.WaitOne();
+                        Interlocked.Increment(ref m_activeFileReaders);
                     }
                 }
                 else
                 {
-                    // We'll resolve to getting the file information from its name only if the file no longer exists
-                    // at the location. This will be the case when file is moved to a different location. In this
-                    // case the file information we provide is only as good as the file name.
-                    string datesString = FilePath.GetFileNameWithoutExtension(fileName).Substring((FilePath.GetFileNameWithoutExtension(m_fileName) + "_").Length);
-                    string[] fileStartEndDates = datesString.Split(new string[] { "_to_" }, StringSplitOptions.None);
-
-                    fileInfo = new Info(fileName);
-
-                    if (fileStartEndDates.Length == 2)
-                    {
-                        fileInfo.StartTimeTag = new TimeTag(Convert.ToDateTime(fileStartEndDates[0].Replace('!', ':')));
-                        fileInfo.EndTimeTag = new TimeTag(Convert.ToDateTime(fileStartEndDates[1].Replace('!', ':')));
-                    }
+                    // Read data from historic file.
+                    usingActiveFile = false;
+                    file = new ArchiveFile();
+                    file.FileName = dataFile.FileName;
+                    file.StateFile = StateFile;
+                    file.IntercomFile = IntercomFile;
+                    file.MetadataFile = m_metadataFile;
+                    file.FileAccessMode = FileAccess.Read;
+                    file.Open();
                 }
-            }
-            catch (Exception ex)
-            {
-                OnHistoricFileListBuildException(new InvalidOperationException(string.Format("Failed during information access attempt for historic data file \"{0}\" due to exception: {1}", FilePath.GetFileName(fileName), ex.Message), ex));
-            }
 
-            return fileInfo;
-        }
+                // Create new data point scanner for the desired points in this file and given time range
+                IArchiveFileScanner scanner;
 
-        #endregion
+                if (timeSorted)
+                    scanner = new TimeSortedArchiveFileScanner();
+                else
+                    scanner = new ArchiveFileScanner();
 
-        #region [ Find Predicates ]
+                scanner.FileAllocationTable = file.Fat;
+                scanner.HistorianIDs = historianIDs;
+                scanner.StartTime = startTime;
+                scanner.EndTime = endTime;
+                scanner.ResumeFrom = resumeFrom;
+                scanner.DataReadExceptionHandler = (_, e) => OnDataReadException(e.Argument);
 
-        private bool FindHistoricArchiveFileForRead(Info fileInfo, TimeTag startTime, TimeTag endTime)
-        {
-            return ((object)fileInfo != null &&
-                ((startTime.CompareTo(fileInfo.StartTimeTag) >= 0 && startTime.CompareTo(fileInfo.EndTimeTag) <= 0) ||
-                (endTime.CompareTo(fileInfo.StartTimeTag) >= 0 && endTime.CompareTo(fileInfo.EndTimeTag) <= 0) ||
-                (startTime.CompareTo(fileInfo.StartTimeTag) < 0 && endTime.CompareTo(fileInfo.EndTimeTag) > 0)));
-        }
+                // Reset resumeFrom to scan from beginning after picking up where left off from roll over
+                resumeFrom = null;
 
-        private bool FindHistoricArchiveFileForWrite(Info fileInfo, TimeTag searchTime)
-        {
-            return ((object)fileInfo != null &&
-                    searchTime.CompareTo(fileInfo.StartTimeTag) >= 0 &&
-                    searchTime.CompareTo(fileInfo.EndTimeTag) <= 0);
-        }
-
-        // Determines if the historic file is in the primary archive location (not offloaded).
-        private bool IsNewHistoricArchiveFile(Info fileInfo, string fileName)
-        {
-            return ((object)fileInfo != null &&
-                    string.Compare(FilePath.GetDirectoryName(fileName), FilePath.GetDirectoryName(fileInfo.FileName), StringComparison.OrdinalIgnoreCase) == 0);
-        }
-
-        #endregion
-
-        #region [ Queue Delegates ]
-
-        private void WriteToCurrentArchiveFile(IDataPoint[] items)
-        {
-            Dictionary<int, List<IDataPoint>> sortedDataPoints = new Dictionary<int, List<IDataPoint>>();
-            Exception ex;
-
-            // First we'll separate all point data by ID.
-            for (int i = 0; i < items.Length; i++)
-            {
-                if (!sortedDataPoints.ContainsKey(items[i].HistorianID))
-                    sortedDataPoints.Add(items[i].HistorianID, new List<IDataPoint>());
-
-                sortedDataPoints[items[i].HistorianID].Add(items[i]);
-            }
-
-            IntercomRecord system = m_intercomFile.Read(1);
-
-            foreach (int pointID in sortedDataPoints.Keys)
-            {
-                // Initialize local variables.
-                StateRecord state = m_stateFile.Read(pointID);
-                MetadataRecord metadata = m_metadataFile.Read(pointID);
-                IDataPoint dataPoint;
-
-                for (int i = 0; i < sortedDataPoints[pointID].Count; i++)
+                // Return data points
+                foreach (IDataPoint dataPoint in scanner.Read())
                 {
-                    dataPoint = sortedDataPoints[pointID][i];
+                    yield return dataPoint;
 
-                    // Ensure that the received data is to be archived.
-                    if ((object)state == null || (object)metadata == null || !metadata.GeneralFlags.Enabled)
+                    // If a rollover needs to happen, we need to relinquish read lock and close file
+                    if (m_rolloverInProgress)
                     {
-                        OnOrphanDataReceived(dataPoint);
-                        continue;
+                        resumeFrom = dataPoint;
+                        pendingRollover = true;
+                        break;
                     }
-
-                    // Ensure that data is not far out in to the future.
-                    if (dataPoint.Time > DateTime.UtcNow.AddMinutes(m_leadTimeTolerance))
-                    {
-                        OnFutureDataReceived(dataPoint);
-                        continue;
-                    }
-
-                    // Perform quality check if data quality is not set.
-                    if ((int)dataPoint.Quality == 31)
-                    {
-                        // Note: Here we're checking if the Quality is 31 instead of -1 because the quality value is stored
-                        // in the first 5 bits (QualityMask = 31) of Flags in the point data. Initially when the Quality is
-                        // set to -1, all the bits Flags (a 32-bit integer) are set to 1. And therefore, when we get the
-                        // Quality, which is a masked value of Flags, we get 31 and not -1.
-                        switch (metadata.GeneralFlags.DataType)
-                        {
-                            case DataType.Analog:
-                                if (dataPoint.Value >= metadata.AnalogFields.HighRange)
-                                    dataPoint.Quality = Quality.UnreasonableHigh;
-                                else if (dataPoint.Value >= metadata.AnalogFields.HighAlarm)
-                                    dataPoint.Quality = Quality.ValueAboveHiHiAlarm;
-                                else if (dataPoint.Value >= metadata.AnalogFields.HighWarning)
-                                    dataPoint.Quality = Quality.ValueAboveHiAlarm;
-                                else if (dataPoint.Value <= metadata.AnalogFields.LowRange)
-                                    dataPoint.Quality = Quality.UnreasonableLow;
-                                else if (dataPoint.Value <= metadata.AnalogFields.LowAlarm)
-                                    dataPoint.Quality = Quality.ValueBelowLoLoAlarm;
-                                else if (dataPoint.Value <= metadata.AnalogFields.LowWarning)
-                                    dataPoint.Quality = Quality.ValueBelowLoAlarm;
-                                else
-                                    dataPoint.Quality = Quality.Good;
-                                break;
-                            case DataType.Digital:
-                                if ((int)dataPoint.Value == metadata.DigitalFields.AlarmState)
-                                    dataPoint.Quality = Quality.LogicalAlarm;
-                                else
-                                    dataPoint.Quality = Quality.Good;
-                                break;
-                        }
-                    }
-
-                    // Update information about the latest data point received.
-                    if (dataPoint.Time.CompareTo(system.LatestDataTime) > 0)
-                    {
-                        system.LatestDataID = dataPoint.HistorianID;
-                        system.LatestDataTime = dataPoint.Time;
-                        m_intercomFile.Write(1, system);
-                    }
-
-                    // Check for data that out-of-sequence based on it's time.
-                    if (dataPoint.Time.CompareTo(state.PreviousData.Time) <= 0)
-                    {
-                        if (dataPoint.Time == state.PreviousData.Time)
-                        {
-                            // Discard data that is an exact duplicate of data in line for archival.
-                            if (dataPoint.Value == state.PreviousData.Value && dataPoint.Quality == state.PreviousData.Quality)
-                                continue;
-                        }
-                        else
-                        {
-                            // Queue out-of-sequence data for processing if it is not be discarded.
-                            if (!m_discardOutOfSequenceData)
-                                m_outOfSequenceDataQueue.Add(dataPoint);
-
-                            OnOutOfSequenceDataReceived(dataPoint);
-                            continue;
-                        }
-                    }
-
-                    // [BEGIN]   Data compression
-                    bool archiveData = false;
-                    bool calculateSlopes = false;
-                    float compressionLimit = metadata.AnalogFields.CompressionLimit;
-
-                    // Set the compression limit to a very low number for digital points.
-                    if (metadata.GeneralFlags.DataType == DataType.Digital)
-                        compressionLimit = 0.000000001f;
-
-                    state.CurrentData = new StateRecordDataPoint(dataPoint);
-
-                    if (state.ArchivedData.IsEmpty)
-                    {
-                        // This is the first time data is received.
-                        state.CurrentData = new StateRecordDataPoint(-1);
-                        archiveData = true;
-                    }
-                    else if (state.PreviousData.IsEmpty)
-                    {
-                        // This is the second time data is received.
-                        calculateSlopes = true;
-                    }
-                    else
-                    {
-                        // Process quality-based alarming if enabled.
-                        if (metadata.GeneralFlags.AlarmEnabled)
-                        {
-                            if (metadata.AlarmFlags.Value.CheckBits(BitExtensions.BitVal((int)state.CurrentData.Quality)))
-                            {
-                                // Current data quality warrants alarming based on the alarming settings.
-                                decimal delay = 0;
-                                switch (metadata.GeneralFlags.DataType)
-                                {
-                                    case DataType.Analog:
-                                        delay = (decimal)metadata.AnalogFields.AlarmDelay;
-                                        break;
-                                    case DataType.Digital:
-                                        delay = (decimal)metadata.DigitalFields.AlarmDelay;
-                                        break;
-                                }
-
-                                // Dispatch the alarm immediately or after a given time based on settings.
-                                if (delay > 0)
-                                {
-                                    // Wait before dispatching alarm.
-                                    decimal first;
-                                    if (m_delayedAlarmProcessing.TryGetValue(dataPoint.HistorianID, out first))
-                                    {
-                                        if (state.CurrentData.Time.Value - first > delay)
-                                        {
-                                            // Wait is now over, dispatch the alarm.
-                                            m_delayedAlarmProcessing.Remove(dataPoint.HistorianID);
-                                            OnProcessAlarmNotification(state);
-                                        }
-                                    }
-                                    else
-                                    {
-                                        m_delayedAlarmProcessing.Add(state.HistorianID, state.CurrentData.Time.Value);
-                                    }
-                                }
-                                else
-                                {
-                                    // Dispatch the alarm immediately.
-                                    OnProcessAlarmNotification(state);
-                                }
-                            }
-                            else
-                            {
-                                m_delayedAlarmProcessing.Remove(dataPoint.HistorianID);
-                            }
-                        }
-
-                        if (m_compressData)
-                        {
-                            // Data is to be compressed.
-                            if (metadata.CompressionMinTime > 0 && state.CurrentData.Time.Value - state.ArchivedData.Time.Value < metadata.CompressionMinTime)
-                            {
-                                // CompressionMinTime is in effect.
-                                archiveData = false;
-                                calculateSlopes = false;
-                            }
-                            else if (state.CurrentData.Quality != state.ArchivedData.Quality || state.CurrentData.Quality != state.PreviousData.Quality || (metadata.CompressionMaxTime > 0 && state.PreviousData.Time.Value - state.ArchivedData.Time.Value > metadata.CompressionMaxTime))
-                            {
-                                // Quality changed or CompressionMaxTime is exceeded.
-                                dataPoint = new ArchiveDataPoint(state.PreviousData);
-                                archiveData = true;
-                                calculateSlopes = true;
-                            }
-                            else
-                            {
-                                // Perform a compression test.
-                                double slope1;
-                                double slope2;
-                                double currentSlope;
-
-                                slope1 = (state.CurrentData.Value - (state.ArchivedData.Value + compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
-                                slope2 = (state.CurrentData.Value - (state.ArchivedData.Value - compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
-                                currentSlope = (state.CurrentData.Value - state.ArchivedData.Value) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
-
-                                if (slope1 >= state.Slope1)
-                                    state.Slope1 = slope1;
-
-                                if (slope2 <= state.Slope2)
-                                    state.Slope2 = slope2;
-
-                                if (currentSlope <= state.Slope1 || currentSlope >= state.Slope2)
-                                {
-                                    dataPoint = new ArchiveDataPoint(state.PreviousData);
-                                    archiveData = true;
-                                    calculateSlopes = true;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // Data is not to be compressed.
-                            dataPoint = new ArchiveDataPoint(state.PreviousData);
-                            archiveData = true;
-                        }
-                    }
-                    // [END]     Data compression
-
-                    // [BEGIN]   Data archival
-                    m_fat.DataPointsReceived++;
-
-                    if (archiveData)
-                    {
-                        if (dataPoint.Time.CompareTo(m_fat.FileStartTime) >= 0)
-                        {
-                            // Data belongs to this file.
-                            ArchiveDataBlock dataBlock;
-                            lock (m_dataBlocks)
-                            {
-                                dataBlock = m_dataBlocks[dataPoint.HistorianID - 1];
-                            }
-
-                            if ((object)dataBlock == null || dataBlock.SlotsAvailable == 0)
-                            {
-                                // Need to find a data block for writting the data.
-                                if ((object)dataBlock != null)
-                                    state.ActiveDataBlockIndex = -1;
-
-                                if (state.ActiveDataBlockIndex >= 0)
-                                {
-                                    // Retrieve previously used data block.
-                                    dataBlock = m_fat.RequestDataBlock(dataPoint.HistorianID, dataPoint.Time, state.ActiveDataBlockIndex);
-                                }
-                                else
-                                {
-                                    // Time to request a brand new data block.
-                                    dataBlock = m_fat.RequestDataBlock(dataPoint.HistorianID, dataPoint.Time, system.DataBlocksUsed);
-                                }
-
-                                if ((object)dataBlock != null)
-                                {
-                                    // Update the total number of data blocks used.
-                                    if (dataBlock.SlotsUsed == 0 && system.DataBlocksUsed == dataBlock.Index)
-                                    {
-                                        system.DataBlocksUsed++;
-                                        m_intercomFile.Write(1, system);
-                                    }
-
-                                    // Update the active data block index information.
-                                    state.ActiveDataBlockIndex = dataBlock.Index;
-                                }
-
-                                // Keep in-memory reference to the data block for consecutive writes.
-                                lock (m_dataBlocks)
-                                {
-                                    m_dataBlocks[dataPoint.HistorianID - 1] = dataBlock;
-                                }
-
-                                // Kick-off the rollover preparation when its threshold is reached.
-                                if (Statistics.FileUsage >= m_rolloverPreparationThreshold && !File.Exists(StandbyArchiveFileName) && !m_rolloverPreparationThread.IsAlive)
-                                {
-                                    m_rolloverPreparationThread = new Thread(PrepareForRollover);
-                                    m_rolloverPreparationThread.Priority = ThreadPriority.Lowest;
-                                    m_rolloverPreparationThread.Start();
-                                }
-                            }
-
-                            if ((object)dataBlock != null)
-                            {
-                                // Write data to the data block.
-                                if (dataBlock.Write(dataPoint, out ex))
-                                    m_fat.DataPointsArchived++;
-                                else
-                                    OnDataWriteException(ex);
-                            }
-                            else
-                            {
-                                OnFileFull();   // Current file is full.
-
-                                m_fat.DataPointsReceived--;
-                                while (true)
-                                {
-                                    Rollover(); // Rollover current file.
-                                    if (m_rolloverWaitHandle.WaitOne(1, false))
-                                        break;  // Rollover is successful.
-                                }
-
-                                i--;                                // Process current data point again.
-                                system = m_intercomFile.Read(1);    // Re-read modified intercom record.
-                                continue;
-                            }
-                        }
-                        else
-                        {
-                            // Data is historic.
-                            m_fat.DataPointsReceived--;
-                            m_historicDataQueue.Add(dataPoint);
-                            OnHistoricDataReceived(dataPoint);
-                        }
-
-                        state.ArchivedData = new StateRecordDataPoint(dataPoint);
-                    }
-
-                    if (calculateSlopes)
-                    {
-                        if (state.CurrentData.Time.Value != state.ArchivedData.Time.Value)
-                        {
-                            state.Slope1 = (state.CurrentData.Value - (state.ArchivedData.Value + compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
-                            state.Slope2 = (state.CurrentData.Value - (state.ArchivedData.Value - compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
-                        }
-                        else
-                        {
-                            state.Slope1 = 0;
-                            state.Slope2 = 0;
-                        }
-                    }
-
-                    state.PreviousData = state.CurrentData;
-
-                    // Write state information to the file.
-                    m_stateFile.Write(state.HistorianID, state);
-                    // [END]     Data archival
                 }
             }
+            finally
+            {
+                if (usingActiveFile)
+                {
+                    // Atomically decrement active file reader count to signal in-process code that read is complete or yielded
+                    Interlocked.Decrement(ref m_activeFileReaders);
+                }
+                else
+                {
+                    file.Dispose();
+                }
+            }
+
+            if (pendingRollover)
+                break;
         }
 
-        private void WriteToHistoricArchiveFile(IDataPoint[] items)
+        if (pendingRollover)
+        {
+            // Recurse into this function with an updated start time and last read point ID so that read can
+            // resume right where it left off - recursed function call will wait until rollover is complete
+            foreach (IDataPoint dataPoint in ReadData(historianIDs, startTime, endTime, resumeFrom, timeSorted))
+                yield return dataPoint;
+        }
+    }
+
+    /// <summary>
+    /// Reads <see cref="MetadataRecord"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing <see cref="MetadataRecord"/> of <see cref="MetadataRecord"/> if found; otherwise null.</returns>
+    public byte[] ReadMetaData(int historianID)
+    {
+        MetadataRecord record = MetadataFile.Read(historianID);
+        return record?.BinaryImage();
+    }
+
+    /// <summary>
+    /// Reads <see cref="StateRecord"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing <see cref="StateRecord"/> of <see cref="StateRecord"/> if found; otherwise null.</returns>
+    public byte[] ReadStateData(int historianID)
+    {
+        StateRecord record = StateFile.Read(historianID);
+        return record?.BinaryImage();
+    }
+
+    /// <summary>
+    /// Reads <see cref="MetadataRecordSummary"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing <see cref="MetadataRecordSummary"/> of <see cref="MetadataRecordSummary"/> if found; otherwise null.</returns>
+    public byte[] ReadMetaDataSummary(int historianID)
+    {
+        MetadataRecord record = MetadataFile.Read(historianID);
+        return record?.Summary.BinaryImage();
+    }
+
+    /// <summary>
+    /// Reads <see cref="StateRecordSummary"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing <see cref="StateRecordSummary"/> of <see cref="StateRecordSummary"/> if found; otherwise null.</returns>
+    public byte[] ReadStateDataSummary(int historianID)
+    {
+        StateRecord record = StateFile.Read(historianID);
+        return record?.Summary.BinaryImage();
+    }
+
+    /// <summary>
+    /// Waits for all readers to relinquish read locks on active file.
+    /// </summary>
+    /// <returns>True if readers released read locks in timely fashion.</returns>
+    protected internal bool WaitForReadersRelease()
+    {
+        int waitCount = 0;
+
+        // Wait up to five seconds for readers to release
+        while (Interlocked.Read(ref m_activeFileReaders) > 0 && waitCount < 5)
+        {
+            Thread.Sleep(1000);
+            waitCount++;
+        }
+
+        return Interlocked.Read(ref m_activeFileReaders) <= 0;
+    }
+
+    /// <summary>
+    /// Raises the <see cref="FileFull"/> event.
+    /// </summary>
+    protected virtual void OnFileFull()
+    {
+        FileFull?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="RolloverStart"/> event.
+    /// </summary>
+    protected internal virtual void OnRolloverStart()
+    {
+        m_rolloverInProgress = true;
+        RolloverStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="RolloverComplete"/> event.
+    /// </summary>
+    protected internal virtual void OnRolloverComplete()
+    {
+        m_rolloverInProgress = false;
+        RolloverComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="RolloverException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="RolloverException"/> event.</param>
+    protected internal virtual void OnRolloverException(Exception ex)
+    {
+        m_rolloverInProgress = false;
+        RolloverException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="OffloadStart"/> event.
+    /// </summary>
+    protected virtual void OnOffloadStart()
+    {
+        OffloadStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="OffloadComplete"/> event.
+    /// </summary>
+    protected virtual void OnOffloadComplete()
+    {
+        OffloadComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="OffloadException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="OffloadException"/> event.</param>
+    protected virtual void OnOffloadException(Exception ex)
+    {
+        OffloadException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="OffloadProgress"/> event.
+    /// </summary>
+    /// <param name="offloadProgress"><see cref="ProcessProgress{T}"/> to send to <see cref="OffloadProgress"/> event.</param>
+    protected virtual void OnOffloadProgress(ProcessProgress<int> offloadProgress)
+    {
+        OffloadProgress?.Invoke(this, new EventArgs<ProcessProgress<int>>(offloadProgress));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="RolloverPreparationStart"/> event.
+    /// </summary>
+    protected virtual void OnRolloverPreparationStart()
+    {
+        RolloverPreparationStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="RolloverPreparationComplete"/> event.
+    /// </summary>
+    protected virtual void OnRolloverPreparationComplete()
+    {
+        RolloverPreparationComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="RolloverPreparationException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="RolloverPreparationException"/> event.</param>
+    protected virtual void OnRolloverPreparationException(Exception ex)
+    {
+        RolloverPreparationException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="HistoricFileListBuildStart"/> event.
+    /// </summary>
+    protected virtual void OnHistoricFileListBuildStart()
+    {
+        HistoricFileListBuildStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="HistoricFileListBuildComplete"/> event.
+    /// </summary>
+    protected virtual void OnHistoricFileListBuildComplete()
+    {
+        HistoricFileListBuildComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raise the <see cref="HistoricFileListBuildException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="HistoricFileListBuildException"/> event.</param>
+    protected virtual void OnHistoricFileListBuildException(Exception ex)
+    {
+        HistoricFileListBuildException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="HistoricFileListUpdated"/> event.
+    /// </summary>
+    protected virtual void OnHistoricFileListUpdated()
+    {
+        HistoricFileListUpdated?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="OrphanDataReceived"/> event.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="OrphanDataReceived"/> event.</param>
+    protected virtual void OnOrphanDataReceived(IDataPoint dataPoint)
+    {
+        OrphanDataReceived?.Invoke(this, new EventArgs<IDataPoint>(dataPoint));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="FutureDataReceived"/> event.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="FutureDataReceived"/> event.</param>
+    protected virtual void OnFutureDataReceived(IDataPoint dataPoint)
+    {
+        FutureDataReceived?.Invoke(this, new EventArgs<IDataPoint>(dataPoint));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="HistoricDataReceived"/> event.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="HistoricDataReceived"/> event.</param>
+    protected virtual void OnHistoricDataReceived(IDataPoint dataPoint)
+    {
+        HistoricDataReceived?.Invoke(this, new EventArgs<IDataPoint>(dataPoint));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="OutOfSequenceDataReceived"/> event.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to send to <see cref="OutOfSequenceDataReceived"/> event.</param>
+    protected virtual void OnOutOfSequenceDataReceived(IDataPoint dataPoint)
+    {
+        OutOfSequenceDataReceived?.Invoke(this, new EventArgs<IDataPoint>(dataPoint));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataReadException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataReadException"/> event.</param>
+    protected virtual void OnDataReadException(Exception ex)
+    {
+        DataReadException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DataWriteException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="DataWriteException"/> event.</param>
+    protected virtual void OnDataWriteException(Exception ex)
+    {
+        DataWriteException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ProcessAlarmNotification"/> event.
+    /// </summary>
+    /// <param name="pointState"><see cref="StateRecord"/> to send to <see cref="ProcessAlarmNotification"/> event.</param>
+    protected virtual void OnProcessAlarmNotification(StateRecord pointState)
+    {
+        ProcessAlarmNotification?.Invoke(this, new EventArgs<StateRecord>(pointState));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="MetadataUpdated"/> event.
+    /// </summary>
+    protected virtual void OnMetadataUpdated()
+    {
+        MetadataUpdated?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the <see cref="ArchiveFile"/> and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (IsDisposed)
+            return;
+        
+        try
+        {
+            // This will be done regardless of whether the object is finalized or disposed.
+            if (!disposing)
+                return;
+            
+            // This will be done only when the object is disposed by calling Dispose().
+            Close();
+            SaveSettings();
+
+            RolloverWaitHandle?.Close();
+
+            if (m_conserveMemoryTimer is not null)
+            {
+                m_conserveMemoryTimer.Elapsed -= ConserveMemoryTimer_Elapsed;
+                m_conserveMemoryTimer.Dispose();
+            }
+
+            if (m_currentDataQueue is not null)
+            {
+                m_currentDataQueue.ProcessException -= CurrentDataQueue_ProcessException;
+                m_currentDataQueue.Dispose();
+            }
+
+            if (m_historicDataQueue is not null)
+            {
+                m_historicDataQueue.ProcessException -= HistoricDataQueue_ProcessException;
+                m_historicDataQueue.Dispose();
+            }
+
+            if (m_outOfSequenceDataQueue is not null)
+            {
+                m_outOfSequenceDataQueue.ProcessException -= OutOfSequenceDataQueue_ProcessException;
+                m_outOfSequenceDataQueue.Dispose();
+            }
+
+            if (m_currentLocationFileWatcher is not null)
+            {
+                m_currentLocationFileWatcher.Renamed -= FileWatcher_Renamed;
+                m_currentLocationFileWatcher.Deleted -= FileWatcher_Deleted;
+                m_currentLocationFileWatcher.Created -= FileWatcher_Created;
+                m_currentLocationFileWatcher.Dispose();
+            }
+
+            if (m_offloadLocationFileWatcher is not null)
+            {
+                m_offloadLocationFileWatcher.Renamed -= FileWatcher_Renamed;
+                m_offloadLocationFileWatcher.Deleted -= FileWatcher_Deleted;
+                m_offloadLocationFileWatcher.Created -= FileWatcher_Created;
+                m_offloadLocationFileWatcher.Dispose();
+            }
+
+            // Detach from all the dependency files.
+            StateFile = null;
+            MetadataFile = null;
+            IntercomFile = null;
+        }
+        finally
+        {
+            IsDisposed = true;          // Prevent duplicate dispose.
+            base.Dispose(disposing);    // Call base class Dispose().
+        }
+    }
+
+    #region [ Helper Methods ]
+
+    private void ReOpen()
+    {
+        if (!IsOpen)
+            return;
+        
+        Close();
+        Open();
+    }
+
+    internal void OpenStream()
+    {
+        try
+        {
+            if (File.Exists(m_fileName))
+            {
+                int attempts = 0;
+
+                while (true)
+                {
+                    try
+                    {
+                        attempts++;
+                        FileData = new FileStream(m_fileName, FileMode.Open, m_fileAccessMode, FileShare.ReadWrite);
+                        Fat = new ArchiveFileAllocationTable(this);
+                        break;
+                    }
+                    catch
+                    {
+                        FileData?.Dispose();
+
+                        if (attempts >= 4)
+                            throw;
+
+                        Thread.Sleep(500);
+                    }
+                }
+            }
+            else if (m_fileAccessMode == FileAccess.Read)
+            {
+                // File does not exist, so we create a placeholder file in the temp directory
+                FileData = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+                Fat = new ArchiveFileAllocationTable(this)
+                { 
+                    FileStartTime = TimeTag.MaxValue,
+                    FileEndTime = TimeTag.MaxValue
+                };
+
+                // Manually call file monitoring event if file watchers are not enabled
+                if (!MonitorNewArchiveFiles)
+                    FileWatcher_Created(this, new FileSystemEventArgs(WatcherChangeTypes.Created, FilePath.GetAbsolutePath(m_fileName), FilePath.GetFileName(m_fileName)));
+            }
+            else
+            {
+                // File does not exist, so we have to create it and initialize it.
+                FileData = new FileStream(m_fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+                Fat = new ArchiveFileAllocationTable(this);
+                Fat.Save(true);
+
+                // Manually call file monitoring event if file watchers are not enabled
+                if (!MonitorNewArchiveFiles)
+                    FileWatcher_Created(this, new FileSystemEventArgs(WatcherChangeTypes.Created, FilePath.GetAbsolutePath(m_fileName), FilePath.GetFileName(m_fileName)));
+            }
+        }
+        catch
+        {
+            FileData?.Dispose();
+            throw;
+        }
+    }
+
+    internal void CloseStream()
+    {
+        Fat = null;
+
+        if (FileData is null)
+            return;
+        
+        lock (FileData)
+        {
+            FileData.Flush();
+            FileData.Close();
+            FileData.Dispose();
+        }
+        
+        FileData = null;
+    }
+
+    private void SyncStateFile(object state)
+    {
+        lock (this)
+        {
+            if (m_dataBlocks is null || 
+                !StateFile.IsOpen || 
+                !m_metadataFile.IsOpen || 
+                StateFile.FileAccessMode == FileAccess.Read || 
+                m_metadataFile.RecordsOnDisk <= StateFile.RecordsOnDisk)
+                return;
+
+            // Since we have more records in the Metadata File than in the State File we'll synchronize
+            // the number of records in both the files (very important) by writing a new record to the State
+            // File with an ID same as the number of records on disk for Metadata File. Doing so will cause the
+            // State File to grow in-memory or on-disk depending on how it's configured.
+            StateFile.Write(m_metadataFile.RecordsOnDisk, new StateRecord(m_metadataFile.RecordsOnDisk));
+            StateFile.Save();
+
+            // We synchronize the block list with the number of state records physically present on the disk.
+            lock (m_dataBlocks)
+                m_dataBlocks.AddRange(new ArchiveDataBlock[StateFile.RecordsOnDisk - m_dataBlocks.Count]);
+        }
+    }
+
+    private void BuildHistoricFileList()
+    {
+        if (m_historicArchiveFiles is not null)
+            return;
+        
+        // The list of historic files has not been created, so we'll create it.
+        try
+        {
+            m_historicArchiveFiles = [];
+
+            // We can safely assume that we'll always get information about the historic file because, the
+            // search pattern ensures that we only can a list of historic archive files and not all files.
+            OnHistoricFileListBuildStart();
+
+            // Prevent the historic file list from being updated by the file watchers.
+            lock (m_historicArchiveFiles)
+            {
+                Info historicFileInfo;
+
+                foreach (string historicFileName in Directory.GetFiles(FilePath.GetDirectoryName(m_fileName), HistoricFilesSearchPattern))
+                {
+                    historicFileInfo = GetHistoricFileInfo(historicFileName);
+                    
+                    if (historicFileInfo is not null)
+                        m_historicArchiveFiles.Add(historicFileInfo);
+                }
+
+                if (Directory.Exists(ArchiveOffloadLocation))
+                {
+                    foreach (string historicFileName in Directory.GetFiles(ArchiveOffloadLocation, HistoricFilesSearchPattern))
+                    {
+                        historicFileInfo = GetHistoricFileInfo(historicFileName);
+                        
+                        if (historicFileInfo is not null)
+                            m_historicArchiveFiles.Add(historicFileInfo);
+                    }
+                }
+            }
+
+            OnHistoricFileListBuildComplete();
+        }
+        catch (ThreadAbortException)
+        {
+            // This thread must die now...
+        }
+        catch (Exception ex)
+        {
+            OnHistoricFileListBuildException(ex);
+        }
+    }
+
+    [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Implementation is correct")]
+    private void PrepareForRollover()
+    {
+        try
+        {
+            DriveInfo archiveDrive = new(Path.GetPathRoot(m_fileName).ToNonNullString());
+
+            // We'll start offloading historic files if we've reached the offload threshold.
+            if (ArchiveOffloadMaxAge > 0)
+                OffloadMaxAgedFiles();
+
+            if (archiveDrive.AvailableFreeSpace < archiveDrive.TotalSize * (1 - m_archiveOffloadThreshold / 100))
+                OffloadHistoricFiles();
+
+            // Maintain maximum number of historic files, if configured to do so
+            MaintainMaximumNumberOfHistoricFiles();
+
+            OnRolloverPreparationStart();
+
+            // Opening and closing a new archive file in "standby" mode will create a "standby" archive file.
+            ArchiveFile standbyArchiveFile = new();
+            standbyArchiveFile.FileName = StandbyArchiveFileName;
+            standbyArchiveFile.FileSize = m_fileSize;
+            standbyArchiveFile.DataBlockSize = m_dataBlockSize;
+            standbyArchiveFile.StateFile = StateFile;
+            standbyArchiveFile.IntercomFile = IntercomFile;
+            standbyArchiveFile.MetadataFile = m_metadataFile;
+
+            try
+            {
+                standbyArchiveFile.Open();
+            }
+            catch
+            {
+                string standbyFileName = standbyArchiveFile.FileName;
+                standbyArchiveFile.Close();
+
+                // We didn't succeed in creating a "standby" archive file, so we'll delete it if it was created
+                // partially (might happen if there isn't enough disk space or thread is aborted). This is to
+                // ensure that this preparation processes is kicked off again until a valid "standby" archive
+                // file is successfully created.
+                DeleteFile(standbyFileName);
+
+                throw; // Rethrow the exception so the appropriate action is taken.
+            }
+            finally
+            {
+                standbyArchiveFile.Dispose();
+            }
+
+            OnRolloverPreparationComplete();
+        }
+        catch (ThreadAbortException)
+        {
+            // This thread must die now...
+        }
+        catch (Exception ex)
+        {
+            OnRolloverPreparationException(ex);
+        }
+    }
+
+    private void OffloadMaxAgedFiles()
+    {
+        if (Directory.Exists(ArchiveOffloadLocation))
         {
             // Wait until the historic file list has been built.
             if (m_buildHistoricFileListThread.IsAlive)
                 m_buildHistoricFileListThread.Join();
 
-            Dictionary<Info, Dictionary<int, List<IDataPoint>>> historicFileData = new Dictionary<Info, Dictionary<int, List<IDataPoint>>>();
+            try
+            {
+                OnOffloadStart();
 
-            // Separate all point data into bins by historic file and point ID
-            foreach (IDataPoint dataPoint in items) {
-                try
+                // The offload path that is specified is a valid one so we'll gather a list of all historic
+                // files in the directory where the current (active) archive file is located.
+                List<Info> newHistoricFiles;
+
+                lock (m_historicArchiveFiles)
+                    newHistoricFiles = m_historicArchiveFiles.FindAll(info => IsNewHistoricArchiveFile(info, m_fileName));
+
+                // Sorting the list will sort the historic files from oldest to newest.
+                newHistoricFiles.Sort();
+
+                List<Info> filesToOffload = [];
+
+                foreach (Info file in newHistoricFiles)
                 {
-                    Info historicFileInfo;
-                    Dictionary<int, List<IDataPoint>> sortedPointData;
-                    List<IDataPoint> pointData;
+                    if ((DateTime.UtcNow - file.StartTimeTag.ToDateTime()).TotalDays > ArchiveOffloadMaxAge)
+                        filesToOffload.Add(file);
+                }
 
-                    lock (m_historicArchiveFiles)
+                // We'll offload the specified number of oldest historic files to the offload location if the
+                // number of historic files is more than the offload count or all of the historic files if the
+                // offload count is smaller the available number of historic files.
+                ProcessProgress<int> offloadProgress = new("FileOffload") { Total = filesToOffload.Count };
+
+                for (int i = 0; i < offloadProgress.Total; i++)
+                {
+                    // Don't attempt to offload active file
+                    if (string.Compare(filesToOffload[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) == 0)
+                        continue;
+
+                    string destinationFileName = FilePath.AddPathSuffix(ArchiveOffloadLocation) + FilePath.GetFileName(filesToOffload[i].FileName);
+
+                    try
                     {
-                        // Attempt to find a historic archive file where the data point belongs
-                        historicFileInfo = m_historicArchiveFiles.Find(info => FindHistoricArchiveFileForWrite(info, dataPoint.Time));
+                        DeleteFile(destinationFileName);
+                        MoveFile(filesToOffload[i].FileName, destinationFileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        OnOffloadException(new InvalidOperationException($"Failed to offload historic file \"{FilePath.GetFileName(filesToOffload[i].FileName)}\": {ex.Message}", ex));
                     }
 
-                    // If a historic file exists, sort the data point into the proper bin
-                    if ((object)historicFileInfo != null)
+                    offloadProgress.Complete++;
+                    offloadProgress.ProgressMessage = FilePath.GetFileName(filesToOffload[i].FileName);
+
+                    OnOffloadProgress(offloadProgress);
+                }
+
+                OnOffloadComplete();
+            }
+            catch (ThreadAbortException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                OnOffloadException(ex);
+            }
+        }
+        else if (string.Compare(ArchiveOffloadLocation.ToNonNullString().Trim(), "*DELETE*", StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            // Handle case where user has requested historic files be deleted instead of offloaded
+
+            // Wait until the historic file list has been built.
+            if (m_buildHistoricFileListThread.IsAlive)
+                m_buildHistoricFileListThread.Join();
+
+            try
+            {
+                OnOffloadStart();
+
+                // Get a local copy of all the historic archive files.
+                List<Info> allHistoricFiles;
+
+                lock (m_historicArchiveFiles)
+                    allHistoricFiles = [..m_historicArchiveFiles];
+
+                // Start deleting historic files from oldest to newest.
+                allHistoricFiles.Sort();
+
+                List<Info> filesToDelete = [];
+
+                foreach (Info file in allHistoricFiles)
+                {
+                    if ((DateTime.UtcNow - file.StartTimeTag.ToDateTime()).TotalDays > ArchiveOffloadMaxAge)
+                        filesToDelete.Add(file);
+                }
+
+                ProcessProgress<int> offloadProgress = new("FileOffload") { Total = filesToDelete.Count };
+
+                for (int i = 0; i < filesToDelete.Count; i++)
+                {
+                    // Don't attempt to offload active file
+                    if (string.Compare(filesToDelete[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) == 0)
+                        continue;
+
+                    try
                     {
-                        sortedPointData = historicFileData.GetOrAdd(historicFileInfo, info => new Dictionary<int, List<IDataPoint>>());
-                        pointData = sortedPointData.GetOrAdd(dataPoint.HistorianID, id => new List<IDataPoint>());
-                        pointData.Add(dataPoint);
+                        DeleteFile(filesToDelete[i].FileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        OnOffloadException(new InvalidOperationException($"Failed to remove historic file \"{FilePath.GetFileName(filesToDelete[i].FileName)}\": {ex.Message}", ex));
+                    }
+
+                    offloadProgress.Complete++;
+                    offloadProgress.ProgressMessage = FilePath.GetFileName(filesToDelete[i].FileName);
+
+                    OnOffloadProgress(offloadProgress);
+                }
+
+                OnOffloadComplete();
+            }
+            catch (ThreadAbortException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                OnOffloadException(ex);
+            }
+        }
+    }
+
+    private void OffloadHistoricFiles()
+    {
+        if (Directory.Exists(ArchiveOffloadLocation))
+        {
+            // Wait until the historic file list has been built.
+            if (m_buildHistoricFileListThread.IsAlive)
+                m_buildHistoricFileListThread.Join();
+
+            try
+            {
+                OnOffloadStart();
+
+                // The offload path that is specified is a valid one so we'll gather a list of all historic
+                // files in the directory where the current (active) archive file is located.
+                List<Info> newHistoricFiles;
+
+                lock (m_historicArchiveFiles)
+                    newHistoricFiles = m_historicArchiveFiles.FindAll(info => IsNewHistoricArchiveFile(info, m_fileName));
+
+                // Sorting the list will sort the historic files from oldest to newest.
+                newHistoricFiles.Sort();
+
+                // We'll offload the specified number of oldest historic files to the offload location if the
+                // number of historic files is more than the offload count or all of the historic files if the
+                // offload count is smaller the available number of historic files.
+                ProcessProgress<int> offloadProgress = new("FileOffload") { Total = newHistoricFiles.Count < m_archiveOffloadCount ? newHistoricFiles.Count : m_archiveOffloadCount };
+
+                for (int i = 0; i < offloadProgress.Total; i++)
+                {
+                    // Don't attempt to offload active file
+                    if (string.Compare(newHistoricFiles[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) == 0)
+                        continue;
+                    
+                    string destinationFileName = FilePath.AddPathSuffix(ArchiveOffloadLocation) + FilePath.GetFileName(newHistoricFiles[i].FileName);
+
+                    try
+                    {
+                        DeleteFile(destinationFileName);
+                        MoveFile(newHistoricFiles[i].FileName, destinationFileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        OnOffloadException(new InvalidOperationException($"Failed to offload historic file \"{FilePath.GetFileName(newHistoricFiles[i].FileName)}\": {ex.Message}", ex));
+                    }
+
+                    offloadProgress.Complete++;
+                    offloadProgress.ProgressMessage = FilePath.GetFileName(newHistoricFiles[i].FileName);
+
+                    OnOffloadProgress(offloadProgress);
+                }
+
+                OnOffloadComplete();
+            }
+            catch (ThreadAbortException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                OnOffloadException(ex);
+            }
+        }
+        else if (string.Compare(ArchiveOffloadLocation.ToNonNullString().Trim(), "*DELETE*", StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            // Handle case where user has requested historic files be deleted instead of offloaded
+
+            // Wait until the historic file list has been built.
+            if (m_buildHistoricFileListThread.IsAlive)
+                m_buildHistoricFileListThread.Join();
+
+            try
+            {
+                OnOffloadStart();
+
+                // Get a local copy of all the historic archive files.
+                List<Info> allHistoricFiles;
+
+                lock (m_historicArchiveFiles)
+                    allHistoricFiles = [..m_historicArchiveFiles];
+
+                // Determine total number of files to remove
+                int filesToDelete = Common.Min(m_archiveOffloadCount, allHistoricFiles.Count);
+
+                ProcessProgress<int> offloadProgress = new("FileOffload") { Total = filesToDelete };
+
+                // Start deleting historic files from oldest to newest.
+                allHistoricFiles.Sort();
+
+                for (int i = 0; i < filesToDelete; i++)
+                {
+                    // Don't attempt to offload active file
+                    if (string.Compare(allHistoricFiles[i].FileName, m_fileName, StringComparison.OrdinalIgnoreCase) == 0)
+                        continue;
+                    
+                    try
+                    {
+                        DeleteFile(allHistoricFiles[i].FileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        OnOffloadException(new InvalidOperationException($"Failed to remove historic file \"{FilePath.GetFileName(allHistoricFiles[i].FileName)}\": {ex.Message}", ex));
+                    }
+
+                    offloadProgress.Complete++;
+                    offloadProgress.ProgressMessage = FilePath.GetFileName(allHistoricFiles[i].FileName);
+
+                    OnOffloadProgress(offloadProgress);
+                }
+
+                OnOffloadComplete();
+            }
+            catch (ThreadAbortException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                OnOffloadException(ex);
+            }
+        }
+    }
+
+    private void MaintainMaximumNumberOfHistoricFiles()
+    {
+        if (m_maxHistoricArchiveFiles < 1)
+            return;
+        
+        // Wait until the historic file list has been built.
+        if (m_buildHistoricFileListThread.IsAlive)
+            m_buildHistoricFileListThread.Join();
+
+        // Get a local copy of all the historic archive files.
+        List<Info> allHistoricFiles;
+
+        lock (m_historicArchiveFiles)
+            allHistoricFiles = [..m_historicArchiveFiles];
+
+        if (allHistoricFiles.Count <= m_maxHistoricArchiveFiles)
+            return;
+
+        // Start deleting historic files from oldest to newest.
+        allHistoricFiles.Sort();
+
+        while (allHistoricFiles.Count > m_maxHistoricArchiveFiles)
+        {
+            try
+            {
+                DeleteFile(allHistoricFiles[0].FileName);
+            }
+            catch (Exception ex)
+            {
+                OnOffloadException(new InvalidOperationException($"Failed during attempt to maintain maximum number of historic files - file \"{FilePath.GetFileName(allHistoricFiles[0].FileName)}\" could not be deleted: {ex.Message}", ex));
+            }
+            finally
+            {
+                allHistoricFiles.RemoveAt(0);
+            }
+        }
+    }
+
+    private Info GetHistoricFileInfo(string fileName)
+    {
+        Info fileInfo = null;
+
+        try
+        {
+            // Validate the file name to determine whether the given file is actually a historic file
+            if (!Regex.IsMatch(fileName, $".+_.+_to_.+\\{FileExtension}$"))
+                return null;
+
+            if (File.Exists(fileName))
+            {
+                // We'll open the file and get relevant information about it.
+                ArchiveFile historicArchiveFile = new();
+
+                historicArchiveFile.FileName = fileName;
+                historicArchiveFile.StateFile = StateFile;
+                historicArchiveFile.IntercomFile = IntercomFile;
+                historicArchiveFile.MetadataFile = m_metadataFile;
+                historicArchiveFile.FileAccessMode = FileAccess.Read;
+
+                try
+                {
+                    historicArchiveFile.Open();
+
+                    fileInfo = new Info(fileName)
+                    {
+                        StartTimeTag = historicArchiveFile.Fat.FileStartTime,
+                        EndTimeTag = historicArchiveFile.Fat.FileEndTime
+                    };
+                }
+                catch (Exception ex)
+                {
+                    OnHistoricFileListBuildException(new InvalidOperationException($"Failed to open historic data file \"{FilePath.GetFileName(fileName)}\" due to exception: {ex.Message}", ex));
+                }
+                finally
+                {
+                    historicArchiveFile.Dispose();
+                }
+            }
+            else
+            {
+                // We'll resolve to getting the file information from its name only if the file no longer exists
+                // at the location. This will be the case when file is moved to a different location. In this
+                // case the file information we provide is only as good as the file name.
+                string datesString = FilePath.GetFileNameWithoutExtension(fileName).Substring((FilePath.GetFileNameWithoutExtension(m_fileName) + "_").Length);
+                string[] fileStartEndDates = datesString.Split(["_to_"], StringSplitOptions.None);
+
+                fileInfo = new Info(fileName);
+
+                if (fileStartEndDates.Length == 2)
+                {
+                    fileInfo.StartTimeTag = new TimeTag(Convert.ToDateTime(fileStartEndDates[0].Replace('!', ':')));
+                    fileInfo.EndTimeTag = new TimeTag(Convert.ToDateTime(fileStartEndDates[1].Replace('!', ':')));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            OnHistoricFileListBuildException(new InvalidOperationException($"Failed during information access attempt for historic data file \"{FilePath.GetFileName(fileName)}\" due to exception: {ex.Message}", ex));
+        }
+
+        return fileInfo;
+    }
+
+    #endregion
+
+    #region [ Queue Delegates ]
+
+    private void WriteToCurrentArchiveFile(IDataPoint[] items)
+    {
+        Dictionary<int, List<IDataPoint>> sortedDataPoints = new();
+
+        // First we'll separate all point data by ID.
+        foreach (IDataPoint dataPoint in items)
+        {
+            if (!sortedDataPoints.ContainsKey(dataPoint.HistorianID))
+                sortedDataPoints.Add(dataPoint.HistorianID, []);
+
+            sortedDataPoints[dataPoint.HistorianID].Add(dataPoint);
+        }
+
+        IntercomRecord system = IntercomFile.Read(1);
+
+        foreach (int pointID in sortedDataPoints.Keys)
+        {
+            // Initialize local variables.
+            StateRecord state = StateFile.Read(pointID);
+            MetadataRecord metadata = m_metadataFile.Read(pointID);
+
+            for (int i = 0; i < sortedDataPoints[pointID].Count; i++)
+            {
+                IDataPoint dataPoint = sortedDataPoints[pointID][i];
+
+                // Ensure that the received data is to be archived.
+                if (state is null || metadata is null || !metadata.GeneralFlags.Enabled)
+                {
+                    OnOrphanDataReceived(dataPoint);
+                    continue;
+                }
+
+                // Ensure that data is not far out in to the future.
+                if (dataPoint.Time > DateTime.UtcNow.AddMinutes(m_leadTimeTolerance))
+                {
+                    OnFutureDataReceived(dataPoint);
+                    continue;
+                }
+
+                // Perform quality check if data quality is not set.
+                if ((int)dataPoint.Quality == 31)
+                {
+                    // Note: Here we're checking if the Quality is 31 instead of -1 because the quality value is stored
+                    // in the first 5 bits (QualityMask = 31) of Flags in the point data. Initially when the Quality is
+                    // set to -1, all the bits Flags (a 32-bit integer) are set to 1. And therefore, when we get the
+                    // Quality, which is a masked value of Flags, we get 31 and not -1.
+                    switch (metadata.GeneralFlags.DataType)
+                    {
+                        case DataType.Analog:
+                            if (dataPoint.Value >= metadata.AnalogFields.HighRange)
+                                dataPoint.Quality = Quality.UnreasonableHigh;
+                            else if (dataPoint.Value >= metadata.AnalogFields.HighAlarm)
+                                dataPoint.Quality = Quality.ValueAboveHiHiAlarm;
+                            else if (dataPoint.Value >= metadata.AnalogFields.HighWarning)
+                                dataPoint.Quality = Quality.ValueAboveHiAlarm;
+                            else if (dataPoint.Value <= metadata.AnalogFields.LowRange)
+                                dataPoint.Quality = Quality.UnreasonableLow;
+                            else if (dataPoint.Value <= metadata.AnalogFields.LowAlarm)
+                                dataPoint.Quality = Quality.ValueBelowLoLoAlarm;
+                            else if (dataPoint.Value <= metadata.AnalogFields.LowWarning)
+                                dataPoint.Quality = Quality.ValueBelowLoAlarm;
+                            else
+                                dataPoint.Quality = Quality.Good;
+                            break;
+                        case DataType.Digital:
+                            dataPoint.Quality = (int)dataPoint.Value == metadata.DigitalFields.AlarmState ? Quality.LogicalAlarm : Quality.Good;
+                            break;
+                    }
+                }
+
+                // Update information about the latest data point received.
+                if (dataPoint.Time.CompareTo(system.LatestDataTime) > 0)
+                {
+                    system.LatestDataID = dataPoint.HistorianID;
+                    system.LatestDataTime = dataPoint.Time;
+                    IntercomFile.Write(1, system);
+                }
+
+                // Check for data that out-of-sequence based on it's time.
+                if (dataPoint.Time.CompareTo(state.PreviousData.Time) <= 0)
+                {
+                    if (dataPoint.Time == state.PreviousData.Time)
+                    {
+                        // Discard data that is an exact duplicate of data in line for archival.
+                        if (dataPoint.Value == state.PreviousData.Value && dataPoint.Quality == state.PreviousData.Quality)
+                            continue;
+                    }
+                    else
+                    {
+                        // Queue out-of-sequence data for processing if it is not be discarded.
+                        if (!DiscardOutOfSequenceData)
+                            m_outOfSequenceDataQueue.Add(dataPoint);
+
+                        OnOutOfSequenceDataReceived(dataPoint);
+                        continue;
+                    }
+                }
+
+                // [BEGIN]   Data compression
+                bool archiveData = false;
+                bool calculateSlopes = false;
+                float compressionLimit = metadata.AnalogFields.CompressionLimit;
+
+                // Set the compression limit to a very low number for digital points.
+                if (metadata.GeneralFlags.DataType == DataType.Digital)
+                    compressionLimit = 0.000000001f;
+
+                state.CurrentData = new StateRecordDataPoint(dataPoint);
+
+                if (state.ArchivedData.IsEmpty)
+                {
+                    // This is the first time data is received.
+                    state.CurrentData = new StateRecordDataPoint(-1);
+                    archiveData = true;
+                }
+                else if (state.PreviousData.IsEmpty)
+                {
+                    // This is the second time data is received.
+                    calculateSlopes = true;
+                }
+                else
+                {
+                    // Process quality-based alarming if enabled.
+                    if (metadata.GeneralFlags.AlarmEnabled)
+                    {
+                        if (metadata.AlarmFlags.Value.CheckBits(BitExtensions.BitVal((int)state.CurrentData.Quality)))
+                        {
+                            // Current data quality warrants alarming based on the alarming settings.
+
+                            decimal delay = metadata.GeneralFlags.DataType switch
+                            {
+                                DataType.Analog => (decimal)metadata.AnalogFields.AlarmDelay,
+                                DataType.Digital => (decimal)metadata.DigitalFields.AlarmDelay,
+                                _ => 0
+                            };
+
+                            // Dispatch the alarm immediately or after a given time based on settings.
+                            if (delay > 0)
+                            {
+                                // Wait before dispatching alarm.
+                                if (m_delayedAlarmProcessing.TryGetValue(dataPoint.HistorianID, out decimal first))
+                                {
+                                    if (state.CurrentData.Time.Value - first > delay)
+                                    {
+                                        // Wait is now over, dispatch the alarm.
+                                        m_delayedAlarmProcessing.Remove(dataPoint.HistorianID);
+                                        OnProcessAlarmNotification(state);
+                                    }
+                                }
+                                else
+                                {
+                                    m_delayedAlarmProcessing.Add(state.HistorianID, state.CurrentData.Time.Value);
+                                }
+                            }
+                            else
+                            {
+                                // Dispatch the alarm immediately.
+                                OnProcessAlarmNotification(state);
+                            }
+                        }
+                        else
+                        {
+                            m_delayedAlarmProcessing.Remove(dataPoint.HistorianID);
+                        }
+                    }
+
+                    if (CompressData)
+                    {
+                        // Data is to be compressed.
+                        if (metadata.CompressionMinTime > 0 && state.CurrentData.Time.Value - state.ArchivedData.Time.Value < metadata.CompressionMinTime)
+                        {
+                            // CompressionMinTime is in effect.
+                            archiveData = false;
+                            calculateSlopes = false;
+                        }
+                        else if (state.CurrentData.Quality != state.ArchivedData.Quality || state.CurrentData.Quality != state.PreviousData.Quality || (metadata.CompressionMaxTime > 0 && state.PreviousData.Time.Value - state.ArchivedData.Time.Value > metadata.CompressionMaxTime))
+                        {
+                            // Quality changed or CompressionMaxTime is exceeded.
+                            dataPoint = new ArchiveDataPoint(state.PreviousData);
+                            archiveData = true;
+                            calculateSlopes = true;
+                        }
+                        else
+                        {
+                            // Perform a compression test.
+                            double slope1 = (state.CurrentData.Value - (state.ArchivedData.Value + compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
+                            double slope2 = (state.CurrentData.Value - (state.ArchivedData.Value - compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
+                            double currentSlope = (state.CurrentData.Value - state.ArchivedData.Value) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
+
+                            if (slope1 >= state.Slope1)
+                                state.Slope1 = slope1;
+
+                            if (slope2 <= state.Slope2)
+                                state.Slope2 = slope2;
+
+                            if (currentSlope <= state.Slope1 || currentSlope >= state.Slope2)
+                            {
+                                dataPoint = new ArchiveDataPoint(state.PreviousData);
+                                archiveData = true;
+                                calculateSlopes = true;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Data is not to be compressed.
+                        dataPoint = new ArchiveDataPoint(state.PreviousData);
+                        archiveData = true;
+                    }
+                }
+                // [END]     Data compression
+
+                // [BEGIN]   Data archival
+                Fat.DataPointsReceived++;
+
+                if (archiveData)
+                {
+                    if (dataPoint.Time.CompareTo(Fat.FileStartTime) >= 0)
+                    {
+                        // Data belongs to this file.
+                        ArchiveDataBlock dataBlock;
+
+                        lock (m_dataBlocks)
+                            dataBlock = m_dataBlocks[dataPoint.HistorianID - 1];
+
+                        if (dataBlock is null || dataBlock.SlotsAvailable == 0)
+                        {
+                            // Need to find a data block for writing the data.
+                            if (dataBlock is not null)
+                                state.ActiveDataBlockIndex = -1;
+                            
+                            dataBlock = Fat.RequestDataBlock(dataPoint.HistorianID, dataPoint.Time, state.ActiveDataBlockIndex >= 0 ? 
+                                state.ActiveDataBlockIndex : // Retrieve previously used data block.
+                                system.DataBlocksUsed);      // Time to request a new data block.
+
+                            if (dataBlock is not null)
+                            {
+                                // Update the total number of data blocks used.
+                                if (dataBlock.SlotsUsed == 0 && system.DataBlocksUsed == dataBlock.Index)
+                                {
+                                    system.DataBlocksUsed++;
+                                    IntercomFile.Write(1, system);
+                                }
+
+                                // Update the active data block index information.
+                                state.ActiveDataBlockIndex = dataBlock.Index;
+                            }
+
+                            // Keep in-memory reference to the data block for consecutive writes.
+                            lock (m_dataBlocks)
+                                m_dataBlocks[dataPoint.HistorianID - 1] = dataBlock;
+
+                            // Kick-off the rollover preparation when its threshold is reached.
+                            if (Statistics.FileUsage >= m_rolloverPreparationThreshold && !File.Exists(StandbyArchiveFileName) && !m_rolloverPreparationThread.IsAlive)
+                            {
+                                m_rolloverPreparationThread = new Thread(PrepareForRollover) { Priority = ThreadPriority.Lowest };
+                                m_rolloverPreparationThread.Start();
+                            }
+                        }
+
+                        if (dataBlock is not null)
+                        {
+                            // Write data to the data block.
+                            if (dataBlock.Write(dataPoint, out Exception ex))
+                                Fat.DataPointsArchived++;
+                            else
+                                OnDataWriteException(ex);
+                        }
+                        else
+                        {
+                            OnFileFull();   // Current file is full.
+
+                            Fat.DataPointsReceived--;
+
+                            while (true)
+                            {
+                                Rollover(); // Rollover current file.
+                                if (RolloverWaitHandle.WaitOne(1, false))
+                                    break;  // Rollover is successful.
+                            }
+
+                            i--;                              // Process current data point again.
+                            system = IntercomFile.Read(1);    // Re-read modified intercom record.
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        // Data is historic.
+                        Fat.DataPointsReceived--;
+                        m_historicDataQueue.Add(dataPoint);
+                        OnHistoricDataReceived(dataPoint);
+                    }
+
+                    state.ArchivedData = new StateRecordDataPoint(dataPoint);
+                }
+
+                if (calculateSlopes)
+                {
+                    if (state.CurrentData.Time.Value != state.ArchivedData.Time.Value)
+                    {
+                        state.Slope1 = (state.CurrentData.Value - (state.ArchivedData.Value + compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
+                        state.Slope2 = (state.CurrentData.Value - (state.ArchivedData.Value - compressionLimit)) / (double)(state.CurrentData.Time.Value - state.ArchivedData.Time.Value);
+                    }
+                    else
+                    {
+                        state.Slope1 = 0;
+                        state.Slope2 = 0;
+                    }
+                }
+
+                state.PreviousData = state.CurrentData;
+
+                // Write state information to the file.
+                StateFile.Write(state.HistorianID, state);
+                // [END]     Data archival
+            }
+        }
+    }
+
+    private void WriteToHistoricArchiveFile(IDataPoint[] items)
+    {
+        // Wait until the historic file list has been built.
+        if (m_buildHistoricFileListThread.IsAlive)
+            m_buildHistoricFileListThread.Join();
+
+        Dictionary<Info, Dictionary<int, List<IDataPoint>>> historicFileData = new();
+
+        // Separate all point data into bins by historic file and point ID
+        foreach (IDataPoint dataPoint in items)
+        {
+            try
+            {
+                Info historicFileInfo;
+
+                // Attempt to find a historic archive file where the data point belongs
+                lock (m_historicArchiveFiles)
+                    historicFileInfo = m_historicArchiveFiles.Find(info => FindHistoricArchiveFileForWrite(info, dataPoint.Time));
+
+                // If a historic file exists, sort the data point into the proper bin
+                if (historicFileInfo is null)
+                    continue;
+                
+                Dictionary<int, List<IDataPoint>> sortedPointData = historicFileData.GetOrAdd(historicFileInfo, _ => new Dictionary<int, List<IDataPoint>>());
+                List<IDataPoint> pointData = sortedPointData.GetOrAdd(dataPoint.HistorianID, _ => []);
+                pointData.Add(dataPoint);
+            }
+            catch (Exception ex)
+            {
+                // Notify of the exception
+                OnDataWriteException(ex);
+            }
+        }
+
+        foreach (Info historicFileInfo in historicFileData.Keys)
+        {
+            Dictionary<int, List<IDataPoint>> sortedPointData = historicFileData[historicFileInfo];
+            int overflowBlocks = 0;
+
+            using ArchiveFile historicFile = new();
+            
+            try
+            {
+                // Open the historic file
+                historicFile.FileName = historicFileInfo.FileName;
+                historicFile.StateFile = StateFile;
+                historicFile.IntercomFile = IntercomFile;
+                historicFile.MetadataFile = m_metadataFile;
+                historicFile.Open();
+            }
+            catch (Exception ex)
+            {
+                // Notify of the exception
+                OnDataWriteException(ex);
+
+                // If we fail to open the historic file,
+                // then we cannot write any of these data
+                // points to it so we might as well move on
+                continue;
+            }
+
+            // Calculate the number of additional data blocks needed to store all the data
+            foreach (int pointID in sortedPointData.Keys)
+            {
+                try
+                {
+                    ArchiveDataBlock lastDataBlock = historicFile.Fat.FindLastDataBlock(pointID);
+                    int blockCapacity = historicFile.DataBlockSize * 1024 / ArchiveDataPoint.FixedLength;
+                    int overflowPoints = sortedPointData[pointID].Count + (lastDataBlock?.SlotsUsed ?? 0) - (lastDataBlock?.Capacity ?? 0);
+                    overflowBlocks += (overflowPoints + blockCapacity - 1) / blockCapacity;
+                }
+                catch (Exception ex)
+                {
+                    // Notify of the exception
+                    OnDataWriteException(ex);
+                }
+            }
+
+            try
+            {
+                // Extend the file by the needed amount
+                if (overflowBlocks > 0)
+                    historicFile.Fat.Extend(overflowBlocks);
+            }
+            catch (Exception ex)
+            {
+                // Notify of the exception
+                OnDataWriteException(ex);
+            }
+
+            foreach (int pointID in sortedPointData.Keys)
+            {
+                try
+                {
+                    ArchiveDataBlock historicFileBlock = null;
+
+                    // Sort the point data for the current point ID by time
+                    sortedPointData[pointID].Sort();
+
+                    foreach (IDataPoint dataPoint in sortedPointData[pointID])
+                    {
+                        // Request a new or previously used data block for point data
+                        if (historicFileBlock is null || historicFileBlock.SlotsAvailable == 0)
+                            historicFileBlock = historicFile.Fat.RequestDataBlock(pointID, dataPoint.Time, -1);
+
+                        // Write the data point into the data block
+                        if (historicFileBlock.Write(dataPoint, out Exception ex))
+                        {
+                            historicFile.Fat.DataPointsReceived++;
+                            historicFile.Fat.DataPointsArchived++;
+                        }
+                        else
+                        {
+                            // Suppress exceptions related to bad timestamps - this handles the case where the system is attempting to write
+                            // a historical point with a timestamp that is less than 01/01/1995, the minimum value for a TimeTag instance
+                            if (ex is not TimeTagException)
+                                OnDataWriteException(ex);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -3572,315 +3286,236 @@ namespace GSF.Historian.Files
                 }
             }
 
-            foreach (Info historicFileInfo in historicFileData.Keys)
+            try
             {
-                Dictionary<int, List<IDataPoint>> sortedPointData = historicFileData[historicFileInfo];
-                int overflowBlocks = 0;
-
-                using (ArchiveFile historicFile = new ArchiveFile())
-                {
-                    try
-                    {
-                        // Open the historic file
-                        historicFile.FileName = historicFileInfo.FileName;
-                        historicFile.StateFile = m_stateFile;
-                        historicFile.IntercomFile = m_intercomFile;
-                        historicFile.MetadataFile = m_metadataFile;
-                        historicFile.Open();
-                    }
-                    catch (Exception ex)
-                    {
-                        // Notify of the exception
-                        OnDataWriteException(ex);
-
-                        // If we fail to open the historic file,
-                        // then we cannot write any of these data
-                        // points to it so we might as well move on
-                        continue;
-                    }
-
-                    // Calculate the number of additional data blocks needed to store all the data
-                    foreach (int pointID in sortedPointData.Keys)
-                    {
-                        try
-                        {
-                            ArchiveDataBlock lastDataBlock = historicFile.Fat.FindLastDataBlock(pointID);
-                            int blockCapacity = historicFile.DataBlockSize * 1024 / ArchiveDataPoint.FixedLength;
-                            int overflowPoints = sortedPointData[pointID].Count + (lastDataBlock?.SlotsUsed ?? 0) - (lastDataBlock?.Capacity ?? 0);
-                            overflowBlocks += (overflowPoints + blockCapacity - 1) / blockCapacity;
-                        }
-                        catch (Exception ex)
-                        {
-                            // Notify of the exception
-                            OnDataWriteException(ex);
-                        }
-                    }
-
-                    try
-                    {
-                        // Extend the file by the needed amount
-                        if (overflowBlocks > 0)
-                            historicFile.Fat.Extend(overflowBlocks);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Notify of the exception
-                        OnDataWriteException(ex);
-                    }
-
-                    foreach (int pointID in sortedPointData.Keys)
-                    {
-                        try
-                        {
-                            ArchiveDataBlock historicFileBlock = null;
-
-                            // Sort the point data for the current point ID by time
-                            sortedPointData[pointID].Sort();
-
-                            foreach (IDataPoint dataPoint in sortedPointData[pointID])
-                            {
-                                if ((object)historicFileBlock == null || historicFileBlock.SlotsAvailable == 0)
-                                {
-                                    // Request a new or previously used data block for point data
-                                    historicFileBlock = historicFile.Fat.RequestDataBlock(pointID, dataPoint.Time, -1);
-                                }
-
-                                // Write the data point into the data block
-                                Exception ex;
-
-                                if (historicFileBlock.Write(dataPoint, out ex))
-                                {
-                                    historicFile.Fat.DataPointsReceived++;
-                                    historicFile.Fat.DataPointsArchived++;
-                                }
-                                else
-                                {
-                                    // Suppress exceptions related to bad timestamps - this handles the case where the system is attempting to write
-                                    // a historical point with a timestamp that is less than 01/01/1995, the minimum value for a TimeTag instance
-                                    if (!(ex is TimeTagException))
-                                        OnDataWriteException(ex);
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            // Notify of the exception
-                            OnDataWriteException(ex);
-                        }
-                    }
-
-                    try
-                    {
-                        // Save the file after all
-                        // data has been written to it
-                        historicFile.Save();
-                    }
-                    catch (Exception ex)
-                    {
-                        // Notify of the exception
-                        OnDataWriteException(ex);
-                    }
-                }
+                // Save the file after all
+                // data has been written to it
+                historicFile.Save();
+            }
+            catch (Exception ex)
+            {
+                // Notify of the exception
+                OnDataWriteException(ex);
             }
         }
-
-        private void InsertInCurrentArchiveFile(IDataPoint[] items)
-        {
-            // TODO: Implement archival of out-of-sequence data.
-        }
-
-        #endregion
-
-        #region [ Event Handlers ]
-
-        private void MetadataFile_FileModified(object sender, EventArgs e)
-        {
-            OnMetadataUpdated();
-            SyncStateFile(null);
-        }
-
-        private void ConserveMemoryTimer_Elapsed(object sender, ElapsedEventArgs e)
-        {
-            lock (m_dataBlocks)
-            {
-                // Go through all data blocks and remove that are inactive.
-                for (int i = 0; i < m_dataBlocks.Count; i++)
-                {
-                    if ((object)m_dataBlocks[i] != null && !m_dataBlocks[i].IsActive)
-                    {
-                        m_dataBlocks[i] = null;
-                        //Trace.WriteLine(string.Format("Inactive block for Point ID {0} disposed", i + 1));
-                    }
-                }
-            }
-        }
-
-        private void CurrentDataQueue_ProcessException(object sender, EventArgs<Exception> e)
-        {
-            OnDataWriteException(e.Argument);
-        }
-
-        private void HistoricDataQueue_ProcessException(object sender, EventArgs<Exception> e)
-        {
-            OnDataWriteException(e.Argument);
-        }
-
-        private void OutOfSequenceDataQueue_ProcessException(object sender, EventArgs<Exception> e)
-        {
-            OnDataWriteException(e.Argument);
-        }
-
-        // File.Delete proxy function that will manually invoke file watcher handlers when file watchers are disabled
-        private void DeleteFile(string fileName)
-        {
-            if (File.Exists(fileName))
-                File.Delete(fileName);
-
-            // Manually call file monitoring events if file watchers are not enabled
-            if (!m_monitorNewArchiveFiles)
-                FileWatcher_Deleted(this, new FileSystemEventArgs(WatcherChangeTypes.Deleted, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(fileName)), FilePath.GetFileName(fileName)));
-        }
-
-        // File.Move proxy function that will manually invoke file watcher handlers when file watchers are disabled
-        private void MoveFile(string sourceFileName, string destinationFileName)
-        {
-            File.Move(sourceFileName, destinationFileName);
-
-            // Manually call file monitoring events if file watchers are not enabled
-            if (!m_monitorNewArchiveFiles)
-            {
-                if (string.Compare(FilePath.GetDirectoryName(FilePath.GetAbsolutePath(sourceFileName)).Trim(), FilePath.GetDirectoryName(FilePath.GetAbsolutePath(destinationFileName)).Trim(), StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    //FileWatcher_Renamed(this, new RenamedEventArgs(WatcherChangeTypes.Renamed, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(sourceFileName)), FilePath.GetFileName(sourceFileName), FilePath.GetFileName(destinationFileName)));
-                    FileWatcher_Renamed(this, new RenamedEventArgs(WatcherChangeTypes.Renamed, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(destinationFileName)), FilePath.GetFileName(destinationFileName), FilePath.GetFileName(sourceFileName)));
-                }
-                else
-                {
-                    FileWatcher_Deleted(this, new FileSystemEventArgs(WatcherChangeTypes.Deleted, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(sourceFileName)), FilePath.GetFileName(sourceFileName)));
-                    FileWatcher_Created(this, new FileSystemEventArgs(WatcherChangeTypes.Created, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(destinationFileName)), FilePath.GetFileName(destinationFileName)));
-                }
-            }
-        }
-
-        private void FileWatcher_Created(object sender, FileSystemEventArgs e)
-        {
-            if ((object)m_historicArchiveFiles != null)
-            {
-                bool historicFileListUpdated = false;
-                Info historicFileInfo = GetHistoricFileInfo(e.FullPath);
-
-                lock (m_historicArchiveFiles)
-                {
-                    if ((object)historicFileInfo != null && !m_historicArchiveFiles.Contains(historicFileInfo))
-                    {
-                        m_historicArchiveFiles.Add(historicFileInfo);
-                        historicFileListUpdated = true;
-                    }
-                }
-
-                if (historicFileListUpdated)
-                    OnHistoricFileListUpdated();
-            }
-        }
-
-        private void FileWatcher_Deleted(object sender, FileSystemEventArgs e)
-        {
-            if ((object)m_historicArchiveFiles != null)
-            {
-                bool historicFileListUpdated = false;
-                Info historicFileInfo = GetHistoricFileInfo(e.FullPath);
-
-                lock (m_historicArchiveFiles)
-                {
-                    if ((object)historicFileInfo != null && m_historicArchiveFiles.Contains(historicFileInfo))
-                    {
-                        m_historicArchiveFiles.Remove(historicFileInfo);
-                        historicFileListUpdated = true;
-                    }
-                }
-
-                if (historicFileListUpdated)
-                    OnHistoricFileListUpdated();
-            }
-        }
-
-        private void FileWatcher_Renamed(object sender, RenamedEventArgs e)
-        {
-            if ((object)m_historicArchiveFiles != null)
-            {
-                if (string.Compare(FilePath.GetExtension(e.OldFullPath), FileExtension, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    try
-                    {
-                        bool historicFileListUpdated = false;
-                        Info oldFileInfo = GetHistoricFileInfo(e.OldFullPath);
-
-                        lock (m_historicArchiveFiles)
-                        {
-                            if ((object)oldFileInfo != null && m_historicArchiveFiles.Contains(oldFileInfo))
-                            {
-                                m_historicArchiveFiles.Remove(oldFileInfo);
-                                historicFileListUpdated = true;
-                            }
-                        }
-
-                        if (historicFileListUpdated)
-                            OnHistoricFileListUpdated();
-                    }
-                    catch
-                    {
-                        // Ignore any exception we might encounter here if an archive file being renamed to a
-                        // historic archive file. This might happen if someone is renaming files manually.
-                    }
-                }
-
-                if (string.Compare(FilePath.GetExtension(e.FullPath), FileExtension, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    try
-                    {
-                        bool historicFileListUpdated = false;
-                        Info newFileInfo = GetHistoricFileInfo(e.FullPath);
-
-                        lock (m_historicArchiveFiles)
-                        {
-                            if ((object)newFileInfo != null && !m_historicArchiveFiles.Contains(newFileInfo))
-                            {
-                                m_historicArchiveFiles.Add(newFileInfo);
-                                historicFileListUpdated = true;
-                            }
-                        }
-
-                        if (historicFileListUpdated)
-                            OnHistoricFileListUpdated();
-                    }
-                    catch
-                    {
-                        // Ignore any exception we might encounter if a historic archive file is being renamed to
-                        // something else. This might happen if someone is renaming files manually.
-                    }
-                }
-            }
-        }
-
-        #endregion
-
-        #endregion
-
-        #region [ Static ]
-
-        // Static Methods
-
-        /// <summary>
-        /// Returns the number of <see cref="ArchiveDataBlock"/>s an <see cref="ArchiveFile"/> can have.
-        /// </summary>
-        /// <param name="fileSize">Size (in MB) of the <see cref="ArchiveFile"/>.</param>
-        /// <param name="blockSize">Size (in KB) of the <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.</param>
-        /// <returns>A 32-bit signed integer for the number of <see cref="ArchiveDataBlock"/>s an <see cref="ArchiveFile"/> can have.</returns>
-        public static int MaximumDataBlocks(double fileSize, int blockSize)
-        {
-            return (int)((fileSize * 1024) / blockSize);
-        }
-
-        #endregion
     }
+
+    private void InsertInCurrentArchiveFile(IDataPoint[] items)
+    {
+        // TODO: Implement archival of out-of-sequence data.
+    }
+
+    #endregion
+
+    #region [ Event Handlers ]
+
+    private void MetadataFile_FileModified(object sender, EventArgs e)
+    {
+        OnMetadataUpdated();
+        SyncStateFile(null);
+    }
+
+    private void ConserveMemoryTimer_Elapsed(object sender, ElapsedEventArgs e)
+    {
+        lock (m_dataBlocks)
+        {
+            // Go through all data blocks and remove that are inactive.
+            for (int i = 0; i < m_dataBlocks.Count; i++)
+            {
+                if (m_dataBlocks[i] is not null && !m_dataBlocks[i].IsActive)
+                    m_dataBlocks[i] = null;
+            }
+        }
+    }
+
+    private void CurrentDataQueue_ProcessException(object sender, EventArgs<Exception> e)
+    {
+        OnDataWriteException(e.Argument);
+    }
+
+    private void HistoricDataQueue_ProcessException(object sender, EventArgs<Exception> e)
+    {
+        OnDataWriteException(e.Argument);
+    }
+
+    private void OutOfSequenceDataQueue_ProcessException(object sender, EventArgs<Exception> e)
+    {
+        OnDataWriteException(e.Argument);
+    }
+
+    // File.Delete proxy function that will manually invoke file watcher handlers when file watchers are disabled
+    private void DeleteFile(string fileName)
+    {
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+
+        // Manually call file monitoring events if file watchers are not enabled
+        if (!MonitorNewArchiveFiles)
+            FileWatcher_Deleted(this, new FileSystemEventArgs(WatcherChangeTypes.Deleted, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(fileName)), FilePath.GetFileName(fileName)));
+    }
+
+    // File.Move proxy function that will manually invoke file watcher handlers when file watchers are disabled
+    private void MoveFile(string sourceFileName, string destinationFileName)
+    {
+        File.Move(sourceFileName, destinationFileName);
+
+        // Manually call file monitoring events if file watchers are not enabled
+        if (MonitorNewArchiveFiles)
+            return;
+        
+        if (string.Compare(FilePath.GetDirectoryName(FilePath.GetAbsolutePath(sourceFileName)).Trim(), FilePath.GetDirectoryName(FilePath.GetAbsolutePath(destinationFileName)).Trim(), StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            //FileWatcher_Renamed(this, new RenamedEventArgs(WatcherChangeTypes.Renamed, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(sourceFileName)), FilePath.GetFileName(sourceFileName), FilePath.GetFileName(destinationFileName)));
+            FileWatcher_Renamed(this, new RenamedEventArgs(WatcherChangeTypes.Renamed, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(destinationFileName)), FilePath.GetFileName(destinationFileName), FilePath.GetFileName(sourceFileName)));
+        }
+        else
+        {
+            FileWatcher_Deleted(this, new FileSystemEventArgs(WatcherChangeTypes.Deleted, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(sourceFileName)), FilePath.GetFileName(sourceFileName)));
+            FileWatcher_Created(this, new FileSystemEventArgs(WatcherChangeTypes.Created, FilePath.GetDirectoryName(FilePath.GetAbsolutePath(destinationFileName)), FilePath.GetFileName(destinationFileName)));
+        }
+    }
+
+    private void FileWatcher_Created(object sender, FileSystemEventArgs e)
+    {
+        if (m_historicArchiveFiles is null)
+            return;
+        
+        bool historicFileListUpdated = false;
+        Info historicFileInfo = GetHistoricFileInfo(e.FullPath);
+
+        lock (m_historicArchiveFiles)
+        {
+            if (historicFileInfo is not null && !m_historicArchiveFiles.Contains(historicFileInfo))
+            {
+                m_historicArchiveFiles.Add(historicFileInfo);
+                historicFileListUpdated = true;
+            }
+        }
+
+        if (historicFileListUpdated)
+            OnHistoricFileListUpdated();
+    }
+
+    private void FileWatcher_Deleted(object sender, FileSystemEventArgs e)
+    {
+        if (m_historicArchiveFiles is null)
+            return;
+        
+        bool historicFileListUpdated = false;
+        Info historicFileInfo = GetHistoricFileInfo(e.FullPath);
+
+        lock (m_historicArchiveFiles)
+        {
+            if (historicFileInfo is not null && m_historicArchiveFiles.Contains(historicFileInfo))
+            {
+                m_historicArchiveFiles.Remove(historicFileInfo);
+                historicFileListUpdated = true;
+            }
+        }
+
+        if (historicFileListUpdated)
+            OnHistoricFileListUpdated();
+    }
+
+    private void FileWatcher_Renamed(object sender, RenamedEventArgs e)
+    {
+        if (m_historicArchiveFiles is null)
+            return;
+        
+        if (string.Compare(FilePath.GetExtension(e.OldFullPath), FileExtension, StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            try
+            {
+                bool historicFileListUpdated = false;
+                Info oldFileInfo = GetHistoricFileInfo(e.OldFullPath);
+
+                lock (m_historicArchiveFiles)
+                {
+                    if (oldFileInfo is not null && m_historicArchiveFiles.Contains(oldFileInfo))
+                    {
+                        m_historicArchiveFiles.Remove(oldFileInfo);
+                        historicFileListUpdated = true;
+                    }
+                }
+
+                if (historicFileListUpdated)
+                    OnHistoricFileListUpdated();
+            }
+            catch
+            {
+                // Ignore any exception we might encounter here if an archive file being renamed to a
+                // historic archive file. This might happen if someone is renaming files manually.
+            }
+        }
+
+        if (string.Compare(FilePath.GetExtension(e.FullPath), FileExtension, StringComparison.OrdinalIgnoreCase) != 0)
+            return;
+        
+        try
+        {
+            bool historicFileListUpdated = false;
+            Info newFileInfo = GetHistoricFileInfo(e.FullPath);
+
+            lock (m_historicArchiveFiles)
+            {
+                if (newFileInfo is not null && !m_historicArchiveFiles.Contains(newFileInfo))
+                {
+                    m_historicArchiveFiles.Add(newFileInfo);
+                    historicFileListUpdated = true;
+                }
+            }
+
+            if (historicFileListUpdated)
+                OnHistoricFileListUpdated();
+        }
+        catch
+        {
+            // Ignore any exception we might encounter if a historic archive file is being renamed to
+            // something else. This might happen if someone is renaming files manually.
+        }
+    }
+
+    #endregion
+
+    #endregion
+
+    #region [ Static ]
+
+    // Static Methods
+
+    /// <summary>
+    /// Returns the number of <see cref="ArchiveDataBlock"/>s an <see cref="ArchiveFile"/> can have.
+    /// </summary>
+    /// <param name="fileSize">Size (in MB) of the <see cref="ArchiveFile"/>.</param>
+    /// <param name="blockSize">Size (in KB) of the <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.</param>
+    /// <returns>A 32-bit signed integer for the number of <see cref="ArchiveDataBlock"/>s an <see cref="ArchiveFile"/> can have.</returns>
+    public static int MaximumDataBlocks(double fileSize, int blockSize)
+    {
+        return (int)(fileSize * 1024 / blockSize);
+    }
+
+    // Find Predicates
+    private static bool FindHistoricArchiveFileForRead(Info fileInfo, TimeTag startTime, TimeTag endTime)
+    {
+        return fileInfo is not null &&
+               ((startTime.CompareTo(fileInfo.StartTimeTag) >= 0 && startTime.CompareTo(fileInfo.EndTimeTag) <= 0) ||
+                (endTime.CompareTo(fileInfo.StartTimeTag) >= 0 && endTime.CompareTo(fileInfo.EndTimeTag) <= 0) ||
+                (startTime.CompareTo(fileInfo.StartTimeTag) < 0 && endTime.CompareTo(fileInfo.EndTimeTag) > 0));
+    }
+
+    private static bool FindHistoricArchiveFileForWrite(Info fileInfo, TimeTag searchTime)
+    {
+        return fileInfo is not null &&
+               searchTime.CompareTo(fileInfo.StartTimeTag) >= 0 &&
+               searchTime.CompareTo(fileInfo.EndTimeTag) <= 0;
+    }
+
+    // Determines if the historic file is in the primary archive location (not offloaded).
+    private static bool IsNewHistoricArchiveFile(Info fileInfo, string fileName)
+    {
+        return fileInfo is not null &&
+               string.Compare(FilePath.GetDirectoryName(fileName), FilePath.GetDirectoryName(fileInfo.FileName), StringComparison.OrdinalIgnoreCase) == 0;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveFileAllocationTable.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveFileAllocationTable.cs
@@ -54,303 +54,51 @@ using GSF.Interop;
 using GSF.Parsing;
 using GSF.Units;
 
-namespace GSF.Historian.Files
+// ReSharper disable InconsistentlySynchronizedField
+// ReSharper disable MemberCanBePrivate.Local
+
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents the File Allocation Table of an <see cref="ArchiveFile"/>.
+/// </summary>
+/// <seealso cref="ArchiveFile"/>.
+/// <seealso cref="ArchiveDataBlock"/>
+/// <seealso cref="ArchiveDataBlockPointer"/>
+public class ArchiveFileAllocationTable : ISupportBinaryImage
 {
+    #region [ Members ]
+
+    // Nested Types
+
     /// <summary>
-    /// Represents the File Allocation Table of an <see cref="ArchiveFile"/>.
+    /// Defines the fixed table region of the <see cref="ArchiveFileAllocationTable"/>.
     /// </summary>
-    /// <seealso cref="ArchiveFile"/>.
-    /// <seealso cref="ArchiveDataBlock"/>
-    /// <seealso cref="ArchiveDataBlockPointer"/>
-    public class ArchiveFileAllocationTable : ISupportBinaryImage
+    private class FixedTableRegion : ISupportBinaryImage
     {
         #region [ Members ]
 
-        // Nested Types
-
-        /// <summary>
-        /// Defines the fixed table region of the <see cref="ArchiveFileAllocationTable"/>.
-        /// </summary>
-        private class FixedTableRegion : ISupportBinaryImage
-        {
-            #region [ Members ]
-
-            // Constants
-
-            /// <summary>
-            /// Specifies the number of bytes in the binary image of the <see cref="FixedTableRegion"/>.
-            /// </summary>
-            public const int FixedLength = 32;
-
-            // Fields
-            private readonly ArchiveFileAllocationTable m_parent;
-
-            #endregion
-
-            #region [ Constructors ]
-
-            /// <summary>
-            /// Creates a new instance of the <see cref="FixedTableRegion"/>.
-            /// </summary>
-            /// <param name="parent">Reference to parent <see cref="ArchiveFileAllocationTable"/>.</param>
-            public FixedTableRegion(ArchiveFileAllocationTable parent)
-            {
-                m_parent = parent;
-            }
-
-            #endregion
-
-            #region [ Properties ]
-
-            /// <summary>
-            /// Gets the length of the <see cref="FixedTableRegion"/>.
-            /// </summary>
-            public int BinaryLength
-            {
-                get
-                {
-                    return FixedLength;
-                }
-            }
-
-            #endregion
-
-            #region [ Methods ]
-
-            /// <summary>
-            /// Initializes <see cref="FixedTableRegion"/> by parsing the specified <paramref name="buffer"/> containing a binary image.
-            /// </summary>
-            /// <param name="buffer">Buffer containing binary image to parse.</param>
-            /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start parsing.</param>
-            /// <param name="length">Valid number of bytes within <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-            /// <returns>The number of bytes used for initialization in the <paramref name="buffer"/> (i.e., the number of bytes parsed).</returns>
-            /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-            /// <exception cref="ArgumentOutOfRangeException">
-            /// <paramref name="startIndex"/> or <paramref name="length"/> is less than 0 -or- 
-            /// <paramref name="startIndex"/> and <paramref name="length"/> will exceed <paramref name="buffer"/> length.
-            /// </exception>
-            public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-            {
-                buffer.ValidateParameters(startIndex, length);
-
-                decimal startTime = (decimal)LittleEndian.ToDouble(buffer, startIndex);
-                decimal stopTime = (decimal)LittleEndian.ToDouble(buffer, startIndex + 8);
-
-                // Validate file time tags
-                if (startTime < TimeTag.MinValue.Value || startTime > TimeTag.MaxValue.Value)
-                    startTime = TimeTag.MinValue.Value;
-
-                if (stopTime < TimeTag.MinValue.Value || stopTime > TimeTag.MaxValue.Value)
-                    stopTime = TimeTag.MinValue.Value;
-
-                m_parent.FileStartTime = new TimeTag(startTime);
-                m_parent.FileEndTime = new TimeTag(stopTime);
-                m_parent.DataPointsReceived = LittleEndian.ToInt32(buffer, startIndex + 16);
-                m_parent.DataPointsArchived = LittleEndian.ToInt32(buffer, startIndex + 20);
-                m_parent.DataBlockSize = LittleEndian.ToInt32(buffer, startIndex + 24);
-                m_parent.DataBlockCount = LittleEndian.ToInt32(buffer, startIndex + 28);
-
-                return FixedLength;
-            }
-
-            /// <summary>
-            /// Generates binary image of the <see cref="FixedTableRegion"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-            /// </summary>
-            /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-            /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-            /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-            /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-            /// <exception cref="ArgumentOutOfRangeException">
-            /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-            /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-            /// </exception>
-            public int GenerateBinaryImage(byte[] buffer, int startIndex)
-            {
-                int length = BinaryLength;
-
-                buffer.ValidateParameters(startIndex, length);
-
-                Buffer.BlockCopy(LittleEndian.GetBytes((double)m_parent.m_fileStartTime.Value), 0, buffer, startIndex, 8);
-                Buffer.BlockCopy(LittleEndian.GetBytes((double)m_parent.m_fileEndTime.Value), 0, buffer, startIndex + 8, 8);
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataPointsReceived), 0, buffer, startIndex + 16, 4);
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataPointsArchived), 0, buffer, startIndex + 20, 4);
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataBlockSize), 0, buffer, startIndex + 24, 4);
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataBlockCount), 0, buffer, startIndex + 28, 4);
-
-                return length;
-            }
-
-            #endregion
-        }
-
-        /// <summary>
-        /// Defines the variable table region of the <see cref="ArchiveFileAllocationTable"/>.
-        /// </summary>
-        private class VariableTableRegion : ISupportBinaryImage
-        {
-            #region [ Members ]
-
-            // Fields
-            private readonly ArchiveFileAllocationTable m_parent;
-
-            #endregion
-
-            #region [ Constructors ]
-
-            /// <summary>
-            /// Creates a new instance of the <see cref="VariableTableRegion"/>.
-            /// </summary>
-            /// <param name="parent">Reference to parent <see cref="ArchiveFileAllocationTable"/>.</param>
-            public VariableTableRegion(ArchiveFileAllocationTable parent)
-            {
-                m_parent = parent;
-            }
-
-            #endregion
-
-            #region [ Properties ]
-
-            /// <summary>
-            /// Gets the length of the <see cref="VariableTableRegion"/>.
-            /// </summary>
-            public int BinaryLength
-            {
-                get
-                {
-                    // We add the extra bytes for the array descriptor that are required for reading the file from a VB6 style application.
-                    return (ArrayDescriptorLength + (m_parent.m_dataBlockCount * ArchiveDataBlockPointer.FixedLength));
-                }
-            }
-
-            #endregion
-
-            #region [ Methods ]
-
-            /// <summary>
-            /// Initializes <see cref="VariableTableRegion"/> by parsing the specified <paramref name="buffer"/> containing a binary image.
-            /// </summary>
-            /// <param name="buffer">Buffer containing binary image to parse.</param>
-            /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start parsing.</param>
-            /// <param name="length">Valid number of bytes within <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-            /// <returns>The number of bytes used for initialization in the <paramref name="buffer"/> (i.e., the number of bytes parsed).</returns>
-            /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-            /// <exception cref="ArgumentOutOfRangeException">
-            /// <paramref name="startIndex"/> or <paramref name="length"/> is less than 0 -or- 
-            /// <paramref name="startIndex"/> and <paramref name="length"/> will exceed <paramref name="buffer"/> length.
-            /// </exception>
-            public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-            {
-                buffer.ValidateParameters(startIndex, length);
-
-                ArchiveDataBlockPointer blockPointer;
-
-                // Set parsing cursor beyond old-style visual basic array descriptor
-                int index = startIndex + ArrayDescriptorLength;
-
-                for (int i = 0; i < m_parent.m_dataBlockCount; i++)
-                {
-                    blockPointer = new ArchiveDataBlockPointer(m_parent.m_parent, i);
-                    index += blockPointer.ParseBinaryImage(buffer, index, length - (index - startIndex));
-                    m_parent.m_dataBlockPointers.Add(blockPointer);
-                }
-
-                return (index - startIndex);
-            }
-
-            /// <summary>
-            /// Generates binary image of the <see cref="VariableTableRegion"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-            /// </summary>
-            /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-            /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-            /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-            /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-            /// <exception cref="ArgumentOutOfRangeException">
-            /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-            /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-            /// </exception>
-            public int GenerateBinaryImage(byte[] buffer, int startIndex)
-            {
-                int length = BinaryLength;
-
-                buffer.ValidateParameters(startIndex, length);
-
-                VBArrayDescriptor arrayDescriptor = VBArrayDescriptor.OneBasedOneDimensionalArray(m_parent.m_dataBlockCount);
-
-                startIndex += arrayDescriptor.GenerateBinaryImage(buffer, startIndex);
-
-                lock (m_parent.m_dataBlockPointers)
-                {
-                    for (int i = 0; i < m_parent.m_dataBlockPointers.Count; i++)
-                    {
-                        startIndex += m_parent.m_dataBlockPointers[i].GenerateBinaryImage(buffer, startIndex);
-                    }
-                }
-
-                return length;
-            }
-
-            #endregion
-        }
-
         // Constants
-        private const int ArrayDescriptorLength = 10;
+
+        /// <summary>
+        /// Specifies the number of bytes in the binary image of the <see cref="FixedTableRegion"/>.
+        /// </summary>
+        public const int FixedLength = 32;
 
         // Fields
-        private TimeTag m_fileStartTime;
-        private TimeTag m_fileEndTime;
-        private int m_dataPointsReceived;
-        private int m_dataPointsArchived;
-        private int m_dataBlockSize;
-        private int m_dataBlockCount;
-        private readonly List<ArchiveDataBlockPointer> m_dataBlockPointers;
-        private readonly ArchiveFile m_parent;
-        private readonly FixedTableRegion m_fixedTableRegion;
-        private readonly VariableTableRegion m_variableTableRegion;
+        private readonly ArchiveFileAllocationTable m_parent;
 
         #endregion
 
         #region [ Constructors ]
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveFileAllocationTable"/> class.
+        /// Creates a new instance of the <see cref="FixedTableRegion"/>.
         /// </summary>
-        /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
-        internal ArchiveFileAllocationTable(ArchiveFile parent)
+        /// <param name="parent">Reference to parent <see cref="ArchiveFileAllocationTable"/>.</param>
+        public FixedTableRegion(ArchiveFileAllocationTable parent)
         {
             m_parent = parent;
-            m_dataBlockPointers = new List<ArchiveDataBlockPointer>();
-            m_fixedTableRegion = new FixedTableRegion(this);
-            m_variableTableRegion = new VariableTableRegion(this);
-
-            if (m_parent.FileData.Length == 0)
-            {
-                // File is brand new.
-                m_fileStartTime = TimeTag.MinValue;
-                m_fileEndTime = TimeTag.MinValue;
-                m_dataBlockSize = m_parent.DataBlockSize;
-                m_dataBlockCount = ArchiveFile.MaximumDataBlocks(m_parent.FileSize, m_parent.DataBlockSize);
-
-                for (int i = 0; i < m_dataBlockCount; i++)
-                {
-                    m_dataBlockPointers.Add(new ArchiveDataBlockPointer(m_parent, i));
-                }
-            }
-            else
-            {
-                // Existing file, read table regions:
-
-                // Seek to beginning of fixed table region
-                m_parent.FileData.Seek(-m_fixedTableRegion.BinaryLength, SeekOrigin.End);
-
-                // Parse fixed table region
-                m_fixedTableRegion.ParseBinaryImageFromStream(m_parent.FileData);
-
-                // Seek to beginning of variable table region (above fixed from bottom of file)
-                m_parent.FileData.Seek(-(m_fixedTableRegion.BinaryLength + m_variableTableRegion.BinaryLength), SeekOrigin.End);
-
-                // Parse variable table region
-                m_variableTableRegion.ParseBinaryImageFromStream(m_parent.FileData);
-            }
         }
 
         #endregion
@@ -358,183 +106,52 @@ namespace GSF.Historian.Files
         #region [ Properties ]
 
         /// <summary>
-        /// Gets or sets the <see cref="TimeTag"/> of the oldest <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
+        /// Gets the length of the <see cref="FixedTableRegion"/>.
         /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
-        public TimeTag FileStartTime
-        {
-            get
-            {
-                return m_fileStartTime;
-            }
-            set
-            {
-                if (value < TimeTag.MinValue || value > TimeTag.MaxValue)
-                    throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
-
-                m_fileStartTime = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="TimeTag"/> of the newest <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
-        public TimeTag FileEndTime
-        {
-            get
-            {
-                return m_fileEndTime;
-            }
-            set
-            {
-                if (value < TimeTag.MinValue || value > TimeTag.MaxValue)
-                    throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
-
-                m_fileEndTime = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number <see cref="ArchiveDataPoint"/>s received by the <see cref="ArchiveFile"/> for archival.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
-        public int DataPointsReceived
-        {
-            get
-            {
-                return m_dataPointsReceived;
-            }
-            set
-            {
-                if (value < 0)
-                    throw new ArgumentException("Value must be positive or zero");
-
-                m_dataPointsReceived = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number <see cref="ArchiveDataPoint"/>s archived by the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
-        public int DataPointsArchived
-        {
-            get
-            {
-                return m_dataPointsArchived;
-            }
-            set
-            {
-                if (value < 0)
-                    throw new ArgumentException("Value must be positive or zero");
-
-                m_dataPointsArchived = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the size (in KB) of a single <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        public int DataBlockSize
-        {
-            get
-            {
-                return m_dataBlockSize;
-            }
-            private set
-            {
-                if (value < 1)
-                    throw new ArgumentException("Value must be positive");
-
-                m_dataBlockSize = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the total number of <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        public int DataBlockCount
-        {
-            get
-            {
-                return m_dataBlockCount;
-            }
-            private set
-            {
-                if (value < 1)
-                    throw new ArgumentException("Value must be positive");
-
-                m_dataBlockCount = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the number of used <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        public int DataBlocksUsed
-        {
-            get
-            {
-                return m_dataBlockCount - DataBlocksAvailable;
-            }
-        }
-
-        /// <summary>
-        /// Gets the number of unused <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        public int DataBlocksAvailable
-        {
-            get
-            {
-                ArchiveDataBlock unusedDataBlock = FindDataBlock(-1);
-
-                if ((object)unusedDataBlock != null)
-                    return m_dataBlockCount - unusedDataBlock.Index;
-
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArchiveDataBlockPointer"/>s to the <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <remarks>
-        /// WARNING: <see cref="DataBlockPointers"/> is not thread safe. Synchronized access is required.
-        /// </remarks>
-        public IList<ArchiveDataBlockPointer> DataBlockPointers
-        {
-            get
-            {
-                return m_dataBlockPointers.AsReadOnly();
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="ArchiveFileAllocationTable"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return m_variableTableRegion.BinaryLength + m_fixedTableRegion.BinaryLength;
-            }
-        }
-
-        private long DataLength
-        {
-            get
-            {
-                return (m_dataBlockCount * (m_dataBlockSize * 1024));
-            }
-        }
+        public int BinaryLength => FixedLength;
 
         #endregion
 
         #region [ Methods ]
 
         /// <summary>
-        /// Generates binary image of the <see cref="ArchiveFileAllocationTable"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+        /// Initializes <see cref="FixedTableRegion"/> by parsing the specified <paramref name="buffer"/> containing a binary image.
+        /// </summary>
+        /// <param name="buffer">Buffer containing binary image to parse.</param>
+        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start parsing.</param>
+        /// <param name="length">Valid number of bytes within <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+        /// <returns>The number of bytes used for initialization in the <paramref name="buffer"/> (i.e., the number of bytes parsed).</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> or <paramref name="length"/> is less than 0 -or- 
+        /// <paramref name="startIndex"/> and <paramref name="length"/> will exceed <paramref name="buffer"/> length.
+        /// </exception>
+        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+        {
+            buffer.ValidateParameters(startIndex, length);
+
+            decimal startTime = (decimal)LittleEndian.ToDouble(buffer, startIndex);
+            decimal stopTime = (decimal)LittleEndian.ToDouble(buffer, startIndex + 8);
+
+            // Validate file time tags
+            if (startTime < TimeTag.MinValue.Value || startTime > TimeTag.MaxValue.Value)
+                startTime = TimeTag.MinValue.Value;
+
+            if (stopTime < TimeTag.MinValue.Value || stopTime > TimeTag.MaxValue.Value)
+                stopTime = TimeTag.MinValue.Value;
+
+            m_parent.FileStartTime = new TimeTag(startTime);
+            m_parent.FileEndTime = new TimeTag(stopTime);
+            m_parent.DataPointsReceived = LittleEndian.ToInt32(buffer, startIndex + 16);
+            m_parent.DataPointsArchived = LittleEndian.ToInt32(buffer, startIndex + 20);
+            m_parent.DataBlockSize = LittleEndian.ToInt32(buffer, startIndex + 24);
+            m_parent.DataBlockCount = LittleEndian.ToInt32(buffer, startIndex + 28);
+
+            return FixedLength;
+        }
+
+        /// <summary>
+        /// Generates binary image of the <see cref="FixedTableRegion"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
         /// </summary>
         /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
         /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
@@ -550,314 +167,618 @@ namespace GSF.Historian.Files
 
             buffer.ValidateParameters(startIndex, length);
 
-            startIndex += m_variableTableRegion.GenerateBinaryImage(buffer, startIndex);
-            m_fixedTableRegion.GenerateBinaryImage(buffer, startIndex);
+            Buffer.BlockCopy(LittleEndian.GetBytes((double)m_parent.m_fileStartTime.Value), 0, buffer, startIndex, 8);
+            Buffer.BlockCopy(LittleEndian.GetBytes((double)m_parent.m_fileEndTime.Value), 0, buffer, startIndex + 8, 8);
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataPointsReceived), 0, buffer, startIndex + 16, 4);
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataPointsArchived), 0, buffer, startIndex + 20, 4);
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataBlockSize), 0, buffer, startIndex + 24, 4);
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_parent.m_dataBlockCount), 0, buffer, startIndex + 28, 4);
 
             return length;
         }
 
-        // 
+        #endregion
+    }
+
+    /// <summary>
+    /// Defines the variable table region of the <see cref="ArchiveFileAllocationTable"/>.
+    /// </summary>
+    private class VariableTableRegion : ISupportBinaryImage
+    {
+        #region [ Members ]
+
+        // Fields
+        private readonly ArchiveFileAllocationTable m_parent;
+
+        #endregion
+
+        #region [ Constructors ]
+
         /// <summary>
-        /// Initializes object by parsing the specified <paramref name="buffer"/> containing a binary image.
+        /// Creates a new instance of the <see cref="VariableTableRegion"/>.
+        /// </summary>
+        /// <param name="parent">Reference to parent <see cref="ArchiveFileAllocationTable"/>.</param>
+        public VariableTableRegion(ArchiveFileAllocationTable parent)
+        {
+            m_parent = parent;
+        }
+
+        #endregion
+
+        #region [ Properties ]
+
+        /// <summary>
+        /// Gets the length of the <see cref="VariableTableRegion"/>.
+        /// </summary>
+        public int BinaryLength =>
+            // We add the extra bytes for the array descriptor that are required for reading the file from a VB6 style application.
+            ArrayDescriptorLength + m_parent.m_dataBlockCount * ArchiveDataBlockPointer.FixedLength;
+
+        #endregion
+
+        #region [ Methods ]
+
+        /// <summary>
+        /// Initializes <see cref="VariableTableRegion"/> by parsing the specified <paramref name="buffer"/> containing a binary image.
         /// </summary>
         /// <param name="buffer">Buffer containing binary image to parse.</param>
         /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start parsing.</param>
-        /// <param name="length">Valid number of bytes within <paramref name="buffer"/> to read from <paramref name="startIndex"/>.</param>
+        /// <param name="length">Valid number of bytes within <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
         /// <returns>The number of bytes used for initialization in the <paramref name="buffer"/> (i.e., the number of bytes parsed).</returns>
-        /// <remarks>
-        /// This method is never used since constructor parses the point allocation table.
-        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> or <paramref name="length"/> is less than 0 -or- 
+        /// <paramref name="startIndex"/> and <paramref name="length"/> will exceed <paramref name="buffer"/> length.
+        /// </exception>
         public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
         {
-            return 0;            
+            buffer.ValidateParameters(startIndex, length);
+
+            // Set parsing cursor beyond old-style visual basic array descriptor
+            int index = startIndex + ArrayDescriptorLength;
+
+            for (int i = 0; i < m_parent.m_dataBlockCount; i++)
+            {
+                ArchiveDataBlockPointer blockPointer = new(m_parent.m_parent, i);
+                index += blockPointer.ParseBinaryImage(buffer, index, length - (index - startIndex));
+                m_parent.m_dataBlockPointers.Add(blockPointer);
+            }
+
+            return index - startIndex;
         }
 
         /// <summary>
-        /// Saves the <see cref="ArchiveFileAllocationTable"/> data to the <see cref="ArchiveFile"/>.
+        /// Generates binary image of the <see cref="VariableTableRegion"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
         /// </summary>
-        /// <param name="forceFlush">Forces an immediate disk flush for save.</param>
-        public void Save(bool forceFlush = false)
+        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+        /// </exception>
+        public int GenerateBinaryImage(byte[] buffer, int startIndex)
         {
-            // Leave space for data blocks.
-            lock (m_parent.FileData)
+            int length = BinaryLength;
+
+            buffer.ValidateParameters(startIndex, length);
+
+            VBArrayDescriptor arrayDescriptor = VBArrayDescriptor.OneBasedOneDimensionalArray(m_parent.m_dataBlockCount);
+
+            startIndex += arrayDescriptor.GenerateBinaryImage(buffer, startIndex);
+
+            lock (m_parent.m_dataBlockPointers)
             {
-                if (m_parent.FileData.Length == 0)
-                    m_parent.FileData.SetLength((long)(m_parent.FileSize * SI2.Mega));
-
-                m_parent.FileData.Seek(DataLength, SeekOrigin.Begin);
-
-                this.CopyBinaryImageToStream(m_parent.FileData);
-
-                if (!m_parent.CacheWrites)
-                    m_parent.FileData.Flush();
-            }
-        }
-
-        /// <summary>
-        /// Extends the <see cref="ArchiveFile"/> by one <see cref="ArchiveDataBlock"/>.
-        /// </summary>
-        public void Extend()
-        {
-            Extend(1);
-        }
-
-        /// <summary>
-        /// Extends the <see cref="ArchiveFile"/> by the specified number of <see cref="ArchiveDataBlock"/>s.
-        /// </summary>
-        /// <param name="dataBlocksToAdd">Number of <see cref="ArchiveDataBlock"/>s to add to the <see cref="ArchiveFile"/>.</param>
-        public void Extend(int dataBlocksToAdd)
-        {
-            // Extend the FAT.
-            lock (m_dataBlockPointers)
-            {
-                for (int i = 1; i <= dataBlocksToAdd; i++)
-                {
-                    m_dataBlockPointers.Add(new ArchiveDataBlockPointer(m_parent, m_dataBlockPointers.Count));
-
-                }
-                m_dataBlockCount = m_dataBlockPointers.Count;
+                for (int i = 0; i < m_parent.m_dataBlockPointers.Count; i++)
+                    startIndex += m_parent.m_dataBlockPointers[i].GenerateBinaryImage(buffer, startIndex);
             }
 
-            Save();
-
-            // Initialize newly added data blocks.
-            ArchiveDataBlock dataBlock;
-
-            for (int i = m_dataBlockCount - dataBlocksToAdd; i < m_dataBlockCount; i++)
-            {
-                dataBlock = new ArchiveDataBlock(m_parent, i, -1);
-                dataBlock.Reset();
-            }
-        }
-
-        /// <summary>
-        /// Returns the first <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier whose <see cref="ArchiveDataBlock"/> is to be retrieved.</param>
-        /// <param name="preRead">true to pre-read data to locate write cursor.</param>
-        /// <returns><see cref="ArchiveDataBlock"/> object if a match is found; otherwise null.</returns>
-        public ArchiveDataBlock FindDataBlock(int historianID, bool preRead = true)
-        {
-            ArchiveDataBlockPointer pointer;
-
-            lock (m_dataBlockPointers)
-            {
-                pointer = m_dataBlockPointers.FirstOrDefault(dataBlockPointer => dataBlockPointer.HistorianID == historianID);
-            }
-
-            if ((object)pointer == null)
-                return null;
-
-            return pointer.GetDataBlock(preRead);
-        }
-
-        /// <summary>
-        /// Returns the last <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="preRead">true to pre-read data to locate write cursor.</param>
-        /// <returns><see cref="ArchiveDataBlock"/> object if a match is found; otherwise null.</returns>
-        public ArchiveDataBlock FindLastDataBlock(int historianID, bool preRead = true)
-        {
-            ArchiveDataBlockPointer pointer;
-
-            lock (m_dataBlockPointers)
-            {
-                pointer = m_dataBlockPointers.LastOrDefault(dataBlockPointer => dataBlockPointer.HistorianID == historianID);
-            }
-
-            if ((object)pointer == null)
-                return null;
-
-            return pointer.GetDataBlock(preRead);
-        }
-
-        /// <summary>
-        /// Returns all <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="preRead">true to pre-read data to locate write cursor.</param>
-        /// <returns>A collection of <see cref="ArchiveDataBlock"/>s.</returns>
-        public List<ArchiveDataBlock> FindDataBlocks(int historianID, bool preRead = true)
-        {
-            return FindDataBlocks(historianID, TimeTag.MinValue, preRead);
-        }
-
-        /// <summary>
-        /// Returns all <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/> with <see cref="ArchiveDataPoint"/> points later than the specified <paramref name="startTime"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="startTime">Start <see cref="TimeTag"/>.</param>
-        /// <param name="preRead">true to pre-read data to locate write cursor.</param>
-        /// <returns>A collection of <see cref="ArchiveDataBlock"/>s.</returns>
-        public List<ArchiveDataBlock> FindDataBlocks(int historianID, TimeTag startTime, bool preRead = true)
-        {
-            return FindDataBlocks(historianID, startTime, TimeTag.MaxValue, preRead);
-        }
-
-        /// <summary>
-        /// Returns all <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/> with <see cref="ArchiveDataPoint"/>s between the specified <paramref name="startTime"/> and <paramref name="endTime"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="startTime">Start <see cref="TimeTag"/>.</param>
-        /// <param name="endTime">End <see cref="TimeTag"/>.</param>
-        /// <param name="preRead">true to pre-read data to locate write cursor.</param>
-        /// <returns>A collection of <see cref="ArchiveDataBlock"/>s.</returns>
-        public List<ArchiveDataBlock> FindDataBlocks(int historianID, TimeTag startTime, TimeTag endTime, bool preRead = true)
-        {
-            if ((object)startTime == null)
-                startTime = TimeTag.MaxValue;
-
-            if ((object)endTime == null)
-                endTime = TimeTag.MaxValue;
-
-            List<ArchiveDataBlockPointer> blockPointers;
-
-            lock (m_dataBlockPointers)
-            {
-                // Get all block pointers for given point ID over specified time range
-                blockPointers = m_dataBlockPointers.FindAll(dataBlockPointer => dataBlockPointer.Matches(historianID, startTime, endTime));
-
-                // Look for pointer to data block on the borders of the specified range which may contain data
-                if (!(startTime == TimeTag.MinValue || endTime == TimeTag.MaxValue))
-                {
-                    // There are 2 different search criteria for this:
-
-                    // 1) If matching data block pointers have been found, then find data block pointer before the first matching data block pointer.
-                    //    or
-                    // 2) Find the last data block pointer in the time range of TimeTag.MinValue to m_searchEndTime.
-
-                    TimeTag searchEndTime = endTime;
-
-                    if (blockPointers.Count > 0)
-                        searchEndTime = new TimeTag(blockPointers.First().StartTime.Value - 1.0M);
-
-                    ArchiveDataBlockPointer borderMatch = m_dataBlockPointers.LastOrDefault(dataBlockPointer => dataBlockPointer.Matches(historianID, TimeTag.MinValue, searchEndTime));
-
-                    if ((object)borderMatch != null)
-                        blockPointers.Insert(0, borderMatch);
-                }
-            }
-
-            // Return list of data blocks for given block pointers
-            return blockPointers.Select(pointer => pointer.GetDataBlock(preRead)).ToList();
-        }
-
-        /// <summary>
-        /// Returns an <see cref="ArchiveDataBlock"/> for writing <see cref="ArchiveDataPoint"/>s for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which the <see cref="ArchiveDataBlock"/> is being requested.</param>
-        /// <param name="dataTime"><see cref="TimeTag"/> of the <see cref="ArchiveDataPoint"/> to be written to the <see cref="ArchiveDataBlock"/>.</param>
-        /// <param name="blockIndex"><see cref="ArchiveDataBlock.Index"/> of the <see cref="ArchiveDataBlock"/> last used for writing <see cref="ArchiveDataPoint"/>s for the <paramref name="historianID"/>.</param>
-        /// <returns><see cref="ArchiveDataBlock"/> object if available; otherwise null if all <see cref="ArchiveDataBlock"/>s have been allocated.</returns>
-        internal ArchiveDataBlock RequestDataBlock(int historianID, TimeTag dataTime, int blockIndex)
-        {
-            ArchiveDataBlock dataBlock = null;
-            ArchiveDataBlockPointer dataBlockPointer = null;
-
-            if (blockIndex >= 0 && blockIndex < m_dataBlockCount)
-            {
-                // Valid data block index is specified, so retrieve the corresponding data block.
-                lock (m_dataBlockPointers)
-                {
-                    dataBlockPointer = m_dataBlockPointers[blockIndex];
-                }
-
-                dataBlock = dataBlockPointer.DataBlock;
-
-                if (!dataBlockPointer.IsAllocated && dataBlock.SlotsUsed > 0)
-                {
-                    // Clear existing data from the data block since it is unallocated.
-                    dataBlock.Reset();
-                }
-                else if (dataBlockPointer.IsAllocated && (dataBlockPointer.HistorianID != historianID || (dataBlockPointer.HistorianID == historianID && dataBlock.SlotsAvailable == 0)))
-                {
-                    // Search for a new data block since the suggested data block cannot be used.
-                    blockIndex = -1;
-                }
-            }
-
-            if (blockIndex < 0)
-            {
-                // Negative data block index is specified indicating a search must be performed for a data block.
-                dataBlock = FindLastDataBlock(historianID);
-
-                if ((object)dataBlock != null && dataBlock.SlotsAvailable == 0)
-                {
-                    // Previously used data block is full.
-                    dataBlock = null;
-                }
-
-                if ((object)dataBlock == null)
-                {
-                    // Look for the first unallocated data block.
-                    dataBlock = FindDataBlock(-1);
-
-                    if ((object)dataBlock == null)
-                    {
-                        // Extend the file for historic writes only.
-                        if (m_parent.FileType == ArchiveFileType.Historic)
-                        {
-                            Extend();
-                            dataBlock = m_dataBlockPointers[m_dataBlockPointers.Count - 1].DataBlock;
-                        }
-                    }
-                    else
-                    {
-                        // Reset the unallocated data block if there is data in it.
-                        if (dataBlock.SlotsUsed > 0)
-                            dataBlock.Reset();
-                    }
-                }
-
-                // Get the pointer to the data block so that its information can be updated if necessary.
-                if ((object)dataBlock == null)
-                {
-                    dataBlockPointer = null;
-                }
-                else
-                {
-                    lock (m_dataBlockPointers)
-                    {
-                        dataBlockPointer = m_dataBlockPointers[dataBlock.Index];
-                    }
-                }
-            }
-
-            if ((object)dataBlockPointer != null && !dataBlockPointer.IsAllocated)
-            {
-                // Mark the data block as allocated.
-                dataBlockPointer.HistorianID = historianID;
-                dataBlockPointer.StartTime = dataTime;
-
-                // Set the file start time if not set.
-                if (m_fileStartTime == TimeTag.MinValue)
-                    m_fileStartTime = dataTime;
-
-                // Persist data block information to disk.
-                lock (m_parent.FileData)
-                {
-                    // We'll write information about the just allocated data block to the file.
-                    m_parent.FileData.Seek(DataLength + ArrayDescriptorLength + (dataBlockPointer.Index * ArchiveDataBlockPointer.FixedLength), SeekOrigin.Begin);
-                    dataBlockPointer.CopyBinaryImageToStream(m_parent.FileData);
-
-                    // We'll also write the fixed part of the FAT data that resides at the end.
-                    m_parent.FileData.Seek(-m_fixedTableRegion.BinaryLength, SeekOrigin.End);
-
-                    // Copy generated binary image to stream
-                    m_fixedTableRegion.CopyBinaryImageToStream(m_parent.FileData);
-
-                    if (!m_parent.CacheWrites)
-                        m_parent.FileData.Flush();
-                }
-
-                // Re-fetch the data block with updated information after allocation.
-                dataBlock = dataBlockPointer.DataBlock;
-            }
-
-            return dataBlock;
+            return length;
         }
 
         #endregion
     }
+
+    // Constants
+    private const int ArrayDescriptorLength = 10;
+
+    // Fields
+    private TimeTag m_fileStartTime;
+    private TimeTag m_fileEndTime;
+    private int m_dataPointsReceived;
+    private int m_dataPointsArchived;
+    private int m_dataBlockSize;
+    private int m_dataBlockCount;
+    private readonly List<ArchiveDataBlockPointer> m_dataBlockPointers;
+    private readonly ArchiveFile m_parent;
+    private readonly FixedTableRegion m_fixedTableRegion;
+    private readonly VariableTableRegion m_variableTableRegion;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveFileAllocationTable"/> class.
+    /// </summary>
+    /// <param name="parent">An <see cref="ArchiveFile"/> object.</param>
+    internal ArchiveFileAllocationTable(ArchiveFile parent)
+    {
+        m_parent = parent;
+        m_dataBlockPointers = [];
+        m_fixedTableRegion = new FixedTableRegion(this);
+        m_variableTableRegion = new VariableTableRegion(this);
+
+        if (m_parent.FileData.Length == 0)
+        {
+            // File is brand new.
+            m_fileStartTime = TimeTag.MinValue;
+            m_fileEndTime = TimeTag.MinValue;
+            m_dataBlockSize = m_parent.DataBlockSize;
+            m_dataBlockCount = ArchiveFile.MaximumDataBlocks(m_parent.FileSize, m_parent.DataBlockSize);
+
+            for (int i = 0; i < m_dataBlockCount; i++)
+                m_dataBlockPointers.Add(new ArchiveDataBlockPointer(m_parent, i));
+        }
+        else
+        {
+            // Existing file, read table regions:
+
+            // Seek to beginning of fixed table region
+            m_parent.FileData.Seek(-m_fixedTableRegion.BinaryLength, SeekOrigin.End);
+
+            // Parse fixed table region
+            m_fixedTableRegion.ParseBinaryImageFromStream(m_parent.FileData);
+
+            // Seek to beginning of variable table region (above fixed from bottom of file)
+            m_parent.FileData.Seek(-(m_fixedTableRegion.BinaryLength + m_variableTableRegion.BinaryLength), SeekOrigin.End);
+
+            // Parse variable table region
+            m_variableTableRegion.ParseBinaryImageFromStream(m_parent.FileData);
+        }
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the <see cref="TimeTag"/> of the oldest <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
+    public TimeTag FileStartTime
+    {
+        get => m_fileStartTime;
+        set
+        {
+            if (value < TimeTag.MinValue || value > TimeTag.MaxValue)
+                throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
+
+            m_fileStartTime = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="TimeTag"/> of the newest <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
+    public TimeTag FileEndTime
+    {
+        get => m_fileEndTime;
+        set
+        {
+            if (value < TimeTag.MinValue || value > TimeTag.MaxValue)
+                throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
+
+            m_fileEndTime = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number <see cref="ArchiveDataPoint"/>s received by the <see cref="ArchiveFile"/> for archival.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
+    public int DataPointsReceived
+    {
+        get => m_dataPointsReceived;
+        set
+        {
+            if (value < 0)
+                throw new ArgumentException("Value must be positive or zero");
+
+            m_dataPointsReceived = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number <see cref="ArchiveDataPoint"/>s archived by the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
+    public int DataPointsArchived
+    {
+        get => m_dataPointsArchived;
+        set
+        {
+            if (value < 0)
+                throw new ArgumentException("Value must be positive or zero");
+
+            m_dataPointsArchived = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the size (in KB) of a single <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    public int DataBlockSize
+    {
+        get => m_dataBlockSize;
+        private set
+        {
+            if (value < 1)
+                throw new ArgumentException("Value must be positive");
+
+            m_dataBlockSize = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the total number of <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    public int DataBlockCount
+    {
+        get => m_dataBlockCount;
+        private set
+        {
+            if (value < 1)
+                throw new ArgumentException("Value must be positive");
+
+            m_dataBlockCount = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of used <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    public int DataBlocksUsed => m_dataBlockCount - DataBlocksAvailable;
+
+    /// <summary>
+    /// Gets the number of unused <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    public int DataBlocksAvailable
+    {
+        get
+        {
+            ArchiveDataBlock unusedDataBlock = FindDataBlock(-1);
+
+            if (unusedDataBlock is not null)
+                return m_dataBlockCount - unusedDataBlock.Index;
+
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ArchiveDataBlockPointer"/>s to the <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <remarks>
+    /// WARNING: <see cref="DataBlockPointers"/> is not thread safe. Synchronized access is required.
+    /// </remarks>
+    public IList<ArchiveDataBlockPointer> DataBlockPointers => m_dataBlockPointers.AsReadOnly();
+
+    /// <summary>
+    /// Gets the length of the <see cref="ArchiveFileAllocationTable"/>.
+    /// </summary>
+    public int BinaryLength => m_variableTableRegion.BinaryLength + m_fixedTableRegion.BinaryLength;
+
+    private long DataLength => m_dataBlockCount * m_dataBlockSize * 1024;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Generates binary image of the <see cref="ArchiveFileAllocationTable"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        startIndex += m_variableTableRegion.GenerateBinaryImage(buffer, startIndex);
+        m_fixedTableRegion.GenerateBinaryImage(buffer, startIndex);
+
+        return length;
+    }
+
+    // 
+    /// <summary>
+    /// Initializes object by parsing the specified <paramref name="buffer"/> containing a binary image.
+    /// </summary>
+    /// <param name="buffer">Buffer containing binary image to parse.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start parsing.</param>
+    /// <param name="length">Valid number of bytes within <paramref name="buffer"/> to read from <paramref name="startIndex"/>.</param>
+    /// <returns>The number of bytes used for initialization in the <paramref name="buffer"/> (i.e., the number of bytes parsed).</returns>
+    /// <remarks>
+    /// This method is never used since constructor parses the point allocation table.
+    /// </remarks>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        return 0;            
+    }
+
+    /// <summary>
+    /// Saves the <see cref="ArchiveFileAllocationTable"/> data to the <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <param name="forceFlush">Forces an immediate disk flush for save.</param>
+    public void Save(bool forceFlush = false)
+    {
+        // Leave space for data blocks.
+        lock (m_parent.FileData)
+        {
+            if (m_parent.FileData.Length == 0)
+                m_parent.FileData.SetLength((long)(m_parent.FileSize * SI2.Mega));
+
+            m_parent.FileData.Seek(DataLength, SeekOrigin.Begin);
+
+            this.CopyBinaryImageToStream(m_parent.FileData);
+
+            if (!m_parent.CacheWrites)
+                m_parent.FileData.Flush();
+        }
+    }
+
+    /// <summary>
+    /// Extends the <see cref="ArchiveFile"/> by one <see cref="ArchiveDataBlock"/>.
+    /// </summary>
+    public void Extend()
+    {
+        Extend(1);
+    }
+
+    /// <summary>
+    /// Extends the <see cref="ArchiveFile"/> by the specified number of <see cref="ArchiveDataBlock"/>s.
+    /// </summary>
+    /// <param name="dataBlocksToAdd">Number of <see cref="ArchiveDataBlock"/>s to add to the <see cref="ArchiveFile"/>.</param>
+    public void Extend(int dataBlocksToAdd)
+    {
+        // Extend the FAT.
+        lock (m_dataBlockPointers)
+        {
+            for (int i = 1; i <= dataBlocksToAdd; i++)
+                m_dataBlockPointers.Add(new ArchiveDataBlockPointer(m_parent, m_dataBlockPointers.Count));
+            
+            m_dataBlockCount = m_dataBlockPointers.Count;
+        }
+
+        Save();
+
+        // Initialize newly added data blocks.
+        for (int i = m_dataBlockCount - dataBlocksToAdd; i < m_dataBlockCount; i++)
+        {
+            ArchiveDataBlock dataBlock = new(m_parent, i, -1);
+            dataBlock.Reset();
+        }
+    }
+
+    /// <summary>
+    /// Returns the first <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier whose <see cref="ArchiveDataBlock"/> is to be retrieved.</param>
+    /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    /// <returns><see cref="ArchiveDataBlock"/> object if a match is found; otherwise null.</returns>
+    public ArchiveDataBlock FindDataBlock(int historianID, bool preRead = true)
+    {
+        ArchiveDataBlockPointer pointer;
+
+        lock (m_dataBlockPointers)
+            pointer = m_dataBlockPointers.FirstOrDefault(dataBlockPointer => dataBlockPointer.HistorianID == historianID);
+
+        return pointer?.GetDataBlock(preRead);
+    }
+
+    /// <summary>
+    /// Returns the last <see cref="ArchiveDataBlock"/> in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    /// <returns><see cref="ArchiveDataBlock"/> object if a match is found; otherwise null.</returns>
+    public ArchiveDataBlock FindLastDataBlock(int historianID, bool preRead = true)
+    {
+        ArchiveDataBlockPointer pointer;
+
+        lock (m_dataBlockPointers)
+            pointer = m_dataBlockPointers.LastOrDefault(dataBlockPointer => dataBlockPointer.HistorianID == historianID);
+
+        return pointer?.GetDataBlock(preRead);
+    }
+
+    /// <summary>
+    /// Returns all <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    /// <returns>A collection of <see cref="ArchiveDataBlock"/>s.</returns>
+    public IEnumerable<(ArchiveDataBlock dataBlock, bool isLast)> FindDataBlocks(int historianID, bool preRead = true)
+    {
+        return FindDataBlocks(historianID, TimeTag.MinValue, preRead);
+    }
+
+    /// <summary>
+    /// Returns all <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/> with <see cref="ArchiveDataPoint"/> points later than the specified <paramref name="startTime"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="startTime">Start <see cref="TimeTag"/>.</param>
+    /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    /// <returns>A collection of <see cref="ArchiveDataBlock"/>s.</returns>
+    public IEnumerable<(ArchiveDataBlock dataBlock, bool isLast)> FindDataBlocks(int historianID, TimeTag startTime, bool preRead = true)
+    {
+        return FindDataBlocks(historianID, startTime, TimeTag.MaxValue, preRead);
+    }
+
+    /// <summary>
+    /// Returns all <see cref="ArchiveDataBlock"/>s in the <see cref="ArchiveFile"/> for the specified <paramref name="historianID"/> with <see cref="ArchiveDataPoint"/>s between the specified <paramref name="startTime"/> and <paramref name="endTime"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="startTime">Start <see cref="TimeTag"/>.</param>
+    /// <param name="endTime">End <see cref="TimeTag"/>.</param>
+    /// <param name="preRead">true to pre-read data to locate write cursor.</param>
+    /// <returns>A collection of <see cref="ArchiveDataBlock"/>s.</returns>
+    public IEnumerable<(ArchiveDataBlock dataBlock, bool isLast)> FindDataBlocks(int historianID, TimeTag startTime, TimeTag endTime, bool preRead = true)
+    {
+        startTime ??= TimeTag.MaxValue;
+        endTime ??= TimeTag.MaxValue;
+
+        List<ArchiveDataBlockPointer> blockPointers;
+
+        lock (m_dataBlockPointers)
+        {
+            // Get all block pointers for given point ID over specified time range
+            blockPointers = m_dataBlockPointers.FindAll(dataBlockPointer => dataBlockPointer.Matches(historianID, startTime, endTime));
+
+            // Look for pointer to data block on the borders of the specified range which may contain data
+            if (startTime == TimeTag.MinValue || endTime == TimeTag.MaxValue)
+                return blockPointers.Select((pointer, i) => (pointer.GetDataBlock(preRead), i == blockPointers.Count - 1));
+            
+            // There are 2 different search criteria for this:
+
+            // 1) If matching data block pointers have been found, then find data block pointer before the first matching data block pointer.
+            //    or
+            // 2) Find the last data block pointer in the time range of TimeTag.MinValue to m_searchEndTime.
+
+            TimeTag searchEndTime = endTime;
+
+            if (blockPointers.Count > 0)
+                searchEndTime = new TimeTag(blockPointers.First().StartTime.Value - 1.0M);
+
+            ArchiveDataBlockPointer borderMatch = m_dataBlockPointers.LastOrDefault(dataBlockPointer => dataBlockPointer.Matches(historianID, TimeTag.MinValue, searchEndTime));
+
+            if (borderMatch is not null)
+                blockPointers.Insert(0, borderMatch);
+        }
+
+        // Return list of data blocks for given block pointers
+        return blockPointers.Select((pointer, i) => (pointer.GetDataBlock(preRead), i == blockPointers.Count - 1));
+    }
+
+    /// <summary>
+    /// Returns an <see cref="ArchiveDataBlock"/> for writing <see cref="ArchiveDataPoint"/>s for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which the <see cref="ArchiveDataBlock"/> is being requested.</param>
+    /// <param name="dataTime"><see cref="TimeTag"/> of the <see cref="ArchiveDataPoint"/> to be written to the <see cref="ArchiveDataBlock"/>.</param>
+    /// <param name="blockIndex"><see cref="ArchiveDataBlock.Index"/> of the <see cref="ArchiveDataBlock"/> last used for writing <see cref="ArchiveDataPoint"/>s for the <paramref name="historianID"/>.</param>
+    /// <returns><see cref="ArchiveDataBlock"/> object if available; otherwise null if all <see cref="ArchiveDataBlock"/>s have been allocated.</returns>
+    internal ArchiveDataBlock RequestDataBlock(int historianID, TimeTag dataTime, int blockIndex)
+    {
+        ArchiveDataBlock dataBlock = null;
+        ArchiveDataBlockPointer dataBlockPointer = null;
+
+        if (blockIndex >= 0 && blockIndex < m_dataBlockCount)
+        {
+            // Valid data block index is specified, so retrieve the corresponding data block.
+            lock (m_dataBlockPointers)
+            {
+                dataBlockPointer = m_dataBlockPointers[blockIndex];
+            }
+
+            dataBlock = dataBlockPointer.DataBlock;
+
+            if (!dataBlockPointer.IsAllocated && dataBlock.SlotsUsed > 0)
+            {
+                // Clear existing data from the data block since it is unallocated.
+                dataBlock.Reset();
+            }
+            else if (dataBlockPointer.IsAllocated && (dataBlockPointer.HistorianID != historianID || (dataBlockPointer.HistorianID == historianID && dataBlock.SlotsAvailable == 0)))
+            {
+                // Search for a new data block since the suggested data block cannot be used.
+                blockIndex = -1;
+            }
+        }
+
+        if (blockIndex < 0)
+        {
+            // Negative data block index is specified indicating a search must be performed for a data block.
+            dataBlock = FindLastDataBlock(historianID);
+
+            if (dataBlock is not null && dataBlock.SlotsAvailable == 0)
+                dataBlock = null; // Previously used data block is full.
+
+            if (dataBlock is null)
+            {
+                // Look for the first unallocated data block.
+                dataBlock = FindDataBlock(-1);
+
+                if (dataBlock is null)
+                {
+                    // Extend the file for historic writes only.
+                    if (m_parent.FileType == ArchiveFileType.Historic)
+                    {
+                        Extend();
+                        dataBlock = m_dataBlockPointers[m_dataBlockPointers.Count - 1].DataBlock;
+                    }
+                }
+                else
+                {
+                    // Reset the unallocated data block if there is data in it.
+                    if (dataBlock.SlotsUsed > 0)
+                        dataBlock.Reset();
+                }
+            }
+
+            // Get the pointer to the data block so that its information can be updated if necessary.
+            if (dataBlock is null)
+            {
+                dataBlockPointer = null;
+            }
+            else
+            {
+                lock (m_dataBlockPointers)
+                    dataBlockPointer = m_dataBlockPointers[dataBlock.Index];
+            }
+        }
+
+        if (dataBlockPointer is null || dataBlockPointer.IsAllocated)
+            return dataBlock;
+        
+        // Mark the data block as allocated.
+        dataBlockPointer.HistorianID = historianID;
+        dataBlockPointer.StartTime = dataTime;
+
+        // Set the file start time if not set.
+        if (m_fileStartTime == TimeTag.MinValue)
+            m_fileStartTime = dataTime;
+
+        // Persist data block information to disk.
+        lock (m_parent.FileData)
+        {
+            // We'll write information about the just allocated data block to the file.
+            m_parent.FileData.Seek(DataLength + ArrayDescriptorLength + dataBlockPointer.Index * ArchiveDataBlockPointer.FixedLength, SeekOrigin.Begin);
+            dataBlockPointer.CopyBinaryImageToStream(m_parent.FileData);
+
+            // We'll also write the fixed part of the FAT data that resides at the end.
+            m_parent.FileData.Seek(-m_fixedTableRegion.BinaryLength, SeekOrigin.End);
+
+            // Copy generated binary image to stream
+            m_fixedTableRegion.CopyBinaryImageToStream(m_parent.FileData);
+
+            if (!m_parent.CacheWrites)
+                m_parent.FileData.Flush();
+        }
+
+        // Re-fetch the data block with updated information after allocation.
+        dataBlock = dataBlockPointer.DataBlock;
+
+        return dataBlock;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveFileScanner.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveFileScanner.cs
@@ -30,7 +30,8 @@ namespace GSF.Historian.Files;
 /// Scans an archive file for data points in a given time
 /// range and returns them in the order that they are scanned.
 /// </summary>
-public class ArchiveFileScanner : IArchiveFileScanner
+/// <param name="reverseQuery">True to read data points in reverse order (i.e., from end time to start time); false to read in normal order.</param>
+public class ArchiveFileScanner(bool reverseQuery) : IArchiveFileScanner
 {
     #region [ Properties ]
 
@@ -57,6 +58,11 @@ public class ArchiveFileScanner : IArchiveFileScanner
     /// of the data points returned by the scanner.
     /// </summary>
     public TimeTag EndTime { get; set; }
+
+    /// <summary>
+    /// Gets flag that determines if data will be queried in reverse order.
+    /// </summary>
+    public bool ReverseQuery => reverseQuery;
 
     /// <summary>
     /// Gets or sets the data point from which to resume
@@ -97,11 +103,11 @@ public class ArchiveFileScanner : IArchiveFileScanner
         {
             if (!alreadyScanned)
             {
-                yield return new DataPointScanner(FileAllocationTable, historianID, StartTime, EndTime, true, DataReadExceptionHandler);
+                yield return new DataPointScanner(FileAllocationTable, historianID, StartTime, EndTime, true, reverseQuery, DataReadExceptionHandler);
             }
             else if (historianID == ResumeFrom.HistorianID)
             {
-                yield return new DataPointScanner(FileAllocationTable, historianID, ResumeFrom.Time, EndTime, false, DataReadExceptionHandler);
+                yield return new DataPointScanner(FileAllocationTable, historianID, ResumeFrom.Time, EndTime, false, reverseQuery, DataReadExceptionHandler);
                 alreadyScanned = false;
             }
         }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveFileScanner.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveFileScanner.cs
@@ -24,168 +24,88 @@
 using System;
 using System.Collections.Generic;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Scans an archive file for data points in a given time
+/// range and returns them in the order that they are scanned.
+/// </summary>
+public class ArchiveFileScanner : IArchiveFileScanner
 {
+    #region [ Properties ]
+
     /// <summary>
-    /// Scans an archive file for data points in a given time
-    /// range and returns them in the order that they are scanned.
+    /// Gets or sets the file allocation table of
+    /// the file that this scanner is reading from.
     /// </summary>
-    public class ArchiveFileScanner : IArchiveFileScanner
+    public ArchiveFileAllocationTable FileAllocationTable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection of
+    /// point IDs to be scanned from the file.
+    /// </summary>
+    public IEnumerable<int> HistorianIDs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum value of the timestamps
+    /// of the data points returned by the scanner.
+    /// </summary>
+    public TimeTag StartTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum value of the timestamps
+    /// of the data points returned by the scanner.
+    /// </summary>
+    public TimeTag EndTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the data point from which to resume
+    /// the scan if it was interrupted by a rollover.
+    /// </summary>
+    public IDataPoint ResumeFrom { get; set; }
+
+    /// <summary>
+    /// Gets or sets the handler used to handle
+    /// errors that occur while scanning the file.
+    /// </summary>
+    public EventHandler<EventArgs<Exception>> DataReadExceptionHandler { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Reads all <see cref="IDataPoint"/>s for the specified historian IDs.
+    /// </summary>
+    /// <returns>Each <see cref="IDataPoint"/> for the specified historian IDs.</returns>
+    public IEnumerable<IDataPoint> Read()
     {
-        #region [ Members ]
-
-        // Fields
-        private ArchiveFileAllocationTable m_fileAllocationTable;
-        private IEnumerable<int> m_historianIDs;
-        private TimeTag m_startTime;
-        private TimeTag m_endTime;
-        private IDataPoint m_resumeFrom;
-        private EventHandler<EventArgs<Exception>> m_dataReadExceptionHandler;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the file allocation table of
-        /// the file that this scanner is reading from.
-        /// </summary>
-        public ArchiveFileAllocationTable FileAllocationTable
+        foreach (DataPointScanner scanner in GetScanners())
         {
-            get
-            {
-                return m_fileAllocationTable;
-            }
-            set
-            {
-                m_fileAllocationTable = value;
-            }
+            foreach (IDataPoint dataPoint in scanner.Read())
+                yield return dataPoint;
         }
-
-        /// <summary>
-        /// Gets or sets the collection of
-        /// point IDs to be scanned from the file.
-        /// </summary>
-        public IEnumerable<int> HistorianIDs
-        {
-            get
-            {
-                return m_historianIDs;
-            }
-            set
-            {
-                m_historianIDs = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the minimum value of the timestamps
-        /// of the data points returned by the scanner.
-        /// </summary>
-        public TimeTag StartTime
-        {
-            get
-            {
-                return m_startTime;
-            }
-            set
-            {
-                m_startTime = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the maximum value of the timestamps
-        /// of the data points returned by the scanner.
-        /// </summary>
-        public TimeTag EndTime
-        {
-            get
-            {
-                return m_endTime;
-            }
-            set
-            {
-                m_endTime = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the data point from which to resume
-        /// the scan if it was interrupted by a rollover.
-        /// </summary>
-        public IDataPoint ResumeFrom
-        {
-            get
-            {
-                return m_resumeFrom;
-            }
-            set
-            {
-                m_resumeFrom = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the handler used to handle
-        /// errors that occur while scanning the file.
-        /// </summary>
-        public EventHandler<EventArgs<Exception>> DataReadExceptionHandler
-        {
-            get
-            {
-                return m_dataReadExceptionHandler;
-            }
-            set
-            {
-                m_dataReadExceptionHandler = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Reads all <see cref="IDataPoint"/>s for the specified historian IDs.
-        /// </summary>
-        /// <returns>Each <see cref="IDataPoint"/> for the specified historian IDs.</returns>
-        public IEnumerable<IDataPoint> Read()
-        {
-            foreach (DataPointScanner scanner in GetScanners())
-            {
-                foreach (IDataPoint dataPoint in scanner.Read())
-                    yield return dataPoint;
-            }
-        }
-
-        // Gets the list of data point scanners used to
-        // scan the file for data belonging to this query.
-        private List<DataPointScanner> GetScanners()
-        {
-            List<DataPointScanner> dataPointScanners = new List<DataPointScanner>();
-            bool alreadyScanned = ((object)m_resumeFrom != null);
-
-            foreach (int historianID in m_historianIDs)
-            {
-                if (!alreadyScanned)
-                {
-                    dataPointScanners.Add(new DataPointScanner(m_fileAllocationTable, historianID, m_startTime, m_endTime, true, m_dataReadExceptionHandler));
-                }
-                else if (historianID == m_resumeFrom.HistorianID)
-                {
-                    dataPointScanners.Add(new DataPointScanner(m_fileAllocationTable, historianID, m_resumeFrom.Time, m_endTime, false, m_dataReadExceptionHandler));
-                    alreadyScanned = false;
-                }
-            }
-
-            return dataPointScanners;
-        }
-
-        #endregion
     }
+
+    // Gets the list of data point scanners used to
+    // scan the file for data belonging to this query.
+    private IEnumerable<DataPointScanner> GetScanners()
+    {
+        bool alreadyScanned = ResumeFrom is not null;
+
+        foreach (int historianID in HistorianIDs)
+        {
+            if (!alreadyScanned)
+            {
+                yield return new DataPointScanner(FileAllocationTable, historianID, StartTime, EndTime, true, DataReadExceptionHandler);
+            }
+            else if (historianID == ResumeFrom.HistorianID)
+            {
+                yield return new DataPointScanner(FileAllocationTable, historianID, ResumeFrom.Time, EndTime, false, DataReadExceptionHandler);
+                alreadyScanned = false;
+            }
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveFileStatistics.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveFileStatistics.cs
@@ -31,50 +31,39 @@
 
 using GSF.Units;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// A class that contains the statistics of an <see cref="ArchiveFile"/>.
+/// </summary>
+/// <seealso cref="ArchiveFile"/>
+public class ArchiveFileStatistics
 {
     /// <summary>
-    /// A class that contains the statistics of an <see cref="ArchiveFile"/>.
+    /// Current usage (in %) of the <see cref="ArchiveFile"/>.
     /// </summary>
-    /// <seealso cref="ArchiveFile"/>
-    public class ArchiveFileStatistics
+    public float FileUsage;
+
+    /// <summary>
+    /// Current rate of data compression (in %) in the <see cref="ArchiveFile"/>.
+    /// </summary>
+    public float CompressionRate;
+
+    /// <summary>
+    /// <see cref="Time"/> over which the <see cref="AverageWriteSpeed"/> is calculated.
+    /// </summary>
+    public Time AveragingWindow;
+
+    /// <summary>
+    /// Average number of time-series data points written to the <see cref="ArchiveFile"/> in one second.
+    /// </summary>
+    public int AverageWriteSpeed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchiveFileStatistics"/> class.
+    /// </summary>
+    internal ArchiveFileStatistics()
     {
-        #region [ Members ]
-
-        // Fields
-
-        /// <summary>
-        /// Current usage (in %) of the <see cref="ArchiveFile"/>.
-        /// </summary>
-        public float FileUsage;
-
-        /// <summary>
-        /// Current rate of data compression (in %) in the <see cref="ArchiveFile"/>.
-        /// </summary>
-        public float CompressionRate;
-
-        /// <summary>
-        /// <see cref="Time"/> over which the <see cref="AverageWriteSpeed"/> is calculated.
-        /// </summary>
-        public Time AveragingWindow;
-
-        /// <summary>
-        /// Average number of time-series data points written to the <see cref="ArchiveFile"/> in one second.
-        /// </summary>
-        public int AverageWriteSpeed;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArchiveFileStatistics"/> class.
-        /// </summary>
-        internal ArchiveFileStatistics()
-        {
-            AveragingWindow = Time.MinValue;
-        }
-
-        #endregion
+        AveragingWindow = Time.MinValue;
     }
 }

--- a/Source/Libraries/GSF.Historian/Files/ArchiveReader.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveReader.cs
@@ -64,35 +64,35 @@ public class ArchiveReader : IDisposable
     /// <summary>
     /// Occurs when the process of building historic <see cref="ArchiveFile"/> list is started.
     /// </summary>
-    [Category("File")]
+    [Category(nameof(File))]
     [Description("Occurs when the process of building historic ArchiveFile list is started.")]
     public event EventHandler HistoricFileListBuildStart;
 
     /// <summary>
     /// Occurs when the process of building historic <see cref="ArchiveFile"/> list is complete.
     /// </summary>
-    [Category("File")]
+    [Category(nameof(File))]
     [Description("Occurs when the process of building historic ArchiveFile list is complete.")]
     public event EventHandler HistoricFileListBuildComplete;
 
     /// <summary>
     /// Occurs when an <see cref="Exception"/> is encountered in historic <see cref="ArchiveFile"/> list building process.
     /// </summary>
-    [Category("File")]
+    [Category(nameof(File))]
     [Description("Occurs when an Exception is encountered in historic ArchiveFile list building process.")]
     public event EventHandler<EventArgs<Exception>> HistoricFileListBuildException;
 
     /// <summary>
     /// Occurs when the historic <see cref="ArchiveFile"/> list is updated to reflect addition or deletion of historic <see cref="ArchiveFile"/>s.
     /// </summary>
-    [Category("File")]
+    [Category(nameof(File))]
     [Description("Occurs when the historic ArchiveFile list is updated to reflect addition or deletion of historic ArchiveFiles.")]
     public event EventHandler HistoricFileListUpdated;
 
     /// <summary>
     /// Occurs when an <see cref="Exception"/> is encountered while reading <see cref="IDataPoint"/> from the current or historic <see cref="ArchiveFile"/>.
     /// </summary>
-    [Category("Data")]
+    [Category(nameof(Data))]
     [Description("Occurs when an Exception is encountered while reading IDataPoint from the current or historic ArchiveFile.")]
     public event EventHandler<EventArgs<Exception>> DataReadException;
 
@@ -369,7 +369,7 @@ public class ArchiveReader : IDisposable
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
     public IEnumerable<IDataPoint> ReadData(int historianID, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
     {
-        return ReadData(new[] { historianID }, startTime, endTime, timeSorted);
+        return ReadData([historianID], startTime, endTime, timeSorted);
     }
 
     /// <summary>
@@ -522,7 +522,7 @@ public class ArchiveReader : IDisposable
         }
         catch (Exception ex)
         {
-            OnDataReadException(new InvalidOperationException("Exception encountered during roll-over processing: " + ex.Message, ex));
+            OnDataReadException(new InvalidOperationException($"Exception encountered during roll-over processing: {ex.Message}", ex));
         }
         finally
         {

--- a/Source/Libraries/GSF.Historian/Files/ArchiveReader.cs
+++ b/Source/Libraries/GSF.Historian/Files/ArchiveReader.cs
@@ -267,6 +267,10 @@ public class ArchiveReader : IDisposable
     /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(int historianID, string startTime, string endTime, bool timeSorted = true)
     {
         return ReadData(historianID, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
@@ -280,6 +284,10 @@ public class ArchiveReader : IDisposable
     /// <param name="endTime"><see cref="String"/> representation of the end time (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, string endTime, bool timeSorted = true)
     {
         return ReadData(historianIDs, TimeTag.Parse(startTime), TimeTag.Parse(endTime), timeSorted);
@@ -317,6 +325,10 @@ public class ArchiveReader : IDisposable
     /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, DateTime endTime, bool timeSorted = true)
     {
         return ReadData(historianID, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
@@ -330,6 +342,10 @@ public class ArchiveReader : IDisposable
     /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, DateTime endTime, bool timeSorted = true)
     {
         return ReadData(historianIDs, new TimeTag(startTime), new TimeTag(endTime), timeSorted);
@@ -367,6 +383,10 @@ public class ArchiveReader : IDisposable
     /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(int historianID, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
     {
         return ReadData([historianID], startTime, endTime, timeSorted);
@@ -380,6 +400,10 @@ public class ArchiveReader : IDisposable
     /// <param name="endTime">End <see cref="TimeTag"/> (in UTC) for the <see cref="ArchiveDataPoint"/>s to be retrieved.</param>
     /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
     /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="ArchiveDataPoint"/>s.</returns>
+    /// <remarks>
+    /// Data is always read from <paramref name="startTime"/> to <paramref name="endTime"/>. If <paramref name="startTime"/> is
+    /// greater than <paramref name="endTime"/>, query data will be read from the archive in reverse time order.
+    /// </remarks>
     public IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, TimeTag startTime, TimeTag endTime, bool timeSorted = true)
     {
         if (m_archiveFile is null)

--- a/Source/Libraries/GSF.Historian/Files/DataPointScanner.cs
+++ b/Source/Libraries/GSF.Historian/Files/DataPointScanner.cs
@@ -78,7 +78,7 @@ internal class DataPointScanner
     public TimeTag StartTime { get; }
 
     /// <summary>
-    /// Gets the end time associated with this <see cref="DataPointScanner"/>. The end time is inclusive if <see cref="IncludeStartTime"/> is true.
+    /// Gets the end time associated with this <see cref="DataPointScanner"/>. The end time is always inclusive.
     /// </summary>
     public TimeTag EndTime { get; }
 

--- a/Source/Libraries/GSF.Historian/Files/IArchiveFileScanner.cs
+++ b/Source/Libraries/GSF.Historian/Files/IArchiveFileScanner.cs
@@ -58,6 +58,11 @@ public interface IArchiveFileScanner
     TimeTag EndTime { get; set; }
 
     /// <summary>
+    /// Gets flag that determines if data will be queried in reverse order.
+    /// </summary>
+    bool ReverseQuery { get; }
+
+    /// <summary>
     /// Gets or sets the data point from which to resume
     /// the scan if it was interrupted by a rollover.
     /// </summary>

--- a/Source/Libraries/GSF.Historian/Files/IArchiveFileScanner.cs
+++ b/Source/Libraries/GSF.Historian/Files/IArchiveFileScanner.cs
@@ -24,85 +24,60 @@
 using System;
 using System.Collections.Generic;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a scanner that reads data points from an archive file for a given time range.
+/// </summary>
+public interface IArchiveFileScanner
 {
+    #region [ Properties ]
+
     /// <summary>
-    /// Represents a scanner that reads data points from an archive file for a given time range.
+    /// Gets or sets the file allocation table of
+    /// the file that this scanner is reading from.
     /// </summary>
-    public interface IArchiveFileScanner
-    {
-        #region [ Properties ]
+    ArchiveFileAllocationTable FileAllocationTable { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file allocation table of
-        /// the file that this scanner is reading from.
-        /// </summary>
-        ArchiveFileAllocationTable FileAllocationTable
-        {
-            get;
-            set;
-        }
+    /// <summary>
+    /// Gets or sets the collection of
+    /// point IDs to be scanned from the file.
+    /// </summary>
+    IEnumerable<int> HistorianIDs { get; set; }
 
-        /// <summary>
-        /// Gets or sets the collection of
-        /// point IDs to be scanned from the file.
-        /// </summary>
-        IEnumerable<int> HistorianIDs
-        {
-            get;
-            set;
-        }
+    /// <summary>
+    /// Gets or sets the minimum value of the timestamps
+    /// of the data points returned by the scanner.
+    /// </summary>
+    TimeTag StartTime { get; set; }
 
-        /// <summary>
-        /// Gets or sets the minimum value of the timestamps
-        /// of the data points returned by the scanner.
-        /// </summary>
-        TimeTag StartTime
-        {
-            get;
-            set;
-        }
+    /// <summary>
+    /// Gets or sets the maximum value of the timestamps
+    /// of the data points returned by the scanner.
+    /// </summary>
+    TimeTag EndTime { get; set; }
 
-        /// <summary>
-        /// Gets or sets the maximum value of the timestamps
-        /// of the data points returned by the scanner.
-        /// </summary>
-        TimeTag EndTime
-        {
-            get;
-            set;
-        }
+    /// <summary>
+    /// Gets or sets the data point from which to resume
+    /// the scan if it was interrupted by a rollover.
+    /// </summary>
+    IDataPoint ResumeFrom { get; set; }
 
-        /// <summary>
-        /// Gets or sets the data point from which to resume
-        /// the scan if it was interrupted by a rollover.
-        /// </summary>
-        IDataPoint ResumeFrom
-        {
-            get;
-            set;
-        }
+    /// <summary>
+    /// Gets or sets the handler used to handle
+    /// errors that occur while scanning the file.
+    /// </summary>
+    EventHandler<EventArgs<Exception>> DataReadExceptionHandler { get; set; }
 
-        /// <summary>
-        /// Gets or sets the handler used to handle
-        /// errors that occur while scanning the file.
-        /// </summary>
-        EventHandler<EventArgs<Exception>> DataReadExceptionHandler
-        {
-            get;
-            set;
-        }
+    #endregion
 
-        #endregion
+    #region [ Methods ]
 
-        #region [ Methods ]
+    /// <summary>
+    /// Reads all <see cref="IDataPoint"/>s for the specified historian IDs.
+    /// </summary>
+    /// <returns>Each <see cref="IDataPoint"/> for the specified historian IDs.</returns>
+    IEnumerable<IDataPoint> Read();
 
-        /// <summary>
-        /// Reads all <see cref="IDataPoint"/>s for the specified historian IDs.
-        /// </summary>
-        /// <returns>Each <see cref="IDataPoint"/> for the specified historian IDs.</returns>
-        IEnumerable<IDataPoint> Read();
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/IntercomFile.cs
+++ b/Source/Libraries/GSF.Historian/Files/IntercomFile.cs
@@ -34,48 +34,47 @@
 using System.Drawing;
 using GSF.IO;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a file containing <see cref="IntercomRecord"/>s.
+/// </summary>
+/// <seealso cref="IntercomRecord"/>
+[ToolboxBitmap(typeof(IntercomFile))]
+public class IntercomFile : IsamDataFileBase<IntercomRecord>
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a file containing <see cref="IntercomRecord"/>s.
+    /// Initializes a new instance of the <see cref="IntercomFile"/> class.
     /// </summary>
-    /// <seealso cref="IntercomRecord"/>
-    [ToolboxBitmap(typeof(IntercomFile))]
-    public class IntercomFile : IsamDataFileBase<IntercomRecord>
+    public IntercomFile()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IntercomFile"/> class.
-        /// </summary>
-        public IntercomFile()
-        {
-            SettingsCategory = this.GetType().Name;
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Gets the binary size of a <see cref="IntercomRecord"/>.
-        /// </summary>
-        /// <returns>A 32-bit signed integer.</returns>
-        protected override int GetRecordSize()
-        {
-            return IntercomRecord.FixedLength;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="IntercomRecord"/> with the specified <paramref name="recordIndex"/>.
-        /// </summary>
-        /// <param name="recordIndex">1-based index of the <see cref="IntercomRecord"/>.</param>
-        /// <returns>A <see cref="IntercomRecord"/> object.</returns>
-        protected override IntercomRecord CreateNewRecord(int recordIndex)
-        {
-            return new IntercomRecord(recordIndex);
-        }
-
-        #endregion
+        SettingsCategory = GetType().Name;
     }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Gets the binary size of a <see cref="IntercomRecord"/>.
+    /// </summary>
+    /// <returns>A 32-bit signed integer.</returns>
+    protected override int GetRecordSize()
+    {
+        return IntercomRecord.FixedLength;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="IntercomRecord"/> with the specified <paramref name="recordIndex"/>.
+    /// </summary>
+    /// <param name="recordIndex">1-based index of the <see cref="IntercomRecord"/>.</param>
+    /// <returns>A <see cref="IntercomRecord"/> object.</returns>
+    protected override IntercomRecord CreateNewRecord(int recordIndex)
+    {
+        return new IntercomRecord(recordIndex);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/IntercomRecord.cs
+++ b/Source/Libraries/GSF.Historian/Files/IntercomRecord.cs
@@ -35,261 +35,230 @@ using System;
 using System.Collections.Generic;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a record in the <see cref="IntercomFile"/> that contains runtime information of a historian.
+/// </summary>
+/// <seealso cref="IntercomFile"/>
+public class IntercomRecord : ISupportBinaryImage
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 4          0-3        Int32      DataBlocksUsed                                                *
+    // * 4          4-7        Boolean    RolloverInProgress                                           *
+    // * 8          8-15       Double     LatestDataTime                                                *
+    // * 4          16-19      Int32      LatestDataID                                                  *
+    // * 160        20-179     Double(20) SourceLatestDataTime                                                     *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a record in the <see cref="IntercomFile"/> that contains runtime information of a historian.
+    /// Specifies the number of bytes in the binary image of <see cref="IntercomRecord"/>.
     /// </summary>
-    /// <seealso cref="IntercomFile"/>
-    public class IntercomRecord : ISupportBinaryImage
+    public const int FixedLength = 180;
+
+    // Fields
+    private int m_dataBlocksUsed;
+    private bool m_rolloverInProgress;
+    private TimeTag m_latestDataTime;
+    private int m_latestDataID;
+    private readonly List<TimeTag> m_sourceLatestDataTime;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntercomRecord"/> class.
+    /// </summary>
+    /// <param name="recordID">ID of the <see cref="IntercomRecord"/>.</param>
+    public IntercomRecord(int recordID)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 4          0-3        Int32      DataBlocksUsed                                                *
-        // * 4          4-7        Boolean    RolloverInProggress                                           *
-        // * 8          8-15       Double     LatestDataTime                                                *
-        // * 4          16-19      Int32      LatestDataID                                                  *
-        // * 160        20-179     Double(20) SourceLatestDataTime                                                     *
-        // **************************************************************************************************
+        RecordID = recordID;
+        m_latestDataTime = TimeTag.MinValue;
+        m_sourceLatestDataTime = [];
 
-        #region [ Members ]
+        for (int i = 0; i < 20; i++)
+            m_sourceLatestDataTime.Add(TimeTag.MinValue);
+    }
 
-        // Constants
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntercomRecord"/> class.
+    /// </summary>
+    /// <param name="recordID">ID of the <see cref="IntercomRecord"/>.</param>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="IntercomRecord"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public IntercomRecord(int recordID, byte[] buffer, int startIndex, int length)
+        : this(recordID)
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
 
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="IntercomRecord"/>.
-        /// </summary>
-        public const int FixedLength = 180;
+    #endregion
 
-        // Fields
-        private int m_recordID;
-        private int m_dataBlocksUsed;
-        private bool m_rolloverInProgress;
-        private TimeTag m_latestDataTime;
-        private int m_latestDataID;
-        private readonly List<TimeTag> m_sourceLatestDataTime;
+    #region [ Properties ]
 
-        #endregion
+    /// <summary>
+    /// Gets the ID of the <see cref="IntercomRecord"/>.
+    /// </summary>
+    public int RecordID { get; }
 
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IntercomRecord"/> class.
-        /// </summary>
-        /// <param name="recordID">ID of the <see cref="IntercomRecord"/>.</param>
-        public IntercomRecord(int recordID)
+    /// <summary>
+    /// Gets or sets the number of allocated <see cref="ArchiveDataBlock"/>s in the active <see cref="ArchiveFile"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
+    public int DataBlocksUsed
+    {
+        get
         {
-            m_recordID = recordID;
-            m_latestDataTime = TimeTag.MinValue;
-            m_sourceLatestDataTime = new List<TimeTag>();
-
-            for (int i = 0; i < 20; i++)
-            {
-                m_sourceLatestDataTime.Add(TimeTag.MinValue);
-            }
+            lock (this)
+                return m_dataBlocksUsed;
         }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IntercomRecord"/> class.
-        /// </summary>
-        /// <param name="recordID">ID of the <see cref="IntercomRecord"/>.</param>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="IntercomRecord"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public IntercomRecord(int recordID, byte[] buffer, int startIndex, int length)
-            : this(recordID)
+        set
         {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the number of allocated <see cref="ArchiveDataBlock"/>s in the active <see cref="ArchiveFile"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
-        public int DataBlocksUsed
-        {
-            get
-            {
-                lock (this)
-                {
-                    return m_dataBlocksUsed;
-                }
-            }
-            set
-            {
-                if (value < 0)
-                    throw new ArgumentException("Value must be positive or zero");
-
-                lock (this)
-                {
-                    m_dataBlocksUsed = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the active <see cref="ArchiveFile"/> if being rolled-over.
-        /// </summary>
-        public bool RolloverInProgress
-        {
-            get
-            {
-                lock (this)
-                {
-                    return m_rolloverInProgress;
-                }
-            }
-            set
-            {
-                lock (this)
-                {
-                    m_rolloverInProgress = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="TimeTag"/> of latest <see cref="ArchiveDataPoint"/> received by the active <see cref="ArchiveFile"/>.
-        /// </summary>
-        public TimeTag LatestDataTime
-        {
-            get
-            {
-                lock (this)
-                {
-                    return m_latestDataTime;
-                }
-            }
-            set
-            {
-                lock (this)
-                {
-                    m_latestDataTime = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the historian identifier of latest <see cref="ArchiveDataPoint"/> received by the active <see cref="ArchiveFile"/>.
-        /// </summary>
-        public int LatestDataID
-        {
-            get
-            {
-                lock (this)
-                {
-                    return m_latestDataID;
-                }
-            }
-            set
-            {
-                lock (this)
-                {
-                    m_latestDataID = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets a list of <see cref="TimeTag"/>s of the latest <see cref="ArchiveDataPoint"/> received from each of the <see cref="MetadataRecord.SourceID"/>s.
-        /// </summary>
-        public IList<TimeTag> SourceLatestDataTime
-        {
-            get
-            {
-                lock (this)
-                {
-                    return m_sourceLatestDataTime.AsReadOnly();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="IntercomRecord"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="IntercomRecord"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="IntercomRecord"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="IntercomRecord"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                DataBlocksUsed = LittleEndian.ToInt32(buffer, startIndex);
-                RolloverInProgress = LittleEndian.ToBoolean(buffer, startIndex + 4);
-                LatestDataTime = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 8));
-                LatestDataID = LittleEndian.ToInt32(buffer, startIndex + 16);
-
-                for (int i = 0; i < m_sourceLatestDataTime.Count; i++)
-                {
-                    m_sourceLatestDataTime[i] = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 20 + (i * 8)));
-                }
-
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="IntercomRecord"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
+            if (value < 0)
+                throw new ArgumentException("Value must be positive or zero");
 
             lock (this)
-            {
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_dataBlocksUsed), 0, buffer, startIndex, 4);
-                Buffer.BlockCopy(LittleEndian.GetBytes(Convert.ToInt32(m_rolloverInProgress)), 0, buffer, startIndex + 4, 4);
-                Buffer.BlockCopy(LittleEndian.GetBytes((double)m_latestDataTime.Value), 0, buffer, startIndex + 8, 8);
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_latestDataID), 0, buffer, startIndex + 16, 4);
+                m_dataBlocksUsed = value;
+        }
+    }
 
-                for (int i = 0; i < m_sourceLatestDataTime.Count; i++)
-                {
-                    Buffer.BlockCopy(LittleEndian.GetBytes((double)m_sourceLatestDataTime[i].Value), 0, buffer, startIndex + 20 + (i * 8), 8);
-                }
-            }
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the active <see cref="ArchiveFile"/> if being rolled-over.
+    /// </summary>
+    public bool RolloverInProgress
+    {
+        get
+        {
+            lock (this)
+                return m_rolloverInProgress;
+        }
+        set
+        {
+            lock (this)
+                m_rolloverInProgress = value;
+        }
+    }
 
-            return length;
+    /// <summary>
+    /// Gets or sets the <see cref="TimeTag"/> of latest <see cref="ArchiveDataPoint"/> received by the active <see cref="ArchiveFile"/>.
+    /// </summary>
+    public TimeTag LatestDataTime
+    {
+        get
+        {
+            lock (this)
+                return m_latestDataTime;
+        }
+        set
+        {
+            lock (this)
+                m_latestDataTime = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the historian identifier of latest <see cref="ArchiveDataPoint"/> received by the active <see cref="ArchiveFile"/>.
+    /// </summary>
+    public int LatestDataID
+    {
+        get
+        {
+            lock (this)
+                return m_latestDataID;
+        }
+        set
+        {
+            lock (this)
+                m_latestDataID = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets a list of <see cref="TimeTag"/>s of the latest <see cref="ArchiveDataPoint"/> received from each of the <see cref="MetadataRecord.SourceID"/>s.
+    /// </summary>
+    public IList<TimeTag> SourceLatestDataTime
+    {
+        get
+        {
+            lock (this)
+                return m_sourceLatestDataTime.AsReadOnly();
+        }
+    }
+
+    /// <summary>
+    /// Gets the length of the <see cref="IntercomRecord"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="IntercomRecord"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="IntercomRecord"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="IntercomRecord"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        DataBlocksUsed = LittleEndian.ToInt32(buffer, startIndex);
+        RolloverInProgress = LittleEndian.ToBoolean(buffer, startIndex + 4);
+        LatestDataTime = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 8));
+        LatestDataID = LittleEndian.ToInt32(buffer, startIndex + 16);
+
+        for (int i = 0; i < m_sourceLatestDataTime.Count; i++)
+            m_sourceLatestDataTime[i] = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 20 + i * 8));
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="IntercomRecord"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        lock (this)
+        {
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_dataBlocksUsed), 0, buffer, startIndex, 4);
+            Buffer.BlockCopy(LittleEndian.GetBytes(Convert.ToInt32(m_rolloverInProgress)), 0, buffer, startIndex + 4, 4);
+            Buffer.BlockCopy(LittleEndian.GetBytes((double)m_latestDataTime.Value), 0, buffer, startIndex + 8, 8);
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_latestDataID), 0, buffer, startIndex + 16, 4);
+
+            for (int i = 0; i < m_sourceLatestDataTime.Count; i++)
+                Buffer.BlockCopy(LittleEndian.GetBytes((double)m_sourceLatestDataTime[i].Value), 0, buffer, startIndex + 20 + i * 8, 8);
         }
 
-        #endregion
+        return length;
     }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataFile.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataFile.cs
@@ -130,7 +130,7 @@ public class MetadataFile : IsamDataFileBase<MetadataRecord>
     /// </summary>
     public MetadataFile()
     {
-        SettingsCategory = this.GetType().Name;
+        SettingsCategory = GetType().Name;
         m_legacyMode = MetadataFileLegacyMode.Disabled;  // Default to only using new file format
         m_records = new Dictionary<int, MetadataRecord>();
     }
@@ -242,7 +242,7 @@ public class MetadataFile : IsamDataFileBase<MetadataRecord>
         ConfigurationFile config = ConfigurationFile.Current;
         CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
         
-        settings["LegacyMode", true].Update(m_legacyMode);
+        settings[nameof(LegacyMode), true].Update(m_legacyMode);
         config.Save();
     }
 
@@ -259,8 +259,8 @@ public class MetadataFile : IsamDataFileBase<MetadataRecord>
 
         // Load settings from the specified category.
         CategorizedSettingsElementCollection settings = ConfigurationFile.Current.Settings[SettingsCategory];
-        settings.Add("LegacyMode", m_legacyMode, "Metadata file legacy format mode. Value is one of \"Disabled\", \"Compatible\" or \"Enabled\" where \"Disabled\" means only use new format, \"Compatible\" means use new format and also write a legacy format file for compatibility and \"Enabled\" means only use the legacy format.");
-        LegacyMode = settings["LegacyMode"].ValueAs(m_legacyMode);
+        settings.Add(nameof(LegacyMode), m_legacyMode, "Metadata file legacy format mode. Value is one of \"Disabled\", \"Compatible\" or \"Enabled\" where \"Disabled\" means only use new format, \"Compatible\" means use new format and also write a legacy format file for compatibility and \"Enabled\" means only use the legacy format.");
+        LegacyMode = settings[nameof(LegacyMode)].ValueAs(m_legacyMode);
 
         // Define new file name for non-legacy implementations
         if (m_legacyMode != MetadataFileLegacyMode.Enabled && !FileName.EndsWith("2"))
@@ -319,7 +319,7 @@ public class MetadataFile : IsamDataFileBase<MetadataRecord>
                 base.FileName = m_baseFileName;
 
             // Use new file format if a newer one exists
-            if (m_legacyMode != MetadataFileLegacyMode.Enabled && !FileName.EndsWith("2") && File.Exists(FileName + "2"))
+            if (m_legacyMode != MetadataFileLegacyMode.Enabled && !FileName.EndsWith("2") && File.Exists($"{FileName}2"))
                 FileName += "2";
 
             // Fall back on legacy mode if needed

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecord.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecord.cs
@@ -36,815 +36,814 @@ using System.IO;
 using System.Text;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a record in the <see cref="MetadataFile"/> that contains the various attributes associates to a <see cref="HistorianID"/>.
+/// </summary>
+/// <seealso cref="MetadataFile"/>
+/// <seealso cref="MetadataRecordAlarmFlags"/>
+/// <seealso cref="MetadataRecordGeneralFlags"/>
+/// <seealso cref="MetadataRecordSecurityFlags"/>
+/// <seealso cref="MetadataRecordAnalogFields"/>
+/// <seealso cref="MetadataRecordComposedFields"/>
+/// <seealso cref="MetadataRecordConstantFields"/>
+/// <seealso cref="MetadataRecordDigitalFields"/>
+/// <seealso cref="MetadataRecordSummary"/>
+public class MetadataRecord : ISupportBinaryImage, IComparable
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 512        0-511      Char(512)  Remarks                                                       *
+    // * 512        512-1023   Char(512)  HardwareInfo                                                  *
+    // * 512        1024-1535  Char(512)  EmailAddresses                                                *
+    // * 80         1536-1615  Char(80)   Description                                                   *
+    // * 80         1616-1695  Char(80)   CurrentData                                                   *
+    // * 40         1696-1735  Char(40)   Name                                                          *
+    // * 40         1736-1775  Char(40)   Synonym1                                                      *
+    // * 40         1776-1815  Char(40)   Synonym2                                                      *
+    // * 40         1816-1855  Char(40)   Synonym3                                                      *
+    // * 40         1856-1895  Char(40)   PagerNumbers                                                  *
+    // * 40         1896-1935  Char(40)   PhoneNumbers                                                  *
+    // * 24         1936-1959  Char(24)   PlantCode                                                     *
+    // * 24         1960-1983  Char(24)   System                                                        *
+    // * 40         1984-2023  Char(40)   EmailTime                                                     *
+    // * 40         2024-2063  Char(40)   [Spare string field 1]                                        *
+    // * 40         2064-2103  Char(40)   [Spare string field 2]                                        *
+    // * 4          2104-2107  Single     ScanRate                                                      *
+    // * 4          2108-2111  Int32      UnitNumber                                                    *
+    // * 4          2112-2115  Int32      SecurityFlags                                                 *
+    // * 4          2116-2119  Int32      GeneralFlags                                                  *
+    // * 4          2120-2123  Int32      AlarmFlags                                                    *
+    // * 4          2124-2127  Int32      CompressionMinTime                                            *
+    // * 4          2128-2131  Int32      CompressionMaxTime                                            *
+    // * 4          2132-2135  Int32      SourceID                                                      *
+    // * 4          2136-2139  Int32      [Spare 32-bit field 1]                                        *
+    // * 4          2140-2143  Int32      [Spare 32-bit field 2]                                        *
+    // * 4          2144-2147  Int32      [Spare 32-bit field 3]                                        *
+    // * 4          2148-2151  Int32      [Spare 32-bit field 4]                                        *
+    // * 512        2152-2663  Byte(512)  (Analog | Digital| Composed |Constant)Fields                  *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a record in the <see cref="MetadataFile"/> that contains the various attributes associates to a <see cref="HistorianID"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="MetadataRecord"/>.
     /// </summary>
-    /// <seealso cref="MetadataFile"/>
-    /// <seealso cref="MetadataRecordAlarmFlags"/>
-    /// <seealso cref="MetadataRecordGeneralFlags"/>
-    /// <seealso cref="MetadataRecordSecurityFlags"/>
-    /// <seealso cref="MetadataRecordAnalogFields"/>
-    /// <seealso cref="MetadataRecordComposedFields"/>
-    /// <seealso cref="MetadataRecordConstantFields"/>
-    /// <seealso cref="MetadataRecordDigitalFields"/>
-    /// <seealso cref="MetadataRecordSummary"/>
-    public class MetadataRecord : ISupportBinaryImage, IComparable
+    public const int FixedLength = 2664;
+
+    // Fields
+    private string m_remarks;
+    private string m_hardwareInfo;
+    private string m_emailAddresses;
+    private string m_description;
+    private string m_currentData;
+    private string m_name;
+    private string m_synonym1;
+    private string m_synonym2;
+    private string m_synonym3;
+    private string m_pagerNumbers;
+    private string m_phoneNumbers;
+    private string m_plantCode;
+    private string m_system;
+    private string m_emailTime;
+    private MetadataRecordSecurityFlags m_securityFlags;
+    private MetadataRecordGeneralFlags m_generalFlags;
+    private MetadataRecordAlarmFlags m_alarmFlags;
+    private int m_sourceID;
+    private MetadataRecordAnalogFields m_analogFields;
+    private MetadataRecordDigitalFields m_digitalFields;
+    private MetadataRecordComposedFields m_composedFields;
+    private MetadataRecordConstantFields m_constantFields;
+    private readonly MetadataFileLegacyMode m_legacyMode;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecord"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="MetadataRecord"/>.</param>
+    /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
+    public MetadataRecord(int historianID, MetadataFileLegacyMode legacyMode)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 512        0-511      Char(512)  Remarks                                                       *
-        // * 512        512-1023   Char(512)  HardwareInfo                                                  *
-        // * 512        1024-1535  Char(512)  EmailAddresses                                                *
-        // * 80         1536-1615  Char(80)   Description                                                   *
-        // * 80         1616-1695  Char(80)   CurrentData                                                   *
-        // * 40         1696-1735  Char(40)   Name                                                          *
-        // * 40         1736-1775  Char(40)   Synonym1                                                      *
-        // * 40         1776-1815  Char(40)   Synonym2                                                      *
-        // * 40         1816-1855  Char(40)   Synonym3                                                      *
-        // * 40         1856-1895  Char(40)   PagerNumbers                                                  *
-        // * 40         1896-1935  Char(40)   PhoneNumbers                                                  *
-        // * 24         1936-1959  Char(24)   PlantCode                                                     *
-        // * 24         1960-1983  Char(24)   System                                                        *
-        // * 40         1984-2023  Char(40)   EmailTime                                                     *
-        // * 40         2024-2063  Char(40)   [Spare string field 1]                                        *
-        // * 40         2064-2103  Char(40)   [Spare string field 2]                                        *
-        // * 4          2104-2107  Single     ScanRate                                                      *
-        // * 4          2108-2111  Int32      UnitNumber                                                    *
-        // * 4          2112-2115  Int32      SecurityFlags                                                 *
-        // * 4          2116-2119  Int32      GeneralFlags                                                  *
-        // * 4          2120-2123  Int32      AlarmFlags                                                    *
-        // * 4          2124-2127  Int32      CompressionMinTime                                            *
-        // * 4          2128-2131  Int32      CompressionMaxTime                                            *
-        // * 4          2132-2135  Int32      SourceID                                                      *
-        // * 4          2136-2139  Int32      [Spare 32-bit field 1]                                        *
-        // * 4          2140-2143  Int32      [Spare 32-bit field 2]                                        *
-        // * 4          2144-2147  Int32      [Spare 32-bit field 3]                                        *
-        // * 4          2148-2151  Int32      [Spare 32-bit field 4]                                        *
-        // * 512        2152-2663  Byte(512)  (Analog | Digital| Composed |Constant)Fields                  *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="MetadataRecord"/>.
-        /// </summary>
-        public const int FixedLength = 2664;
-
-        // Fields
-        private string m_remarks;
-        private string m_hardwareInfo;
-        private string m_emailAddresses;
-        private string m_description;
-        private string m_currentData;
-        private string m_name;
-        private string m_synonym1;
-        private string m_synonym2;
-        private string m_synonym3;
-        private string m_pagerNumbers;
-        private string m_phoneNumbers;
-        private string m_plantCode;
-        private string m_system;
-        private string m_emailTime;
-        private MetadataRecordSecurityFlags m_securityFlags;
-        private MetadataRecordGeneralFlags m_generalFlags;
-        private MetadataRecordAlarmFlags m_alarmFlags;
-        private int m_sourceID;
-        private MetadataRecordAnalogFields m_analogFields;
-        private MetadataRecordDigitalFields m_digitalFields;
-        private MetadataRecordComposedFields m_composedFields;
-        private MetadataRecordConstantFields m_constantFields;
-        private readonly MetadataFileLegacyMode m_legacyMode;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecord"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="MetadataRecord"/>.</param>
-        /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
-        public MetadataRecord(int historianID, MetadataFileLegacyMode legacyMode)
-        {
-            if (historianID < 0)
-                throw new ArgumentOutOfRangeException(nameof(historianID));
-
-            HistorianID = historianID;
-            m_remarks = string.Empty;
-            m_hardwareInfo = string.Empty;
-            m_emailAddresses = string.Empty;
-            m_description = string.Empty;
-            m_currentData = string.Empty;
-            m_name = string.Empty;
-            m_synonym1 = string.Empty;
-            m_synonym2 = string.Empty;
-            m_synonym3 = string.Empty;
-            m_pagerNumbers = string.Empty;
-            m_phoneNumbers = string.Empty;
-            m_plantCode = string.Empty;
-            m_system = string.Empty;
-            m_emailTime = string.Empty;
-            m_securityFlags = new MetadataRecordSecurityFlags();
-            m_generalFlags = new MetadataRecordGeneralFlags();
-            m_alarmFlags = new MetadataRecordAlarmFlags();
-            m_analogFields = new MetadataRecordAnalogFields(legacyMode);
-            m_digitalFields = new MetadataRecordDigitalFields(legacyMode);
-            m_composedFields = new MetadataRecordComposedFields(legacyMode);
-            m_constantFields = new MetadataRecordConstantFields();
-            m_legacyMode = legacyMode;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecord"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="MetadataRecord"/>.</param>
-        /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecord"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public MetadataRecord(int historianID, MetadataFileLegacyMode legacyMode, byte[] buffer, int startIndex, int length)
-            : this(historianID, legacyMode)
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        internal MetadataRecord(BinaryReader reader)
-        {
-            HistorianID = reader.ReadInt32();
-            m_remarks = reader.ReadString();
-            m_hardwareInfo = reader.ReadString();
-            m_emailAddresses = reader.ReadString();
-            m_description = reader.ReadString();
-            m_currentData = reader.ReadString();
-            m_name = reader.ReadString();
-            m_synonym1 = reader.ReadString();
-            m_synonym2 = reader.ReadString();
-            m_synonym3 = reader.ReadString();
-            m_pagerNumbers = reader.ReadString();
-            m_phoneNumbers = reader.ReadString();
-            m_plantCode = reader.ReadString();
-            m_system = reader.ReadString();
-            m_emailTime = reader.ReadString();
-            ScanRate = reader.ReadSingle();
-            UnitNumber = reader.ReadInt32();
-
-            m_securityFlags = new MetadataRecordSecurityFlags { Value = reader.ReadInt32() };
-            m_generalFlags = new MetadataRecordGeneralFlags { Value = reader.ReadInt32() };
-            m_alarmFlags = new MetadataRecordAlarmFlags { Value = reader.ReadInt32() };
-
-            CompressionMinTime = reader.ReadInt32();
-            CompressionMaxTime = reader.ReadInt32();
-            m_sourceID = reader.ReadInt32();
-
-            switch (m_generalFlags.DataType)
-            {
-                case DataType.Analog:
-                    m_analogFields = new MetadataRecordAnalogFields(reader);
-                    m_digitalFields = new MetadataRecordDigitalFields(MetadataFileLegacyMode.Disabled);
-                    m_composedFields = new MetadataRecordComposedFields(MetadataFileLegacyMode.Disabled);
-                    m_constantFields = new MetadataRecordConstantFields();
-                    break;
-                case DataType.Digital:
-                    m_digitalFields = new MetadataRecordDigitalFields(reader);
-                    m_analogFields = new MetadataRecordAnalogFields(MetadataFileLegacyMode.Disabled);
-                    m_composedFields = new MetadataRecordComposedFields(MetadataFileLegacyMode.Disabled);
-                    m_constantFields = new MetadataRecordConstantFields();
-                    break;
-                case DataType.Composed:
-                    m_composedFields = new MetadataRecordComposedFields(reader);
-                    m_analogFields = new MetadataRecordAnalogFields(MetadataFileLegacyMode.Disabled);
-                    m_digitalFields = new MetadataRecordDigitalFields(MetadataFileLegacyMode.Disabled);
-                    m_constantFields = new MetadataRecordConstantFields();
-                    break;
-                case DataType.Constant:
-                    m_constantFields = new MetadataRecordConstantFields(reader);
-                    m_analogFields = new MetadataRecordAnalogFields(MetadataFileLegacyMode.Disabled);
-                    m_digitalFields = new MetadataRecordDigitalFields(MetadataFileLegacyMode.Disabled);
-                    m_composedFields = new MetadataRecordComposedFields(MetadataFileLegacyMode.Disabled);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets any remarks associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="Remarks"/> is 512 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string Remarks
-        {
-            get => m_remarks;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_remarks = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(512) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets hardware information associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="HardwareInfo"/> is 512 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string HardwareInfo
-        {
-            get => m_hardwareInfo;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_hardwareInfo = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(512) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a comma-separated list of email addresses that will receive alarm notification email messages based 
-        /// on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="AlarmEmails"/> is 512 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string AlarmEmails
-        {
-            get => m_emailAddresses;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_emailAddresses = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(512) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the description associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="Description"/> is 80 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string Description
-        {
-            get => m_description;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_description = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(80) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the time, value and quality of the most current data received for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="CurrentData"/> is 80 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string CurrentData
-        {
-            get => m_currentData;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_currentData = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(80) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets an alphanumeric name for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="Name"/> is 40 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string Name
-        {
-            get => m_name;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_name = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets an alternate <see cref="Name"/> for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="Synonym1"/> is 40 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string Synonym1
-        {
-            get => m_synonym1;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_synonym1 = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets an alternate <see cref="Name"/> for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="Synonym2"/> is 40 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string Synonym2
-        {
-            get => m_synonym2;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_synonym2 = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets an alternate <see cref="Name"/> for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="Synonym3"/> is 40 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string Synonym3
-        {
-            get => m_synonym3;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_synonym3 = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a comma-separated list of pager numbers that will receive alarm notification text messages based 
-        /// on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="AlarmPagers"/> is 40 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string AlarmPagers
-        {
-            get => m_pagerNumbers;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_pagerNumbers = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a comma-separated list of phone numbers that will receive alarm notification voice messages based 
-        /// on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="AlarmPhones"/> is 40 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string AlarmPhones
-        {
-            get => m_phoneNumbers;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_phoneNumbers = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the plant to which the <see cref="HistorianID"/> is associated.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="PlantCode"/> is 24 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string PlantCode
-        {
-            get => m_plantCode;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_plantCode = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the alphanumeric system identifier for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="SystemName"/> is 24 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string SystemName
-        {
-            get => m_system;
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_system = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the data and time when an alarm notification is sent based on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="EmailTime"/> is 40 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
-        public string EmailTime
-        {
-            get => m_emailTime;
-            set => m_emailTime = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
-        }
-
-        /// <summary>
-        /// Gets or sets the rate at which the source device scans and sends data for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="ScanRate"/> is used by data acquisition components for polling data from the actual device.
-        /// </remarks>
-        public float ScanRate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the unit (i.e. generator) to which the <see cref="HistorianID"/> is associated.
-        /// </summary>
-        public int UnitNumber { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordSecurityFlags"/> associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public MetadataRecordSecurityFlags SecurityFlags
-        {
-            get => m_securityFlags;
-            set => m_securityFlags = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordGeneralFlags"/> associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public MetadataRecordGeneralFlags GeneralFlags
-        {
-            get => m_generalFlags;
-            set => m_generalFlags = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAlarmFlags"/> associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public MetadataRecordAlarmFlags AlarmFlags
-        {
-            get => m_alarmFlags;
-            set => m_alarmFlags = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Gets or sets the minimum allowable time (in seconds) between archived data for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="CompressionMinTime"/> is useful for limiting archived data for noisy <see cref="HistorianID"/>s.
-        /// </remarks>
-        public int CompressionMinTime { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum time (in seconds) after which data is to be archived for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="CompressionMaxTime"/> ensures that archived data exist every "n" seconds for the <see cref="HistorianID"/>, 
-        /// which would otherwise be omitted due to compression.
-        /// </remarks>
-        public int CompressionMaxTime { get; set; }
-
-        /// <summary>
-        /// Gets or sets the numeric identifier of the data source for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="SourceID"/> is used for the determination of "global time" when that client option is in effect.  
-        /// When "global time" is in effect, the historian returns the current data time for a <see cref="HistorianID"/> 
-        /// based on the latest time received for all <see cref="HistorianID"/>s with the same <see cref="SourceID"/>.
-        /// </remarks>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
-        public int SourceID
-        {
-            get => m_sourceID;
-            set
-            {
-                if (value < 0)
-                    throw new ArgumentException("Value must be positive or zero");
-
-                m_sourceID = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordAnalogFields"/> associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public MetadataRecordAnalogFields AnalogFields
-        {
-            get => m_analogFields;
-            set => m_analogFields = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordDigitalFields"/> associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public MetadataRecordDigitalFields DigitalFields
-        {
-            get => m_digitalFields;
-            set => m_digitalFields = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordComposedFields"/> associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public MetadataRecordComposedFields ComposedFields
-        {
-            get => m_composedFields;
-            set => m_composedFields = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataRecordConstantFields"/> associated with the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public MetadataRecordConstantFields ConstantFields
-        {
-            get => m_constantFields;
-            set => m_constantFields = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        /// Gets the historian identifier of <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int HistorianID { get; }
-
-        /// <summary>
-        /// Gets the <see cref="MetadataRecordSummary"/> object for <see cref="MetadataRecord"/>.
-        /// </summary>
-        public MetadataRecordSummary Summary => new(this);
-
-        /// <summary>
-        /// Gets the length of the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int BinaryLength => FixedLength;
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="MetadataRecord"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecord"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecord"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length < FixedLength)
-                return 0;
-
-            // Binary image has sufficient data.
-            Remarks = Encoding.ASCII.GetString(buffer, startIndex, 512).Trim();
-            HardwareInfo = Encoding.ASCII.GetString(buffer, startIndex + 512, 512).Trim();
-            AlarmEmails = Encoding.ASCII.GetString(buffer, startIndex + 1024, 512).Trim();
-            Description = Encoding.ASCII.GetString(buffer, startIndex + 1536, 80).Trim();
-            CurrentData = Encoding.ASCII.GetString(buffer, startIndex + 1616, 80).Trim();
-            Name = Encoding.ASCII.GetString(buffer, startIndex + 1696, 40).Trim();
-            Synonym1 = Encoding.ASCII.GetString(buffer, startIndex + 1736, 40).Trim();
-            Synonym2 = Encoding.ASCII.GetString(buffer, startIndex + 1776, 40).Trim();
-            Synonym3 = Encoding.ASCII.GetString(buffer, startIndex + 1816, 40).Trim();
-            AlarmPagers = Encoding.ASCII.GetString(buffer, startIndex + 1856, 40).Trim();
-            AlarmPhones = Encoding.ASCII.GetString(buffer, startIndex + 1896, 40).Trim();
-            PlantCode = Encoding.ASCII.GetString(buffer, startIndex + 1936, 24).Trim();
-            SystemName = Encoding.ASCII.GetString(buffer, startIndex + 1960, 24).Trim();
-            EmailTime = Encoding.ASCII.GetString(buffer, startIndex + 1984, 40).Trim();
-            ScanRate = LittleEndian.ToSingle(buffer, startIndex + 2104);
-            UnitNumber = LittleEndian.ToInt32(buffer, startIndex + 2108);
-            SecurityFlags.Value = LittleEndian.ToInt32(buffer, startIndex + 2112);
-            GeneralFlags.Value = LittleEndian.ToInt32(buffer, startIndex + 2116);
-            AlarmFlags.Value = LittleEndian.ToInt32(buffer, startIndex + 2120);
-            CompressionMinTime = LittleEndian.ToInt32(buffer, startIndex + 2124);
-            CompressionMaxTime = LittleEndian.ToInt32(buffer, startIndex + 2128);
-            SourceID = LittleEndian.ToInt32(buffer, startIndex + 2132);
-
-            switch (GeneralFlags.DataType)
-            {
-                case DataType.Analog:
-                    m_analogFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
-                    break;
-                case DataType.Digital:
-                    m_digitalFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
-                    break;
-                case DataType.Composed:
-                    m_composedFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
-                    break;
-                case DataType.Constant:
-                    m_constantFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
-                    break;
-            }
-
-            return FixedLength;
-
-            // Binary image does not have sufficient data.
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="MetadataRecord"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            // Construct the binary IP buffer for this event
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_remarks.PadRight(512).TruncateRight(512)), 0, buffer, startIndex, 512);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_hardwareInfo.PadRight(512).TruncateRight(512)), 0, buffer, startIndex + 512, 512);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_emailAddresses.PadRight(512).TruncateRight(512)), 0, buffer, startIndex + 1024, 512);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_description.PadRight(80).TruncateRight(80)), 0, buffer, startIndex + 1536, 80);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_currentData.PadRight(80).TruncateRight(80)), 0, buffer, startIndex + 1616, 80);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_name.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1696, 40);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_synonym1.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1736, 40);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_synonym2.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1776, 40);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_synonym3.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1816, 40);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_pagerNumbers.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1856, 40);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_phoneNumbers.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1896, 40);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_plantCode.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 1936, 24);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_system.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 1960, 24);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_emailTime.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1984, 40);
-            Buffer.BlockCopy(LittleEndian.GetBytes(ScanRate), 0, buffer, startIndex + 2104, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(UnitNumber), 0, buffer, startIndex + 2108, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_securityFlags.Value), 0, buffer, startIndex + 2112, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_generalFlags.Value), 0, buffer, startIndex + 2116, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_alarmFlags.Value), 0, buffer, startIndex + 2120, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(CompressionMinTime), 0, buffer, startIndex + 2124, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(CompressionMaxTime), 0, buffer, startIndex + 2128, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_sourceID), 0, buffer, startIndex + 2132, 4);
-
-            switch (m_generalFlags.DataType)
-            {
-                case DataType.Analog:
-                    m_analogFields.GenerateBinaryImage(buffer, startIndex + 2152);
-                    break;
-                case DataType.Digital:
-                    m_digitalFields.GenerateBinaryImage(buffer, startIndex + 2152);
-                    break;
-                case DataType.Composed:
-                    m_composedFields.GenerateBinaryImage(buffer, startIndex + 2152);
-                    break;
-                case DataType.Constant:
-                    m_constantFields.GenerateBinaryImage(buffer, startIndex + 2152);
-                    break;
-            }
-
-            return length;
-        }
-
-        /// <summary>
-        /// Compares the current <see cref="MetadataRecord"/> object to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="MetadataRecord"/> object is to be compared.</param>
-        /// <returns>
-        /// Negative value if the current <see cref="MetadataRecord"/> object is less than <paramref name="obj"/>, 
-        /// Zero if the current <see cref="MetadataRecord"/> object is equal to <paramref name="obj"/>, 
-        /// Positive value if the current <see cref="MetadataRecord"/> object is greater than <paramref name="obj"/>.
-        /// </returns>
-        public virtual int CompareTo(object obj)
-        {
-            return obj is MetadataRecord other ? HistorianID.CompareTo(other.HistorianID) : 1;
-        }
-
-        /// <summary>
-        /// Determines whether the current <see cref="MetadataRecord"/> object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="MetadataRecord"/> object is to be compared for equality.</param>
-        /// <returns>true if the current <see cref="MetadataRecord"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            return CompareTo(obj) == 0;
-        }
-
-        /// <summary>
-        /// Returns the text representation of <see cref="MetadataRecord"/> object.
-        /// </summary>
-        /// <returns>A <see cref="string"/> value.</returns>
-        public override string ToString()
-        {
-            return $"ID={HistorianID}; Name={m_name}";
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current <see cref="MetadataRecord"/> object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return HistorianID.GetHashCode();
-        }
-
-        internal void WriteImage(BinaryWriter writer)
-        {
-            writer.Write(HistorianID);
-            writer.Write(m_remarks);
-            writer.Write(m_hardwareInfo);
-            writer.Write(m_emailAddresses);
-            writer.Write(m_description);
-            writer.Write(m_currentData);
-            writer.Write(m_name);
-            writer.Write(m_synonym1);
-            writer.Write(m_synonym2);
-            writer.Write(m_synonym3);
-            writer.Write(m_pagerNumbers);
-            writer.Write(m_phoneNumbers);
-            writer.Write(m_plantCode);
-            writer.Write(m_system);
-            writer.Write(m_emailTime);
-            writer.Write(ScanRate);
-            writer.Write(UnitNumber);
-            writer.Write(m_securityFlags.Value);
-            writer.Write(m_generalFlags.Value);
-            writer.Write(m_alarmFlags.Value);
-            writer.Write(CompressionMinTime);
-            writer.Write(CompressionMaxTime);
-            writer.Write(m_sourceID);
-
-            switch (m_generalFlags.DataType)
-            {
-                case DataType.Analog:
-                    m_analogFields.WriteImage(writer);
-                    break;
-                case DataType.Digital:
-                    m_digitalFields.WriteImage(writer);
-                    break;
-                case DataType.Composed:
-                    m_composedFields.WriteImage(writer);
-                    break;
-                case DataType.Constant:
-                    m_constantFields.WriteImage(writer);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        #endregion
+        if (historianID < 0)
+            throw new ArgumentOutOfRangeException(nameof(historianID));
+
+        HistorianID = historianID;
+        m_remarks = string.Empty;
+        m_hardwareInfo = string.Empty;
+        m_emailAddresses = string.Empty;
+        m_description = string.Empty;
+        m_currentData = string.Empty;
+        m_name = string.Empty;
+        m_synonym1 = string.Empty;
+        m_synonym2 = string.Empty;
+        m_synonym3 = string.Empty;
+        m_pagerNumbers = string.Empty;
+        m_phoneNumbers = string.Empty;
+        m_plantCode = string.Empty;
+        m_system = string.Empty;
+        m_emailTime = string.Empty;
+        m_securityFlags = new MetadataRecordSecurityFlags();
+        m_generalFlags = new MetadataRecordGeneralFlags();
+        m_alarmFlags = new MetadataRecordAlarmFlags();
+        m_analogFields = new MetadataRecordAnalogFields(legacyMode);
+        m_digitalFields = new MetadataRecordDigitalFields(legacyMode);
+        m_composedFields = new MetadataRecordComposedFields(legacyMode);
+        m_constantFields = new MetadataRecordConstantFields();
+        m_legacyMode = legacyMode;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecord"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="MetadataRecord"/>.</param>
+    /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecord"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public MetadataRecord(int historianID, MetadataFileLegacyMode legacyMode, byte[] buffer, int startIndex, int length)
+        : this(historianID, legacyMode)
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    internal MetadataRecord(BinaryReader reader)
+    {
+        HistorianID = reader.ReadInt32();
+        m_remarks = reader.ReadString();
+        m_hardwareInfo = reader.ReadString();
+        m_emailAddresses = reader.ReadString();
+        m_description = reader.ReadString();
+        m_currentData = reader.ReadString();
+        m_name = reader.ReadString();
+        m_synonym1 = reader.ReadString();
+        m_synonym2 = reader.ReadString();
+        m_synonym3 = reader.ReadString();
+        m_pagerNumbers = reader.ReadString();
+        m_phoneNumbers = reader.ReadString();
+        m_plantCode = reader.ReadString();
+        m_system = reader.ReadString();
+        m_emailTime = reader.ReadString();
+        ScanRate = reader.ReadSingle();
+        UnitNumber = reader.ReadInt32();
+
+        m_securityFlags = new MetadataRecordSecurityFlags { Value = reader.ReadInt32() };
+        m_generalFlags = new MetadataRecordGeneralFlags { Value = reader.ReadInt32() };
+        m_alarmFlags = new MetadataRecordAlarmFlags { Value = reader.ReadInt32() };
+
+        CompressionMinTime = reader.ReadInt32();
+        CompressionMaxTime = reader.ReadInt32();
+        m_sourceID = reader.ReadInt32();
+
+        switch (m_generalFlags.DataType)
+        {
+            case DataType.Analog:
+                m_analogFields = new MetadataRecordAnalogFields(reader);
+                m_digitalFields = new MetadataRecordDigitalFields(MetadataFileLegacyMode.Disabled);
+                m_composedFields = new MetadataRecordComposedFields(MetadataFileLegacyMode.Disabled);
+                m_constantFields = new MetadataRecordConstantFields();
+                break;
+            case DataType.Digital:
+                m_digitalFields = new MetadataRecordDigitalFields(reader);
+                m_analogFields = new MetadataRecordAnalogFields(MetadataFileLegacyMode.Disabled);
+                m_composedFields = new MetadataRecordComposedFields(MetadataFileLegacyMode.Disabled);
+                m_constantFields = new MetadataRecordConstantFields();
+                break;
+            case DataType.Composed:
+                m_composedFields = new MetadataRecordComposedFields(reader);
+                m_analogFields = new MetadataRecordAnalogFields(MetadataFileLegacyMode.Disabled);
+                m_digitalFields = new MetadataRecordDigitalFields(MetadataFileLegacyMode.Disabled);
+                m_constantFields = new MetadataRecordConstantFields();
+                break;
+            case DataType.Constant:
+                m_constantFields = new MetadataRecordConstantFields(reader);
+                m_analogFields = new MetadataRecordAnalogFields(MetadataFileLegacyMode.Disabled);
+                m_digitalFields = new MetadataRecordDigitalFields(MetadataFileLegacyMode.Disabled);
+                m_composedFields = new MetadataRecordComposedFields(MetadataFileLegacyMode.Disabled);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets any remarks associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="Remarks"/> is 512 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string Remarks
+    {
+        get => m_remarks;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_remarks = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(512) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets hardware information associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="HardwareInfo"/> is 512 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string HardwareInfo
+    {
+        get => m_hardwareInfo;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_hardwareInfo = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(512) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a comma-separated list of email addresses that will receive alarm notification email messages based 
+    /// on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="AlarmEmails"/> is 512 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string AlarmEmails
+    {
+        get => m_emailAddresses;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_emailAddresses = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(512) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the description associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="Description"/> is 80 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string Description
+    {
+        get => m_description;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_description = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(80) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the time, value and quality of the most current data received for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="CurrentData"/> is 80 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string CurrentData
+    {
+        get => m_currentData;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_currentData = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(80) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets an alphanumeric name for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="Name"/> is 40 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string Name
+    {
+        get => m_name;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_name = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets an alternate <see cref="Name"/> for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="Synonym1"/> is 40 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string Synonym1
+    {
+        get => m_synonym1;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_synonym1 = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets an alternate <see cref="Name"/> for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="Synonym2"/> is 40 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string Synonym2
+    {
+        get => m_synonym2;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_synonym2 = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets an alternate <see cref="Name"/> for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="Synonym3"/> is 40 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string Synonym3
+    {
+        get => m_synonym3;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_synonym3 = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a comma-separated list of pager numbers that will receive alarm notification text messages based 
+    /// on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="AlarmPagers"/> is 40 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string AlarmPagers
+    {
+        get => m_pagerNumbers;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_pagerNumbers = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a comma-separated list of phone numbers that will receive alarm notification voice messages based 
+    /// on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="AlarmPhones"/> is 40 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string AlarmPhones
+    {
+        get => m_phoneNumbers;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_phoneNumbers = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the plant to which the <see cref="HistorianID"/> is associated.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="PlantCode"/> is 24 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string PlantCode
+    {
+        get => m_plantCode;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_plantCode = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the alphanumeric system identifier for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="SystemName"/> is 24 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string SystemName
+    {
+        get => m_system;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_system = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the data and time when an alarm notification is sent based on the <see cref="AlarmFlags"/> settings for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="EmailTime"/> is 40 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null string.</exception>
+    public string EmailTime
+    {
+        get => m_emailTime;
+        set => m_emailTime = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(40) : value;
+    }
+
+    /// <summary>
+    /// Gets or sets the rate at which the source device scans and sends data for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ScanRate"/> is used by data acquisition components for polling data from the actual device.
+    /// </remarks>
+    public float ScanRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unit (i.e. generator) to which the <see cref="HistorianID"/> is associated.
+    /// </summary>
+    public int UnitNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordSecurityFlags"/> associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public MetadataRecordSecurityFlags SecurityFlags
+    {
+        get => m_securityFlags;
+        set => m_securityFlags = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordGeneralFlags"/> associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public MetadataRecordGeneralFlags GeneralFlags
+    {
+        get => m_generalFlags;
+        set => m_generalFlags = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAlarmFlags"/> associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public MetadataRecordAlarmFlags AlarmFlags
+    {
+        get => m_alarmFlags;
+        set => m_alarmFlags = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum allowable time (in seconds) between archived data for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CompressionMinTime"/> is useful for limiting archived data for noisy <see cref="HistorianID"/>s.
+    /// </remarks>
+    public int CompressionMinTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum time (in seconds) after which data is to be archived for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CompressionMaxTime"/> ensures that archived data exist every "n" seconds for the <see cref="HistorianID"/>, 
+    /// which would otherwise be omitted due to compression.
+    /// </remarks>
+    public int CompressionMaxTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the numeric identifier of the data source for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SourceID"/> is used for the determination of "global time" when that client option is in effect.  
+    /// When "global time" is in effect, the historian returns the current data time for a <see cref="HistorianID"/> 
+    /// based on the latest time received for all <see cref="HistorianID"/>s with the same <see cref="SourceID"/>.
+    /// </remarks>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or zero.</exception>
+    public int SourceID
+    {
+        get => m_sourceID;
+        set
+        {
+            if (value < 0)
+                throw new ArgumentException("Value must be positive or zero");
+
+            m_sourceID = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordAnalogFields"/> associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public MetadataRecordAnalogFields AnalogFields
+    {
+        get => m_analogFields;
+        set => m_analogFields = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordDigitalFields"/> associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public MetadataRecordDigitalFields DigitalFields
+    {
+        get => m_digitalFields;
+        set => m_digitalFields = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordComposedFields"/> associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public MetadataRecordComposedFields ComposedFields
+    {
+        get => m_composedFields;
+        set => m_composedFields = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataRecordConstantFields"/> associated with the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public MetadataRecordConstantFields ConstantFields
+    {
+        get => m_constantFields;
+        set => m_constantFields = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets the historian identifier of <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int HistorianID { get; }
+
+    /// <summary>
+    /// Gets the <see cref="MetadataRecordSummary"/> object for <see cref="MetadataRecord"/>.
+    /// </summary>
+    public MetadataRecordSummary Summary => new(this);
+
+    /// <summary>
+    /// Gets the length of the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="MetadataRecord"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecord"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecord"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        if (length < FixedLength)
+            return 0;
+
+        // Binary image has sufficient data.
+        Remarks = Encoding.ASCII.GetString(buffer, startIndex, 512).Trim();
+        HardwareInfo = Encoding.ASCII.GetString(buffer, startIndex + 512, 512).Trim();
+        AlarmEmails = Encoding.ASCII.GetString(buffer, startIndex + 1024, 512).Trim();
+        Description = Encoding.ASCII.GetString(buffer, startIndex + 1536, 80).Trim();
+        CurrentData = Encoding.ASCII.GetString(buffer, startIndex + 1616, 80).Trim();
+        Name = Encoding.ASCII.GetString(buffer, startIndex + 1696, 40).Trim();
+        Synonym1 = Encoding.ASCII.GetString(buffer, startIndex + 1736, 40).Trim();
+        Synonym2 = Encoding.ASCII.GetString(buffer, startIndex + 1776, 40).Trim();
+        Synonym3 = Encoding.ASCII.GetString(buffer, startIndex + 1816, 40).Trim();
+        AlarmPagers = Encoding.ASCII.GetString(buffer, startIndex + 1856, 40).Trim();
+        AlarmPhones = Encoding.ASCII.GetString(buffer, startIndex + 1896, 40).Trim();
+        PlantCode = Encoding.ASCII.GetString(buffer, startIndex + 1936, 24).Trim();
+        SystemName = Encoding.ASCII.GetString(buffer, startIndex + 1960, 24).Trim();
+        EmailTime = Encoding.ASCII.GetString(buffer, startIndex + 1984, 40).Trim();
+        ScanRate = LittleEndian.ToSingle(buffer, startIndex + 2104);
+        UnitNumber = LittleEndian.ToInt32(buffer, startIndex + 2108);
+        SecurityFlags.Value = LittleEndian.ToInt32(buffer, startIndex + 2112);
+        GeneralFlags.Value = LittleEndian.ToInt32(buffer, startIndex + 2116);
+        AlarmFlags.Value = LittleEndian.ToInt32(buffer, startIndex + 2120);
+        CompressionMinTime = LittleEndian.ToInt32(buffer, startIndex + 2124);
+        CompressionMaxTime = LittleEndian.ToInt32(buffer, startIndex + 2128);
+        SourceID = LittleEndian.ToInt32(buffer, startIndex + 2132);
+
+        switch (GeneralFlags.DataType)
+        {
+            case DataType.Analog:
+                m_analogFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
+                break;
+            case DataType.Digital:
+                m_digitalFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
+                break;
+            case DataType.Composed:
+                m_composedFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
+                break;
+            case DataType.Constant:
+                m_constantFields.ParseBinaryImage(buffer, startIndex + 2152, length - 2152);
+                break;
+        }
+
+        return FixedLength;
+
+        // Binary image does not have sufficient data.
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="MetadataRecord"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        // Construct the binary IP buffer for this event
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_remarks.PadRight(512).TruncateRight(512)), 0, buffer, startIndex, 512);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_hardwareInfo.PadRight(512).TruncateRight(512)), 0, buffer, startIndex + 512, 512);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_emailAddresses.PadRight(512).TruncateRight(512)), 0, buffer, startIndex + 1024, 512);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_description.PadRight(80).TruncateRight(80)), 0, buffer, startIndex + 1536, 80);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_currentData.PadRight(80).TruncateRight(80)), 0, buffer, startIndex + 1616, 80);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_name.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1696, 40);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_synonym1.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1736, 40);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_synonym2.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1776, 40);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_synonym3.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1816, 40);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_pagerNumbers.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1856, 40);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_phoneNumbers.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1896, 40);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_plantCode.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 1936, 24);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_system.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 1960, 24);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_emailTime.PadRight(40).TruncateRight(40)), 0, buffer, startIndex + 1984, 40);
+        Buffer.BlockCopy(LittleEndian.GetBytes(ScanRate), 0, buffer, startIndex + 2104, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(UnitNumber), 0, buffer, startIndex + 2108, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_securityFlags.Value), 0, buffer, startIndex + 2112, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_generalFlags.Value), 0, buffer, startIndex + 2116, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_alarmFlags.Value), 0, buffer, startIndex + 2120, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(CompressionMinTime), 0, buffer, startIndex + 2124, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(CompressionMaxTime), 0, buffer, startIndex + 2128, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_sourceID), 0, buffer, startIndex + 2132, 4);
+
+        switch (m_generalFlags.DataType)
+        {
+            case DataType.Analog:
+                m_analogFields.GenerateBinaryImage(buffer, startIndex + 2152);
+                break;
+            case DataType.Digital:
+                m_digitalFields.GenerateBinaryImage(buffer, startIndex + 2152);
+                break;
+            case DataType.Composed:
+                m_composedFields.GenerateBinaryImage(buffer, startIndex + 2152);
+                break;
+            case DataType.Constant:
+                m_constantFields.GenerateBinaryImage(buffer, startIndex + 2152);
+                break;
+        }
+
+        return length;
+    }
+
+    /// <summary>
+    /// Compares the current <see cref="MetadataRecord"/> object to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="MetadataRecord"/> object is to be compared.</param>
+    /// <returns>
+    /// Negative value if the current <see cref="MetadataRecord"/> object is less than <paramref name="obj"/>, 
+    /// Zero if the current <see cref="MetadataRecord"/> object is equal to <paramref name="obj"/>, 
+    /// Positive value if the current <see cref="MetadataRecord"/> object is greater than <paramref name="obj"/>.
+    /// </returns>
+    public virtual int CompareTo(object obj)
+    {
+        return obj is MetadataRecord other ? HistorianID.CompareTo(other.HistorianID) : 1;
+    }
+
+    /// <summary>
+    /// Determines whether the current <see cref="MetadataRecord"/> object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="MetadataRecord"/> object is to be compared for equality.</param>
+    /// <returns>true if the current <see cref="MetadataRecord"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        return CompareTo(obj) == 0;
+    }
+
+    /// <summary>
+    /// Returns the text representation of <see cref="MetadataRecord"/> object.
+    /// </summary>
+    /// <returns>A <see cref="string"/> value.</returns>
+    public override string ToString()
+    {
+        return $"ID={HistorianID}; Name={m_name}";
+    }
+
+    /// <summary>
+    /// Returns the hash code for the current <see cref="MetadataRecord"/> object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        return HistorianID.GetHashCode();
+    }
+
+    internal void WriteImage(BinaryWriter writer)
+    {
+        writer.Write(HistorianID);
+        writer.Write(m_remarks);
+        writer.Write(m_hardwareInfo);
+        writer.Write(m_emailAddresses);
+        writer.Write(m_description);
+        writer.Write(m_currentData);
+        writer.Write(m_name);
+        writer.Write(m_synonym1);
+        writer.Write(m_synonym2);
+        writer.Write(m_synonym3);
+        writer.Write(m_pagerNumbers);
+        writer.Write(m_phoneNumbers);
+        writer.Write(m_plantCode);
+        writer.Write(m_system);
+        writer.Write(m_emailTime);
+        writer.Write(ScanRate);
+        writer.Write(UnitNumber);
+        writer.Write(m_securityFlags.Value);
+        writer.Write(m_generalFlags.Value);
+        writer.Write(m_alarmFlags.Value);
+        writer.Write(CompressionMinTime);
+        writer.Write(CompressionMaxTime);
+        writer.Write(m_sourceID);
+
+        switch (m_generalFlags.DataType)
+        {
+            case DataType.Analog:
+                m_analogFields.WriteImage(writer);
+                break;
+            case DataType.Digital:
+                m_digitalFields.WriteImage(writer);
+                break;
+            case DataType.Composed:
+                m_composedFields.WriteImage(writer);
+                break;
+            case DataType.Constant:
+                m_constantFields.WriteImage(writer);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordAlarmFlags.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordAlarmFlags.cs
@@ -29,488 +29,290 @@
 //
 //******************************************************************************************************
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Defines which data <see cref="Quality"/> should trigger an alarm notification.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordAlarmFlags
 {
+    #region [ Properties ]
+
     /// <summary>
-    /// Defines which data <see cref="Quality"/> should trigger an alarm notification.
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.Unknown"/> should trigger an alarm notification.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordAlarmFlags
+    public bool Unknown
     {
-        #region [ Members ]
-
-        // Fields
-        private int m_value;
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.Unknown"/> should trigger an alarm notification.
-        /// </summary>
-        public bool Unknown
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit00);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit00) : m_value.ClearBits(Bits.Bit00);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DeletedFromProcessing"/> should trigger an alarm notification.
-        /// </summary>
-        public bool DeletedFromProcessing
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit01);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit01) : m_value.ClearBits(Bits.Bit01);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.CouldNotCalculate"/> should trigger an alarm notification.
-        /// </summary>
-        public bool CouldNotCalculate
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit02);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit02) : m_value.ClearBits(Bits.Bit02);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.FrontEndHardwareError"/> should trigger an alarm notification.
-        /// </summary>
-        public bool FrontEndHardwareError
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit03);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit03) : m_value.ClearBits(Bits.Bit03);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SensorReadError"/> should trigger an alarm notification.
-        /// </summary>
-        public bool SensorReadError
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit04);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit04) : m_value.ClearBits(Bits.Bit04);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.OpenThermocouple"/> should trigger an alarm notification.
-        /// </summary>
-        public bool OpenThermocouple
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit05);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit05) : m_value.ClearBits(Bits.Bit05);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InputCountsOutOfSensorRange"/> should trigger an alarm notification.
-        /// </summary>
-        public bool InputCountsOutOfSensorRange
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit06);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit06) : m_value.ClearBits(Bits.Bit06);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.UnreasonableHigh"/> should trigger an alarm notification.
-        /// </summary>
-        public bool UnreasonableHigh
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit07);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit07) : m_value.ClearBits(Bits.Bit07);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.UnreasonableLow"/> should trigger an alarm notification.
-        /// </summary>
-        public bool UnreasonableLow
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit08);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit08) : m_value.ClearBits(Bits.Bit08);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.Old"/> should trigger an alarm notification.
-        /// </summary>
-        public bool Old
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit09);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit09) : m_value.ClearBits(Bits.Bit09);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueAboveHiHiLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool SuspectValueAboveHiHiLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit10);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit10) : m_value.ClearBits(Bits.Bit10);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueBelowLoLoLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool SuspectValueBelowLoLoLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit11);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit11) : m_value.ClearBits(Bits.Bit11);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueAboveHiLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool SuspectValueAboveHiLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit12);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit12) : m_value.ClearBits(Bits.Bit12);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueBelowLoLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool SuspectValueBelowLoLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit13);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit13) : m_value.ClearBits(Bits.Bit13);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectData"/> should trigger an alarm notification.
-        /// </summary>
-        public bool SuspectData
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit14);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit14) : m_value.ClearBits(Bits.Bit14);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DigitalSuspectAlarm"/> should trigger an alarm notification.
-        /// </summary>
-        public bool DigitalSuspectAlarm
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit15);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit15) : m_value.ClearBits(Bits.Bit15);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueAboveHiHiLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool InsertedValueAboveHiHiLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit16);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit16) : m_value.ClearBits(Bits.Bit16);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueBelowLoLoLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool InsertedValueBelowLoLoLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit17);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit17) : m_value.ClearBits(Bits.Bit17);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueAboveHiLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool InsertedValueAboveHiLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit18);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit18) : m_value.ClearBits(Bits.Bit18);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueBelowLoLimit"/> should trigger an alarm notification.
-        /// </summary>
-        public bool InsertedValueBelowLoLimit
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit19);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit19) : m_value.ClearBits(Bits.Bit19);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValue"/> should trigger an alarm notification.
-        /// </summary>
-        public bool InsertedValue
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit20);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit20) : m_value.ClearBits(Bits.Bit20);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DigitalInsertedStatusInAlarm"/> should trigger an alarm notification.
-        /// </summary>
-        public bool DigitalInsertedStatusInAlarm
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit21);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit21) : m_value.ClearBits(Bits.Bit21);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.LogicalAlarm"/> should trigger an alarm notification.
-        /// </summary>
-        public bool LogicalAlarm
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit22);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit22) : m_value.ClearBits(Bits.Bit22);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueAboveHiHiAlarm"/> should trigger an alarm notification.
-        /// </summary>
-        public bool ValueAboveHiHiAlarm
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit23);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit23) : m_value.ClearBits(Bits.Bit23);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueBelowLoLoAlarm"/> should trigger an alarm notification.
-        /// </summary>
-        public bool ValueBelowLoLoAlarm
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit24);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit24) : m_value.ClearBits(Bits.Bit24);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueAboveHiAlarm"/> should trigger an alarm notification.
-        /// </summary>
-        public bool ValueAboveHiAlarm
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit25);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit25) : m_value.ClearBits(Bits.Bit25);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueBelowLoAlarm"/> should trigger an alarm notification.
-        /// </summary>
-        public bool ValueBelowLoAlarm
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit26);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit26) : m_value.ClearBits(Bits.Bit26);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DeletedFromAlarmChecks"/> should trigger an alarm notification.
-        /// </summary>
-        public bool DeletedFromAlarmChecks
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit27);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit27) : m_value.ClearBits(Bits.Bit27);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InhibitedByCutoutPoint"/> should trigger an alarm notification.
-        /// </summary>
-        public bool InhibitedByCutoutPoint
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit28);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit28) : m_value.ClearBits(Bits.Bit28);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.Good"/> should trigger an alarm notification.
-        /// </summary>
-        public bool Good
-        {
-            get
-            {
-                return m_value.CheckBits(Bits.Bit29);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(Bits.Bit29) : m_value.ClearBits(Bits.Bit29);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the 32-bit integer value used for defining which data <see cref="Quality"/> should trigger an alarm notification.
-        /// </summary>
-        public int Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        #endregion
+        get => Value.CheckBits(Bits.Bit00);
+        set => Value = value ? Value.SetBits(Bits.Bit00) : Value.ClearBits(Bits.Bit00);
     }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DeletedFromProcessing"/> should trigger an alarm notification.
+    /// </summary>
+    public bool DeletedFromProcessing
+    {
+        get => Value.CheckBits(Bits.Bit01);
+        set => Value = value ? Value.SetBits(Bits.Bit01) : Value.ClearBits(Bits.Bit01);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.CouldNotCalculate"/> should trigger an alarm notification.
+    /// </summary>
+    public bool CouldNotCalculate
+    {
+        get => Value.CheckBits(Bits.Bit02);
+        set => Value = value ? Value.SetBits(Bits.Bit02) : Value.ClearBits(Bits.Bit02);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.FrontEndHardwareError"/> should trigger an alarm notification.
+    /// </summary>
+    public bool FrontEndHardwareError
+    {
+        get => Value.CheckBits(Bits.Bit03);
+        set => Value = value ? Value.SetBits(Bits.Bit03) : Value.ClearBits(Bits.Bit03);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SensorReadError"/> should trigger an alarm notification.
+    /// </summary>
+    public bool SensorReadError
+    {
+        get => Value.CheckBits(Bits.Bit04);
+        set => Value = value ? Value.SetBits(Bits.Bit04) : Value.ClearBits(Bits.Bit04);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.OpenThermocouple"/> should trigger an alarm notification.
+    /// </summary>
+    public bool OpenThermocouple
+    {
+        get => Value.CheckBits(Bits.Bit05);
+        set => Value = value ? Value.SetBits(Bits.Bit05) : Value.ClearBits(Bits.Bit05);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InputCountsOutOfSensorRange"/> should trigger an alarm notification.
+    /// </summary>
+    public bool InputCountsOutOfSensorRange
+    {
+        get => Value.CheckBits(Bits.Bit06);
+        set => Value = value ? Value.SetBits(Bits.Bit06) : Value.ClearBits(Bits.Bit06);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.UnreasonableHigh"/> should trigger an alarm notification.
+    /// </summary>
+    public bool UnreasonableHigh
+    {
+        get => Value.CheckBits(Bits.Bit07);
+        set => Value = value ? Value.SetBits(Bits.Bit07) : Value.ClearBits(Bits.Bit07);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.UnreasonableLow"/> should trigger an alarm notification.
+    /// </summary>
+    public bool UnreasonableLow
+    {
+        get => Value.CheckBits(Bits.Bit08);
+        set => Value = value ? Value.SetBits(Bits.Bit08) : Value.ClearBits(Bits.Bit08);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.Old"/> should trigger an alarm notification.
+    /// </summary>
+    public bool Old
+    {
+        get => Value.CheckBits(Bits.Bit09);
+        set => Value = value ? Value.SetBits(Bits.Bit09) : Value.ClearBits(Bits.Bit09);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueAboveHiHiLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool SuspectValueAboveHiHiLimit
+    {
+        get => Value.CheckBits(Bits.Bit10);
+        set => Value = value ? Value.SetBits(Bits.Bit10) : Value.ClearBits(Bits.Bit10);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueBelowLoLoLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool SuspectValueBelowLoLoLimit
+    {
+        get => Value.CheckBits(Bits.Bit11);
+        set => Value = value ? Value.SetBits(Bits.Bit11) : Value.ClearBits(Bits.Bit11);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueAboveHiLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool SuspectValueAboveHiLimit
+    {
+        get => Value.CheckBits(Bits.Bit12);
+        set => Value = value ? Value.SetBits(Bits.Bit12) : Value.ClearBits(Bits.Bit12);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectValueBelowLoLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool SuspectValueBelowLoLimit
+    {
+        get => Value.CheckBits(Bits.Bit13);
+        set => Value = value ? Value.SetBits(Bits.Bit13) : Value.ClearBits(Bits.Bit13);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.SuspectData"/> should trigger an alarm notification.
+    /// </summary>
+    public bool SuspectData
+    {
+        get => Value.CheckBits(Bits.Bit14);
+        set => Value = value ? Value.SetBits(Bits.Bit14) : Value.ClearBits(Bits.Bit14);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DigitalSuspectAlarm"/> should trigger an alarm notification.
+    /// </summary>
+    public bool DigitalSuspectAlarm
+    {
+        get => Value.CheckBits(Bits.Bit15);
+        set => Value = value ? Value.SetBits(Bits.Bit15) : Value.ClearBits(Bits.Bit15);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueAboveHiHiLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool InsertedValueAboveHiHiLimit
+    {
+        get => Value.CheckBits(Bits.Bit16);
+        set => Value = value ? Value.SetBits(Bits.Bit16) : Value.ClearBits(Bits.Bit16);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueBelowLoLoLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool InsertedValueBelowLoLoLimit
+    {
+        get => Value.CheckBits(Bits.Bit17);
+        set => Value = value ? Value.SetBits(Bits.Bit17) : Value.ClearBits(Bits.Bit17);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueAboveHiLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool InsertedValueAboveHiLimit
+    {
+        get => Value.CheckBits(Bits.Bit18);
+        set => Value = value ? Value.SetBits(Bits.Bit18) : Value.ClearBits(Bits.Bit18);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValueBelowLoLimit"/> should trigger an alarm notification.
+    /// </summary>
+    public bool InsertedValueBelowLoLimit
+    {
+        get => Value.CheckBits(Bits.Bit19);
+        set => Value = value ? Value.SetBits(Bits.Bit19) : Value.ClearBits(Bits.Bit19);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InsertedValue"/> should trigger an alarm notification.
+    /// </summary>
+    public bool InsertedValue
+    {
+        get => Value.CheckBits(Bits.Bit20);
+        set => Value = value ? Value.SetBits(Bits.Bit20) : Value.ClearBits(Bits.Bit20);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DigitalInsertedStatusInAlarm"/> should trigger an alarm notification.
+    /// </summary>
+    public bool DigitalInsertedStatusInAlarm
+    {
+        get => Value.CheckBits(Bits.Bit21);
+        set => Value = value ? Value.SetBits(Bits.Bit21) : Value.ClearBits(Bits.Bit21);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.LogicalAlarm"/> should trigger an alarm notification.
+    /// </summary>
+    public bool LogicalAlarm
+    {
+        get => Value.CheckBits(Bits.Bit22);
+        set => Value = value ? Value.SetBits(Bits.Bit22) : Value.ClearBits(Bits.Bit22);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueAboveHiHiAlarm"/> should trigger an alarm notification.
+    /// </summary>
+    public bool ValueAboveHiHiAlarm
+    {
+        get => Value.CheckBits(Bits.Bit23);
+        set => Value = value ? Value.SetBits(Bits.Bit23) : Value.ClearBits(Bits.Bit23);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueBelowLoLoAlarm"/> should trigger an alarm notification.
+    /// </summary>
+    public bool ValueBelowLoLoAlarm
+    {
+        get => Value.CheckBits(Bits.Bit24);
+        set => Value = value ? Value.SetBits(Bits.Bit24) : Value.ClearBits(Bits.Bit24);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueAboveHiAlarm"/> should trigger an alarm notification.
+    /// </summary>
+    public bool ValueAboveHiAlarm
+    {
+        get => Value.CheckBits(Bits.Bit25);
+        set => Value = value ? Value.SetBits(Bits.Bit25) : Value.ClearBits(Bits.Bit25);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.ValueBelowLoAlarm"/> should trigger an alarm notification.
+    /// </summary>
+    public bool ValueBelowLoAlarm
+    {
+        get => Value.CheckBits(Bits.Bit26);
+        set => Value = value ? Value.SetBits(Bits.Bit26) : Value.ClearBits(Bits.Bit26);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.DeletedFromAlarmChecks"/> should trigger an alarm notification.
+    /// </summary>
+    public bool DeletedFromAlarmChecks
+    {
+        get => Value.CheckBits(Bits.Bit27);
+        set => Value = value ? Value.SetBits(Bits.Bit27) : Value.ClearBits(Bits.Bit27);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.InhibitedByCutoutPoint"/> should trigger an alarm notification.
+    /// </summary>
+    public bool InhibitedByCutoutPoint
+    {
+        get => Value.CheckBits(Bits.Bit28);
+        set => Value = value ? Value.SetBits(Bits.Bit28) : Value.ClearBits(Bits.Bit28);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a data <see cref="Quality"/> of <see cref="Quality.Good"/> should trigger an alarm notification.
+    /// </summary>
+    public bool Good
+    {
+        get => Value.CheckBits(Bits.Bit29);
+        set => Value = value ? Value.SetBits(Bits.Bit29) : Value.ClearBits(Bits.Bit29);
+    }
+
+    /// <summary>
+    /// Gets or sets the 32-bit integer value used for defining which data <see cref="Quality"/> should trigger an alarm notification.
+    /// </summary>
+    public int Value { get; set; }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordAnalogFields.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordAnalogFields.cs
@@ -38,357 +38,232 @@ using System.IO;
 using System.Text;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Analog"/>.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordAnalogFields : ISupportBinaryImage
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 24         0-23       Char(24)   EngineeringUnits                                              *
+    // * 4          24-27      Single     HighAlarm                                                     *
+    // * 4          28-31      Single     LowAlarm                                                      *
+    // * 4          32-35      Single     HighRange                                                     *
+    // * 4          36-39      Single     LowRange                                                      *
+    // * 4          40-43      Single     HighWarning                                                   *
+    // * 4          44-47      Single     LowWarning                                                    *
+    // * 4          48-51      Single     ExceptionLimit                                                *
+    // * 4          52-55      Single     CompressionLimit                                              *
+    // * 4          56-59      Single     AlarmDelay                                                    *
+    // * 4          60-63      Int32      DisplayDigits                                                 *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Analog"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordAnalogFields"/>.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordAnalogFields : ISupportBinaryImage
+    public const int FixedLength = 64;
+
+    // Fields
+    private string m_engineeringUnits;
+    private readonly MetadataFileLegacyMode m_legacyMode;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecordAnalogFields"/> class.
+    /// </summary>
+    /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
+    internal MetadataRecordAnalogFields(MetadataFileLegacyMode legacyMode)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 24         0-23       Char(24)   EngineeringUnits                                              *
-        // * 4          24-27      Single     HighAlarm                                                     *
-        // * 4          28-31      Single     LowAlarm                                                      *
-        // * 4          32-35      Single     HighRange                                                     *
-        // * 4          36-39      Single     LowRange                                                      *
-        // * 4          40-43      Single     HighWarning                                                   *
-        // * 4          44-47      Single     LowWarning                                                    *
-        // * 4          48-51      Single     ExceptionLimit                                                *
-        // * 4          52-55      Single     CompressionLimit                                              *
-        // * 4          56-59      Single     AlarmDelay                                                    *
-        // * 4          60-63      Int32      DisplayDigits                                                 *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordAnalogFields"/>.
-        /// </summary>
-        public const int FixedLength = 64;
-
-        // Fields
-        private string m_engineeringUnits;
-        private float m_highAlarm;
-        private float m_lowAlarm;
-        private float m_highRange;
-        private float m_lowRange;
-        private float m_highWarning;
-        private float m_lowWarning;
-        private float m_exceptionLimit;
-        private float m_compressionLimit;
-        private float m_alarmDelay;
-        private int m_displayDigits;
-        private readonly MetadataFileLegacyMode m_legacyMode;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecordAnalogFields"/> class.
-        /// </summary>
-        /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
-        internal MetadataRecordAnalogFields(MetadataFileLegacyMode legacyMode)
-        {
-            m_engineeringUnits = string.Empty;
-            m_legacyMode = legacyMode;
-        }
-
-        internal MetadataRecordAnalogFields(BinaryReader reader)
-        {
-            m_legacyMode = MetadataFileLegacyMode.Disabled;
-            m_engineeringUnits = reader.ReadString();
-            m_highAlarm = reader.ReadSingle();
-            m_lowAlarm = reader.ReadSingle();
-            m_highRange = reader.ReadSingle();
-            m_lowRange = reader.ReadSingle();
-            m_highWarning = reader.ReadSingle();
-            m_lowWarning = reader.ReadSingle();
-            m_exceptionLimit = reader.ReadSingle();
-            m_compressionLimit = reader.ReadSingle();
-            m_alarmDelay = reader.ReadSingle();
-            m_displayDigits = reader.ReadInt32();
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the engineering units of archived data values for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="EngineeringUnits"/> is 24 characters.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public string EngineeringUnits
-        {
-            get
-            {
-                return m_engineeringUnits;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (m_legacyMode == MetadataFileLegacyMode.Enabled)
-                    m_engineeringUnits = value.TruncateRight(24);
-                else
-                    m_engineeringUnits = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiHiAlarm"/>.
-        /// </summary>
-        public float HighAlarm
-        {
-            get
-            {
-                return m_highAlarm;
-            }
-            set
-            {
-                m_highAlarm = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoLoAlarm"/>.
-        /// </summary>
-        public float LowAlarm
-        {
-            get
-            {
-                return m_lowAlarm;
-            }
-            set
-            {
-                m_lowAlarm = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableHigh"/>.
-        /// </summary>
-        public float HighRange
-        {
-            get
-            {
-                return m_highRange;
-            }
-            set
-            {
-                m_highRange = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableLow"/>.
-        /// </summary>
-        public float LowRange
-        {
-            get
-            {
-                return m_lowRange;
-            }
-            set
-            {
-                m_lowRange = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiAlarm"/>.
-        /// </summary>
-        public float HighWarning
-        {
-            get
-            {
-                return m_highWarning;
-            }
-            set
-            {
-                m_highWarning = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoAlarm"/>.
-        /// </summary>
-        public float LowWarning
-        {
-            get
-            {
-                return m_lowWarning;
-            }
-            set
-            {
-                m_lowWarning = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the amount, expressed in <see cref="EngineeringUnits"/>,  by which data values for the <see cref="MetadataRecord"/> must change before being sent for archival by the data aquisition source.
-        /// </summary>
-        public float ExceptionLimit
-        {
-            get
-            {
-                return m_exceptionLimit;
-            }
-            set
-            {
-                m_exceptionLimit = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the amount, expressed in <see cref="EngineeringUnits"/>, by which data values for the <see cref="MetadataRecord"/>  must changed before being archived.
-        /// </summary>
-        public float CompressionLimit
-        {
-            get
-            {
-                return m_compressionLimit;
-            }
-            set
-            {
-                m_compressionLimit = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the time (in seconds) to wait before consecutive alarm notifications are sent for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public float AlarmDelay
-        {
-            get
-            {
-                return m_alarmDelay;
-            }
-            set
-            {
-                m_alarmDelay = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of digits after the decimal point to be displayed for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int DisplayDigits
-        {
-            get
-            {
-                return m_displayDigits;
-            }
-            set
-            {
-                m_displayDigits = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="MetadataRecordAnalogFields"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="MetadataRecordAnalogFields"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordAnalogFields"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordAnalogFields"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                EngineeringUnits = Encoding.ASCII.GetString(buffer, startIndex, 24).Trim();
-                HighAlarm = LittleEndian.ToSingle(buffer, startIndex + 24);
-                LowAlarm = LittleEndian.ToSingle(buffer, startIndex + 28);
-                HighRange = LittleEndian.ToSingle(buffer, startIndex + 32);
-                LowRange = LittleEndian.ToSingle(buffer, startIndex + 36);
-                HighWarning = LittleEndian.ToSingle(buffer, startIndex + 40);
-                LowWarning = LittleEndian.ToSingle(buffer, startIndex + 44);
-                ExceptionLimit = LittleEndian.ToSingle(buffer, startIndex + 48);
-                CompressionLimit = LittleEndian.ToSingle(buffer, startIndex + 52);
-                AlarmDelay = LittleEndian.ToSingle(buffer, startIndex + 56);
-                DisplayDigits = LittleEndian.ToInt32(buffer, startIndex + 60);
-
-                return FixedLength;
-            }
-
-            // Binary image does not have sufficient data.
-            return 0;
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="MetadataRecordAnalogFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_engineeringUnits.PadRight(24).TruncateRight(24)), 0, buffer, startIndex, 24);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highAlarm), 0, buffer, startIndex + 24, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowAlarm), 0, buffer, startIndex + 28, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highRange), 0, buffer, startIndex + 32, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowRange), 0, buffer, startIndex + 36, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highWarning), 0, buffer, startIndex + 40, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowWarning), 0, buffer, startIndex + 44, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_exceptionLimit), 0, buffer, startIndex + 48, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_compressionLimit), 0, buffer, startIndex + 52, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_alarmDelay), 0, buffer, startIndex + 56, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_displayDigits), 0, buffer, startIndex + 60, 4);
-
-            return length;
-        }
-
-        internal void WriteImage(BinaryWriter writer)
-        {
-            writer.Write(m_engineeringUnits);
-            writer.Write(m_highAlarm);
-            writer.Write(m_lowAlarm);
-            writer.Write(m_highRange);
-            writer.Write(m_lowRange);
-            writer.Write(m_highWarning);
-            writer.Write(m_lowWarning);
-            writer.Write(m_exceptionLimit);
-            writer.Write(m_compressionLimit);
-            writer.Write(m_alarmDelay);
-            writer.Write(m_displayDigits);
-        }
-
-        #endregion
+        m_engineeringUnits = string.Empty;
+        m_legacyMode = legacyMode;
     }
+
+    internal MetadataRecordAnalogFields(BinaryReader reader)
+    {
+        m_legacyMode = MetadataFileLegacyMode.Disabled;
+        m_engineeringUnits = reader.ReadString();
+        HighAlarm = reader.ReadSingle();
+        LowAlarm = reader.ReadSingle();
+        HighRange = reader.ReadSingle();
+        LowRange = reader.ReadSingle();
+        HighWarning = reader.ReadSingle();
+        LowWarning = reader.ReadSingle();
+        ExceptionLimit = reader.ReadSingle();
+        CompressionLimit = reader.ReadSingle();
+        AlarmDelay = reader.ReadSingle();
+        DisplayDigits = reader.ReadInt32();
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the engineering units of archived data values for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="EngineeringUnits"/> is 24 characters.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public string EngineeringUnits
+    {
+        get => m_engineeringUnits;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_engineeringUnits = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiHiAlarm"/>.
+    /// </summary>
+    public float HighAlarm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoLoAlarm"/>.
+    /// </summary>
+    public float LowAlarm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableHigh"/>.
+    /// </summary>
+    public float HighRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableLow"/>.
+    /// </summary>
+    public float LowRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiAlarm"/>.
+    /// </summary>
+    public float HighWarning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoAlarm"/>.
+    /// </summary>
+    public float LowWarning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the amount, expressed in <see cref="EngineeringUnits"/>,  by which data values for the <see cref="MetadataRecord"/> must change before being sent for archival by the data aquisition source.
+    /// </summary>
+    public float ExceptionLimit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the amount, expressed in <see cref="EngineeringUnits"/>, by which data values for the <see cref="MetadataRecord"/>  must changed before being archived.
+    /// </summary>
+    public float CompressionLimit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time (in seconds) to wait before consecutive alarm notifications are sent for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public float AlarmDelay { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of digits after the decimal point to be displayed for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int DisplayDigits { get; set; }
+
+    /// <summary>
+    /// Gets the length of the <see cref="MetadataRecordAnalogFields"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="MetadataRecordAnalogFields"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordAnalogFields"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordAnalogFields"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        EngineeringUnits = Encoding.ASCII.GetString(buffer, startIndex, 24).Trim();
+        HighAlarm = LittleEndian.ToSingle(buffer, startIndex + 24);
+        LowAlarm = LittleEndian.ToSingle(buffer, startIndex + 28);
+        HighRange = LittleEndian.ToSingle(buffer, startIndex + 32);
+        LowRange = LittleEndian.ToSingle(buffer, startIndex + 36);
+        HighWarning = LittleEndian.ToSingle(buffer, startIndex + 40);
+        LowWarning = LittleEndian.ToSingle(buffer, startIndex + 44);
+        ExceptionLimit = LittleEndian.ToSingle(buffer, startIndex + 48);
+        CompressionLimit = LittleEndian.ToSingle(buffer, startIndex + 52);
+        AlarmDelay = LittleEndian.ToSingle(buffer, startIndex + 56);
+        DisplayDigits = LittleEndian.ToInt32(buffer, startIndex + 60);
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="MetadataRecordAnalogFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_engineeringUnits.PadRight(24).TruncateRight(24)), 0, buffer, startIndex, 24);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighAlarm), 0, buffer, startIndex + 24, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowAlarm), 0, buffer, startIndex + 28, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighRange), 0, buffer, startIndex + 32, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowRange), 0, buffer, startIndex + 36, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighWarning), 0, buffer, startIndex + 40, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowWarning), 0, buffer, startIndex + 44, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(ExceptionLimit), 0, buffer, startIndex + 48, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(CompressionLimit), 0, buffer, startIndex + 52, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(AlarmDelay), 0, buffer, startIndex + 56, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(DisplayDigits), 0, buffer, startIndex + 60, 4);
+
+        return length;
+    }
+
+    internal void WriteImage(BinaryWriter writer)
+    {
+        writer.Write(m_engineeringUnits);
+        writer.Write(HighAlarm);
+        writer.Write(LowAlarm);
+        writer.Write(HighRange);
+        writer.Write(LowRange);
+        writer.Write(HighWarning);
+        writer.Write(LowWarning);
+        writer.Write(ExceptionLimit);
+        writer.Write(CompressionLimit);
+        writer.Write(AlarmDelay);
+        writer.Write(DisplayDigits);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordComposedFields.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordComposedFields.cs
@@ -37,389 +37,264 @@ using System.IO;
 using System.Text;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Composed"/>.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordComposedFields : ISupportBinaryImage
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 4           0-3         Single      HighAlarm                                                  *
+    // * 4           4-7         Single      LowAlarm                                                   *
+    // * 4           8-11        Single      HighRange                                                  *
+    // * 4           12-15       Single      LowRange                                                   *
+    // * 4           16-19       Single      LowWarning                                                 *
+    // * 4           20-23       Single      HighWarning                                                *
+    // * 4           24-27       Int32       DisplayDigits                                              *
+    // * 48          28-75       Int32(12)   InputPointers                                              *
+    // * 24          76-99       Char(24)    EngineeringUnits                                           *
+    // * 256         100-355     Char(256)   Equation                                                   *
+    // * 4           356-359     Single      CompressionLimit                                           *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Composed"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordComposedFields"/>.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordComposedFields : ISupportBinaryImage
+    public const int FixedLength = 360;
+
+    // Fields
+    private readonly List<int> m_inputPointers;
+    private string m_engineeringUnits;
+    private string m_equation;
+    private readonly MetadataFileLegacyMode m_legacyMode;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecordComposedFields"/> class.
+    /// </summary>
+    /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
+    internal MetadataRecordComposedFields(MetadataFileLegacyMode legacyMode)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 4           0-3         Single      HighAlarm                                                  *
-        // * 4           4-7         Single      LowAlarm                                                   *
-        // * 4           8-11        Single      HighRange                                                  *
-        // * 4           12-15       Single      LowRange                                                   *
-        // * 4           16-19       Single      LowWarning                                                 *
-        // * 4           20-23       Single      HighWarning                                                *
-        // * 4           24-27       Int32       DisplayDigits                                              *
-        // * 48          28-75       Int32(12)   InputPointers                                              *
-        // * 24          76-99       Char(24)    EngineeringUnits                                           *
-        // * 256         100-355     Char(256)   Equation                                                   *
-        // * 4           356-359     Single      CompressionLimit                                           *
-        // **************************************************************************************************
+        m_engineeringUnits = string.Empty;
+        m_equation = string.Empty;
+        m_inputPointers = [];
 
-        #region [ Members ]
+        for (int i = 0; i < 12; i++)
+            m_inputPointers.Add(0);
 
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordComposedFields"/>.
-        /// </summary>
-        public const int FixedLength = 360;
-
-        // Fields
-        private float m_highAlarm;
-        private float m_lowAlarm;
-        private float m_highRange;
-        private float m_lowRange;
-        private float m_lowWarning;
-        private float m_highWarning;
-        private int m_displayDigits;
-        private readonly List<int> m_inputPointers;
-        private string m_engineeringUnits;
-        private string m_equation;
-        private float m_compressionLimit;
-        private readonly MetadataFileLegacyMode m_legacyMode;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecordComposedFields"/> class.
-        /// </summary>
-        /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
-        internal MetadataRecordComposedFields(MetadataFileLegacyMode legacyMode)
-        {
-            m_engineeringUnits = string.Empty;
-            m_equation = string.Empty;
-            m_inputPointers = new List<int>();
-
-            for (int i = 0; i < 12; i++)
-            {
-                m_inputPointers.Add(default(int));
-            }
-
-            m_legacyMode = legacyMode;
-        }
-
-        internal MetadataRecordComposedFields(BinaryReader reader)
-        {
-            m_legacyMode = MetadataFileLegacyMode.Disabled;
-            m_highAlarm = reader.ReadSingle();
-            m_lowAlarm = reader.ReadSingle();
-            m_highRange = reader.ReadSingle();
-            m_lowRange = reader.ReadSingle();
-            m_lowWarning = reader.ReadSingle();
-            m_highWarning = reader.ReadSingle();
-            m_displayDigits = reader.ReadInt32();
-            m_inputPointers = new List<int>();
-
-            int count = reader.ReadInt32();
-
-            for (int i = 0; i < count; i++)
-            {
-                m_inputPointers.Add(reader.ReadInt32());
-            }
-
-            m_engineeringUnits = reader.ReadString();
-            m_equation = reader.ReadString();
-            m_compressionLimit = reader.ReadSingle();
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiHiAlarm"/>.
-        /// </summary>
-        public float HighAlarm
-        {
-            get
-            {
-                return m_highAlarm;
-            }
-            set
-            {
-                m_highAlarm = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoLoAlarm"/>.
-        /// </summary>
-        public float LowAlarm
-        {
-            get
-            {
-                return m_lowAlarm;
-            }
-            set
-            {
-                m_lowAlarm = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableHigh"/>.
-        /// </summary>
-        public float HighRange
-        {
-            get
-            {
-                return m_highRange;
-            }
-            set
-            {
-                m_highRange = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableLow"/>.
-        /// </summary>
-        public float LowRange
-        {
-            get
-            {
-                return m_lowRange;
-            }
-            set
-            {
-                m_lowRange = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoAlarm"/>.
-        /// </summary>
-        public float LowWarning
-        {
-            get
-            {
-                return m_lowWarning;
-            }
-            set
-            {
-                m_lowWarning = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiAlarm"/>.
-        /// </summary>
-        public float HighWarning
-        {
-            get
-            {
-                return m_highWarning;
-            }
-            set
-            {
-                m_highWarning = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of digits after the decimal point to be displayed for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int DisplayDigits
-        {
-            get
-            {
-                return m_displayDigits;
-            }
-            set
-            {
-                m_displayDigits = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the historian identifiers being used in the <see cref="Equation"/>.
-        /// </summary>
-        public IList<int> InputPointers
-        {
-            get
-            {
-                return m_inputPointers.AsReadOnly();
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the engineering units of archived data values for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public string EngineeringUnits
-        {
-            get
-            {
-                return m_engineeringUnits;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (m_legacyMode == MetadataFileLegacyMode.Enabled)
-                    m_engineeringUnits = value.TruncateRight(24);
-                else
-                    m_engineeringUnits = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the mathematical equation used for calculating the data value for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public string Equation
-        {
-            get
-            {
-                return m_equation;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (m_legacyMode == MetadataFileLegacyMode.Enabled)
-                    m_equation = value.TruncateRight(256);
-                else
-                    m_equation = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the amount, expressed in <see cref="EngineeringUnits"/>, by which data values for the <see cref="MetadataRecord"/>  must changed before being archived.
-        /// </summary>
-        public float CompressionLimit
-        {
-            get
-            {
-                return m_compressionLimit;
-            }
-            set
-            {
-                m_compressionLimit = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="MetadataRecordComposedFields"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="MetadataRecordComposedFields"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordComposedFields"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordComposedFields"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                HighAlarm = LittleEndian.ToSingle(buffer, startIndex);
-                LowAlarm = LittleEndian.ToSingle(buffer, startIndex + 4);
-                HighRange = LittleEndian.ToSingle(buffer, startIndex + 8);
-                LowRange = LittleEndian.ToSingle(buffer, startIndex + 12);
-                LowWarning = LittleEndian.ToSingle(buffer, startIndex + 16);
-                HighWarning = LittleEndian.ToSingle(buffer, startIndex + 20);
-                DisplayDigits = LittleEndian.ToInt32(buffer, startIndex + 24);
-
-                for (int i = 0; i < m_inputPointers.Count; i++)
-                {
-                    m_inputPointers[i] = LittleEndian.ToInt32(buffer, startIndex + 28 + (i * 4));
-                }
-
-                EngineeringUnits = Encoding.ASCII.GetString(buffer, startIndex + 76, 24).Trim();
-                Equation = Encoding.ASCII.GetString(buffer, startIndex + 100, 256).Trim();
-                CompressionLimit = LittleEndian.ToSingle(buffer, startIndex + 356);
-
-                return FixedLength;
-            }
-
-            // Binary image does not have sufficient data.
-            return 0;
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="MetadataRecordComposedFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highAlarm), 0, buffer, startIndex, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowAlarm), 0, buffer, startIndex + 4, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highRange), 0, buffer, startIndex + 8, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowRange), 0, buffer, startIndex + 12, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowWarning), 0, buffer, startIndex + 16, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highWarning), 0, buffer, startIndex + 20, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_displayDigits), 0, buffer, startIndex + 24, 4);
-
-            for (int i = 0; i < m_inputPointers.Count; i++)
-            {
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_inputPointers[i]), 0, buffer, startIndex + 28 + (i * 4), 4);
-            }
-
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_engineeringUnits.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 76, 24);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_equation.PadRight(256).TruncateRight(256)), 0, buffer, startIndex + 100, 256);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_compressionLimit), 0, buffer, startIndex + 356, 4);
-
-            return length;
-        }
-
-        internal void WriteImage(BinaryWriter writer)
-        {
-            writer.Write(m_highAlarm);
-            writer.Write(m_lowAlarm);
-            writer.Write(m_highRange);
-            writer.Write(m_lowRange);
-            writer.Write(m_lowWarning);
-            writer.Write(m_highWarning);
-            writer.Write(m_displayDigits);
-            writer.Write(m_inputPointers.Count);
-
-            foreach (int inputPointer in m_inputPointers)
-            {
-                writer.Write(inputPointer);
-            }
-
-            writer.Write(m_engineeringUnits);
-            writer.Write(m_equation);
-            writer.Write(m_compressionLimit);
-        }
-
-        #endregion
+        m_legacyMode = legacyMode;
     }
+
+    internal MetadataRecordComposedFields(BinaryReader reader)
+    {
+        m_legacyMode = MetadataFileLegacyMode.Disabled;
+        HighAlarm = reader.ReadSingle();
+        LowAlarm = reader.ReadSingle();
+        HighRange = reader.ReadSingle();
+        LowRange = reader.ReadSingle();
+        LowWarning = reader.ReadSingle();
+        HighWarning = reader.ReadSingle();
+        DisplayDigits = reader.ReadInt32();
+        m_inputPointers = [];
+
+        int count = reader.ReadInt32();
+
+        for (int i = 0; i < count; i++)
+            m_inputPointers.Add(reader.ReadInt32());
+
+        m_engineeringUnits = reader.ReadString();
+        m_equation = reader.ReadString();
+        CompressionLimit = reader.ReadSingle();
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiHiAlarm"/>.
+    /// </summary>
+    public float HighAlarm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoLoAlarm"/>.
+    /// </summary>
+    public float LowAlarm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableHigh"/>.
+    /// </summary>
+    public float HighRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.UnreasonableLow"/>.
+    /// </summary>
+    public float LowRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueBelowLoAlarm"/>.
+    /// </summary>
+    public float LowWarning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value above which archived data for the <see cref="MetadataRecord"/> is assigned a quality of <see cref="Quality.ValueAboveHiAlarm"/>.
+    /// </summary>
+    public float HighWarning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of digits after the decimal point to be displayed for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int DisplayDigits { get; set; }
+
+    /// <summary>
+    /// Gets or sets the historian identifiers being used in the <see cref="Equation"/>.
+    /// </summary>
+    public IList<int> InputPointers => m_inputPointers.AsReadOnly();
+
+    /// <summary>
+    /// Gets or sets the engineering units of archived data values for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public string EngineeringUnits
+    {
+        get => m_engineeringUnits;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_engineeringUnits = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the mathematical equation used for calculating the data value for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public string Equation
+    {
+        get => m_equation;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_equation = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(256) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the amount, expressed in <see cref="EngineeringUnits"/>, by which data values for the <see cref="MetadataRecord"/>  must changed before being archived.
+    /// </summary>
+    public float CompressionLimit { get; set; }
+
+    /// <summary>
+    /// Gets the length of the <see cref="MetadataRecordComposedFields"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="MetadataRecordComposedFields"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordComposedFields"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordComposedFields"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        HighAlarm = LittleEndian.ToSingle(buffer, startIndex);
+        LowAlarm = LittleEndian.ToSingle(buffer, startIndex + 4);
+        HighRange = LittleEndian.ToSingle(buffer, startIndex + 8);
+        LowRange = LittleEndian.ToSingle(buffer, startIndex + 12);
+        LowWarning = LittleEndian.ToSingle(buffer, startIndex + 16);
+        HighWarning = LittleEndian.ToSingle(buffer, startIndex + 20);
+        DisplayDigits = LittleEndian.ToInt32(buffer, startIndex + 24);
+
+        for (int i = 0; i < m_inputPointers.Count; i++)
+            m_inputPointers[i] = LittleEndian.ToInt32(buffer, startIndex + 28 + i * 4);
+
+        EngineeringUnits = Encoding.ASCII.GetString(buffer, startIndex + 76, 24).Trim();
+        Equation = Encoding.ASCII.GetString(buffer, startIndex + 100, 256).Trim();
+        CompressionLimit = LittleEndian.ToSingle(buffer, startIndex + 356);
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="MetadataRecordComposedFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighAlarm), 0, buffer, startIndex, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowAlarm), 0, buffer, startIndex + 4, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighRange), 0, buffer, startIndex + 8, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowRange), 0, buffer, startIndex + 12, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowWarning), 0, buffer, startIndex + 16, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighWarning), 0, buffer, startIndex + 20, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(DisplayDigits), 0, buffer, startIndex + 24, 4);
+
+        for (int i = 0; i < m_inputPointers.Count; i++)
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_inputPointers[i]), 0, buffer, startIndex + 28 + i * 4, 4);
+
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_engineeringUnits.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 76, 24);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_equation.PadRight(256).TruncateRight(256)), 0, buffer, startIndex + 100, 256);
+        Buffer.BlockCopy(LittleEndian.GetBytes(CompressionLimit), 0, buffer, startIndex + 356, 4);
+
+        return length;
+    }
+
+    internal void WriteImage(BinaryWriter writer)
+    {
+        writer.Write(HighAlarm);
+        writer.Write(LowAlarm);
+        writer.Write(HighRange);
+        writer.Write(LowRange);
+        writer.Write(LowWarning);
+        writer.Write(HighWarning);
+        writer.Write(DisplayDigits);
+        writer.Write(m_inputPointers.Count);
+
+        foreach (int inputPointer in m_inputPointers)
+            writer.Write(inputPointer);
+
+        writer.Write(m_engineeringUnits);
+        writer.Write(m_equation);
+        writer.Write(CompressionLimit);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordConstantFields.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordConstantFields.cs
@@ -35,153 +35,120 @@ using System;
 using System.IO;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Constant"/>.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordConstantFields : ISupportBinaryImage
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 4          0-3        Single     Value                                                         *
+    // * 4          4-7        Int32      DisplayDigits                                                 *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Constant"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordConstantFields"/>.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordConstantFields : ISupportBinaryImage
+    public const int FixedLength = 8;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecordConstantFields"/> class.
+    /// </summary>
+    internal MetadataRecordConstantFields()
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 4          0-3        Single     Value                                                         *
-        // * 4          4-7        Int32      DisplayDigits                                                 *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordConstantFields"/>.
-        /// </summary>
-        public const int FixedLength = 8;
-
-        // Fields
-        private float m_value;
-        private int m_displayDigits;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecordConstantFields"/> class.
-        /// </summary>
-        internal MetadataRecordConstantFields()
-        {
-        }
-
-        internal MetadataRecordConstantFields(BinaryReader reader)
-        {
-            m_value = reader.ReadSingle();
-            m_displayDigits = reader.ReadInt32();
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the constant value of the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public float Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of digits after the decimal point to be displayed for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int DisplayDigits
-        {
-            get
-            {
-                return m_displayDigits;
-            }
-            set
-            {
-                m_displayDigits = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="MetadataRecordConstantFields"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="MetadataRecordConstantFields"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordConstantFields"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordConstantFields"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                Value = LittleEndian.ToSingle(buffer, startIndex);
-                DisplayDigits = LittleEndian.ToInt32(buffer, startIndex + 4);
-
-                return FixedLength;
-            }
-
-            // Binary image does not have sufficient data.
-            return 0;
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="MetadataRecordConstantFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_value), 0, buffer, startIndex, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_displayDigits), 0, buffer, startIndex + 4, 4);
-
-            return length;
-        }
-
-        internal void WriteImage(BinaryWriter writer)
-        {
-            writer.Write(m_value);
-            writer.Write(m_displayDigits);
-        }
-
-        #endregion
     }
+
+    internal MetadataRecordConstantFields(BinaryReader reader)
+    {
+        Value = reader.ReadSingle();
+        DisplayDigits = reader.ReadInt32();
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the constant value of the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public float Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of digits after the decimal point to be displayed for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int DisplayDigits { get; set; }
+
+    /// <summary>
+    /// Gets the length of the <see cref="MetadataRecordConstantFields"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="MetadataRecordConstantFields"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordConstantFields"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordConstantFields"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        Value = LittleEndian.ToSingle(buffer, startIndex);
+        DisplayDigits = LittleEndian.ToInt32(buffer, startIndex + 4);
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="MetadataRecordConstantFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(Value), 0, buffer, startIndex, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(DisplayDigits), 0, buffer, startIndex + 4, 4);
+
+        return length;
+    }
+
+    internal void WriteImage(BinaryWriter writer)
+    {
+        writer.Write(Value);
+        writer.Write(DisplayDigits);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordDigitalFields.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordDigitalFields.cs
@@ -38,224 +38,189 @@ using System.IO;
 using System.Text;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Digital"/>.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordDigitalFields : ISupportBinaryImage
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 24         0-23       Char(24)   SetDescription                                                *
+    // * 24         24-47      Char(24)   ClearDescription                                              *
+    // * 4          48-51      Int32      AlarmState                                                    *
+    // * 4          52-55      Single     AlarmDelay                                                    *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Defines specific fields for <see cref="MetadataRecord"/>s that are of type <see cref="DataType.Digital"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordDigitalFields"/>.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordDigitalFields : ISupportBinaryImage
+    public const int FixedLength = 56;
+
+    // Fields
+    private string m_setDescription;
+    private string m_clearDescription;
+    private int m_alarmState;
+    private readonly MetadataFileLegacyMode m_legacyMode;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecordDigitalFields"/> class.
+    /// </summary>
+    /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
+    internal MetadataRecordDigitalFields(MetadataFileLegacyMode legacyMode)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 24         0-23       Char(24)   SetDescription                                                *
-        // * 24         24-47      Char(24)   ClearDescription                                              *
-        // * 4          48-51      Int32      AlarmState                                                    *
-        // * 4          52-55      Single     AlarmDelay                                                    *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordDigitalFields"/>.
-        /// </summary>
-        public const int FixedLength = 56;
-
-        // Fields
-        private string m_setDescription;
-        private string m_clearDescription;
-        private int m_alarmState;
-        private float m_alarmDelay;
-        private readonly MetadataFileLegacyMode m_legacyMode;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecordDigitalFields"/> class.
-        /// </summary>
-        /// <param name="legacyMode">Legacy mode of <see cref="MetadataFile"/>.</param>
-        internal MetadataRecordDigitalFields(MetadataFileLegacyMode legacyMode)
-        {
-            m_setDescription = string.Empty;
-            m_clearDescription = string.Empty;
-            m_legacyMode = legacyMode;
-        }
-
-        internal MetadataRecordDigitalFields(BinaryReader reader)
-        {
-            m_legacyMode = MetadataFileLegacyMode.Disabled;
-            m_setDescription = reader.ReadString();
-            m_clearDescription = reader.ReadString();
-            m_alarmState = reader.ReadInt32();
-            m_alarmDelay = reader.ReadSingle();
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the text description of the data value for the <see cref="MetadataRecord"/> when it is 1.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="SetDescription"/> is 24 characters.
-        /// </remarks>
-        public string SetDescription
-        {
-            get
-            {
-                return m_setDescription;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (m_legacyMode == MetadataFileLegacyMode.Enabled)
-                    m_setDescription = value.TruncateRight(24);
-                else
-                    m_setDescription = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the text description of the data value for the <see cref="MetadataRecord"/> when it is 0.
-        /// </summary>
-        /// <remarks>
-        /// Maximum length for <see cref="ClearDescription"/> is 24 characters.
-        /// </remarks>
-        public string ClearDescription
-        {
-            get
-            {
-                return m_clearDescription;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (m_legacyMode == MetadataFileLegacyMode.Enabled)
-                    m_clearDescription = value.TruncateRight(24);
-                else
-                    m_clearDescription = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value (0 or 1) that indicates alarm state for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        /// <remarks>A value of -1 indicates no alarm state.</remarks>
-        /// <exception cref="ArgumentException">The value being assigned is not -1, 0 or 1.</exception>
-        public int AlarmState
-        {
-            get
-            {
-                return m_alarmState;
-            }
-            set
-            {
-                if (value < -1 || value > 1)
-                    throw new ArgumentException("Value must be either -1, 0 or 1");
-
-                m_alarmState = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the time (in seconds) to wait before consecutive alarm notifications are sent for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public float AlarmDelay
-        {
-            get
-            {
-                return m_alarmDelay;
-            }
-            set
-            {
-                m_alarmDelay = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="MetadataRecordDigitalFields"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="MetadataRecordDigitalFields"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordDigitalFields"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordDigitalFields"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                SetDescription = Encoding.ASCII.GetString(buffer, startIndex, 24).Trim();
-                ClearDescription = Encoding.ASCII.GetString(buffer, startIndex + 24, 24).Trim();
-                AlarmState = LittleEndian.ToInt32(buffer, startIndex + 48);
-                AlarmDelay = LittleEndian.ToSingle(buffer, startIndex + 52);
-
-                return FixedLength;
-            }
-
-            // Binary image does not have sufficient data.
-            return 0;
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="MetadataRecordDigitalFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_setDescription.PadRight(24).TruncateRight(24)), 0, buffer, startIndex, 24);
-            Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_clearDescription.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 24, 24);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_alarmState), 0, buffer, startIndex + 48, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_alarmDelay), 0, buffer, startIndex + 52, 4);
-
-            return length;
-        }
-
-        internal void WriteImage(BinaryWriter writer)
-        {
-            writer.Write(m_setDescription);
-            writer.Write(m_clearDescription);
-            writer.Write(m_alarmState);
-            writer.Write(m_alarmDelay);
-        }
-
-        #endregion
+        m_setDescription = string.Empty;
+        m_clearDescription = string.Empty;
+        m_legacyMode = legacyMode;
     }
+
+    internal MetadataRecordDigitalFields(BinaryReader reader)
+    {
+        m_legacyMode = MetadataFileLegacyMode.Disabled;
+        m_setDescription = reader.ReadString();
+        m_clearDescription = reader.ReadString();
+        m_alarmState = reader.ReadInt32();
+        AlarmDelay = reader.ReadSingle();
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the text description of the data value for the <see cref="MetadataRecord"/> when it is 1.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="SetDescription"/> is 24 characters.
+    /// </remarks>
+    public string SetDescription
+    {
+        get => m_setDescription;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_setDescription = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the text description of the data value for the <see cref="MetadataRecord"/> when it is 0.
+    /// </summary>
+    /// <remarks>
+    /// Maximum length for <see cref="ClearDescription"/> is 24 characters.
+    /// </remarks>
+    public string ClearDescription
+    {
+        get => m_clearDescription;
+        set
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            m_clearDescription = m_legacyMode == MetadataFileLegacyMode.Enabled ? value.TruncateRight(24) : value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the value (0 or 1) that indicates alarm state for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    /// <remarks>A value of -1 indicates no alarm state.</remarks>
+    /// <exception cref="ArgumentException">The value being assigned is not -1, 0 or 1.</exception>
+    public int AlarmState
+    {
+        get => m_alarmState;
+        set
+        {
+            if (value is < -1 or > 1)
+                throw new ArgumentException("Value must be either -1, 0 or 1");
+
+            m_alarmState = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the time (in seconds) to wait before consecutive alarm notifications are sent for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public float AlarmDelay { get; set; }
+
+    /// <summary>
+    /// Gets the length of the <see cref="MetadataRecordDigitalFields"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="MetadataRecordDigitalFields"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordDigitalFields"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordDigitalFields"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        SetDescription = Encoding.ASCII.GetString(buffer, startIndex, 24).Trim();
+        ClearDescription = Encoding.ASCII.GetString(buffer, startIndex + 24, 24).Trim();
+        AlarmState = LittleEndian.ToInt32(buffer, startIndex + 48);
+        AlarmDelay = LittleEndian.ToSingle(buffer, startIndex + 52);
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="MetadataRecordDigitalFields"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_setDescription.PadRight(24).TruncateRight(24)), 0, buffer, startIndex, 24);
+        Buffer.BlockCopy(Encoding.ASCII.GetBytes(m_clearDescription.PadRight(24).TruncateRight(24)), 0, buffer, startIndex + 24, 24);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_alarmState), 0, buffer, startIndex + 48, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(AlarmDelay), 0, buffer, startIndex + 52, 4);
+
+        return length;
+    }
+
+    internal void WriteImage(BinaryWriter writer)
+    {
+        writer.Write(m_setDescription);
+        writer.Write(m_clearDescription);
+        writer.Write(m_alarmState);
+        writer.Write(AlarmDelay);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordGeneralFlags.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordGeneralFlags.cs
@@ -29,228 +29,154 @@
 //
 //******************************************************************************************************
 
-namespace GSF.Historian.Files
-{
-    #region [ Enumerations ]
+namespace GSF.Historian.Files;
 
+#region [ Enumerations ]
+
+/// <summary>
+/// Indicates the type of data being archived for a <see cref="MetadataRecord"/>.
+/// </summary>
+public enum DataType
+{
     /// <summary>
-    /// Indicates the type of data being archived for a <see cref="MetadataRecord"/>.
+    /// Data value is analog in nature.
     /// </summary>
-    public enum DataType
-    {
-        /// <summary>
-        /// Data value is analog in nature.
-        /// </summary>
-        Analog,
-        /// <summary>
-        /// Data value is digital in nature.
-        /// </summary>
-        Digital,
-        /// <summary>
-        /// Data value is calculated based on an equation upon retrieval.
-        /// </summary>
-        Composed,
-        /// <summary>
-        /// Data value is a constant and no real-time time-series data is received.
-        /// </summary>
-        Constant
-    }
+    Analog,
+    /// <summary>
+    /// Data value is digital in nature.
+    /// </summary>
+    Digital,
+    /// <summary>
+    /// Data value is calculated based on an equation upon retrieval.
+    /// </summary>
+    Composed,
+    /// <summary>
+    /// Data value is a constant and no real-time time-series data is received.
+    /// </summary>
+    Constant
+}
+
+#endregion
+
+/// <summary>
+/// Defines general boolean settings for a <see cref="MetadataRecord"/>.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordGeneralFlags
+{
+    #region [ Members ]
+
+    // Constants
+    private const Bits DataTypeMask = Bits.Bit00 | Bits.Bit01 | Bits.Bit02;
+    private const Bits EnabledMask = Bits.Bit03;
+    private const Bits UsedMask = Bits.Bit04;
+    private const Bits AlarmEnabledMask = Bits.Bit05;
+    private const Bits NotifyByEmailMask = Bits.Bit06;
+    private const Bits NotifyByPagerMask = Bits.Bit07;
+    private const Bits NotifyByPhoneMask = Bits.Bit08;
+    private const Bits LogToFileMask = Bits.Bit09;
+    private const Bits SpareMask = Bits.Bit10;
+    private const Bits ChangedMask = Bits.Bit11;
+    private const Bits StepCheckMask = Bits.Bit12;
 
     #endregion
 
+    #region [ Properties ]
+
     /// <summary>
-    /// Defines general boolean settings for a <see cref="MetadataRecord"/>.
+    /// Gets or sets the <see cref="DataType"/> of archived data for the <see cref="MetadataRecord"/>.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordGeneralFlags
+    public DataType DataType
     {
-        #region [ Members ]
-
-        // Constants
-        private const Bits DataTypeMask = Bits.Bit00 | Bits.Bit01 | Bits.Bit02;
-        private const Bits EnabledMask = Bits.Bit03;
-        private const Bits UsedMask = Bits.Bit04;
-        private const Bits AlarmEnabledMask = Bits.Bit05;
-        private const Bits NotifyByEmailMask = Bits.Bit06;
-        private const Bits NotifyByPagerMask = Bits.Bit07;
-        private const Bits NotifyByPhoneMask = Bits.Bit08;
-        private const Bits LogToFileMask = Bits.Bit09;
-        private const Bits SpareMask = Bits.Bit10;
-        private const Bits ChangedMask = Bits.Bit11;
-        private const Bits StepCheckMask = Bits.Bit12;
-
-        // Fields
-        private int m_value;
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the <see cref="DataType"/> of archived data for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public DataType DataType
-        {
-            get
-            {
-                return (DataType)m_value.GetMaskedValue(DataTypeMask);
-            }
-            set
-            {
-                m_value = m_value.SetMaskedValue(DataTypeMask, (int)value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="MetadataRecord"/> is currently enabled for archival of new data.
-        /// </summary>
-        public bool Enabled
-        {
-            get
-            {
-                return m_value.CheckBits(EnabledMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(EnabledMask) : m_value.ClearBits(EnabledMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="MetadataRecord"/> is being used (need to be verify).
-        /// </summary>
-        public bool Used
-        {
-            get
-            {
-                return m_value.CheckBits(UsedMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(UsedMask) : m_value.ClearBits(UsedMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether alarm notifications are enabled for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public bool AlarmEnabled
-        {
-            get
-            {
-                return m_value.CheckBits(AlarmEnabledMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(AlarmEnabledMask) : m_value.ClearBits(AlarmEnabledMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether email alarm notifications are to be sent for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public bool AlarmByEmail
-        {
-            get
-            {
-                return m_value.CheckBits(NotifyByEmailMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(NotifyByEmailMask) : m_value.ClearBits(NotifyByEmailMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether text alarm notifications are to be sent for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public bool AlarmByPager
-        {
-            get
-            {
-                return m_value.CheckBits(NotifyByPagerMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(NotifyByPagerMask) : m_value.ClearBits(NotifyByPagerMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether voice alarm notifications are to be sent for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public bool AlarmByPhone
-        {
-            get
-            {
-                return m_value.CheckBits(NotifyByPhoneMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(NotifyByPhoneMask) : m_value.ClearBits(NotifyByPhoneMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether alarm notifications for the <see cref="MetadataRecord"/> are to be logged to a text file.
-        /// </summary>
-        public bool AlarmToFile
-        {
-            get
-            {
-                return m_value.CheckBits(LogToFileMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(LogToFileMask) : m_value.ClearBits(LogToFileMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether the <see cref="MetadataRecord"/> has been modified.
-        /// </summary>
-        public bool Changed
-        {
-            get
-            {
-                return m_value.CheckBits(ChangedMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(ChangedMask) : m_value.ClearBits(ChangedMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a boolean value that indicates whether a "step change" operation is to be performed on incoming time-series data for the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public bool StepCheck
-        {
-            get
-            {
-                return m_value.CheckBits(StepCheckMask);
-            }
-            set
-            {
-                m_value = value ? m_value.SetBits(StepCheckMask) : m_value.ClearBits(StepCheckMask);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the 32-bit integer value used for defining general boolean settings for a <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        #endregion
+        get => (DataType)Value.GetMaskedValue(DataTypeMask);
+        set => Value = Value.SetMaskedValue(DataTypeMask, (int)value);
     }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="MetadataRecord"/> is currently enabled for archival of new data.
+    /// </summary>
+    public bool Enabled
+    {
+        get => Value.CheckBits(EnabledMask);
+        set => Value = value ? Value.SetBits(EnabledMask) : Value.ClearBits(EnabledMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="MetadataRecord"/> is being used.
+    /// </summary>
+    public bool Used
+    {
+        get => Value.CheckBits(UsedMask);
+        set => Value = value ? Value.SetBits(UsedMask) : Value.ClearBits(UsedMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether alarm notifications are enabled for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public bool AlarmEnabled
+    {
+        get => Value.CheckBits(AlarmEnabledMask);
+        set => Value = value ? Value.SetBits(AlarmEnabledMask) : Value.ClearBits(AlarmEnabledMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether email alarm notifications are to be sent for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public bool AlarmByEmail
+    {
+        get => Value.CheckBits(NotifyByEmailMask);
+        set => Value = value ? Value.SetBits(NotifyByEmailMask) : Value.ClearBits(NotifyByEmailMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether text alarm notifications are to be sent for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public bool AlarmByPager
+    {
+        get => Value.CheckBits(NotifyByPagerMask);
+        set => Value = value ? Value.SetBits(NotifyByPagerMask) : Value.ClearBits(NotifyByPagerMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether voice alarm notifications are to be sent for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public bool AlarmByPhone
+    {
+        get => Value.CheckBits(NotifyByPhoneMask);
+        set => Value = value ? Value.SetBits(NotifyByPhoneMask) : Value.ClearBits(NotifyByPhoneMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether alarm notifications for the <see cref="MetadataRecord"/> are to be logged to a text file.
+    /// </summary>
+    public bool AlarmToFile
+    {
+        get => Value.CheckBits(LogToFileMask);
+        set => Value = value ? Value.SetBits(LogToFileMask) : Value.ClearBits(LogToFileMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether the <see cref="MetadataRecord"/> has been modified.
+    /// </summary>
+    public bool Changed
+    {
+        get => Value.CheckBits(ChangedMask);
+        set => Value = value ? Value.SetBits(ChangedMask) : Value.ClearBits(ChangedMask);
+    }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether a "step change" operation is to be performed on incoming time-series data for the <see cref="MetadataRecord"/>.
+    /// </summary>
+    public bool StepCheck
+    {
+        get => Value.CheckBits(StepCheckMask);
+        set => Value = value ? Value.SetBits(StepCheckMask) : Value.ClearBits(StepCheckMask);
+    }
+
+    /// <summary>
+    /// Gets or sets the 32-bit integer value used for defining general boolean settings for a <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int Value { get; set; }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordSecurityFlags.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordSecurityFlags.cs
@@ -29,72 +29,48 @@
 //
 //******************************************************************************************************
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Defines the security level for a <see cref="MetadataRecord"/>.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordSecurityFlags
 {
+    #region [ Members ]
+
+    // Constants
+    private const Bits RecordSecurityMask = Bits.Bit00 | Bits.Bit01 | Bits.Bit02;
+    private const Bits AccessSecurityMask = Bits.Bit03 | Bits.Bit04 | Bits.Bit05;
+
+    // Fields
+
+    #endregion
+
+    #region [ Properties ]
+
     /// <summary>
-    /// Defines the security level for a <see cref="MetadataRecord"/>.
+    /// Gets or sets the access level required for a user to edit the <see cref="MetadataRecord"/>.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordSecurityFlags
+    public int ChangeSecurity
     {
-        #region [ Members ]
-
-        // Constants
-        private const Bits RecordSecurityMask = Bits.Bit00 | Bits.Bit01 | Bits.Bit02;
-        private const Bits AccessSecurityMask = Bits.Bit03 | Bits.Bit04 | Bits.Bit05;
-
-        // Fields
-        private int m_value;
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the access level required for a user to edit the <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int ChangeSecurity
-        {
-            get
-            {
-                return m_value.GetMaskedValue(RecordSecurityMask);
-            }
-            set
-            {
-                m_value = m_value.SetMaskedValue(RecordSecurityMask, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the access level required for a user to retrieve archived data associated to a <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int AccessSecurity
-        {
-            get
-            {
-                return m_value.GetMaskedValue(AccessSecurityMask) >> 3; // <- 1st 3 bits are record security.
-            }
-            set
-            {
-                m_value = m_value.SetMaskedValue(AccessSecurityMask, value << 3);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the 32-bit integer value used for defining the security level for a <see cref="MetadataRecord"/>.
-        /// </summary>
-        public int Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        #endregion
+        get => Value.GetMaskedValue(RecordSecurityMask);
+        set => Value = Value.SetMaskedValue(RecordSecurityMask, value);
     }
+
+    /// <summary>
+    /// Gets or sets the access level required for a user to retrieve archived data associated to a <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int AccessSecurity
+    {
+        get => Value.GetMaskedValue(AccessSecurityMask) >> 3; // <- 1st 3 bits are record security.
+        set => Value = Value.SetMaskedValue(AccessSecurityMask, value << 3);
+    }
+
+    /// <summary>
+    /// Gets or sets the 32-bit integer value used for defining the security level for a <see cref="MetadataRecord"/>.
+    /// </summary>
+    public int Value { get; set; }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/MetadataRecordSummary.cs
+++ b/Source/Libraries/GSF.Historian/Files/MetadataRecordSummary.cs
@@ -34,303 +34,206 @@
 using System;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// A class with a subset of information defined in <see cref="MetadataRecord"/>. The generated binary image of 
+/// <see cref="MetadataRecordSummary"/> is sent back as a reply to <see cref="Historian.Packets.PacketType3"/> and 
+/// <see cref="Historian.Packets.PacketType4"/>.
+/// </summary>
+/// <seealso cref="MetadataRecord"/>
+public class MetadataRecordSummary : ISupportBinaryImage
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 4          0-3        Int32      HistorianID                                                   *
+    // * 4          4-7        Single     ExceptionLimit                                                *
+    // * 4          8-11       Int32      Enabled                                                       *
+    // * 4          12-15      Single     HighWarning                                                   *
+    // * 4          16-19      Single     LowWarning                                                    *
+    // * 4          20-23      Single     HighAlarm                                                     *
+    // * 4          24-27      Single     LowAlarm                                                      *
+    // * 4          28-31      Single     HighRange                                                     *
+    // * 4          32-35      Single     LowRange                                                      *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// A class with a subset of information defined in <see cref="MetadataRecord"/>. The generated binary image of 
-    /// <see cref="MetadataRecordSummary"/> is sent back as a reply to <see cref="Historian.Packets.PacketType3"/> and 
-    /// <see cref="Historian.Packets.PacketType4"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordSummary"/>.
     /// </summary>
-    /// <seealso cref="MetadataRecord"/>
-    public class MetadataRecordSummary : ISupportBinaryImage
+    public const int FixedLength = 36;
+
+    // Fields
+    private int m_historianID;
+    private int m_enabled;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecordSummary"/> class.
+    /// </summary>
+    /// <param name="record">A <see cref="MetadataRecord"/> object.</param>
+    public MetadataRecordSummary(MetadataRecord record)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 4          0-3        Int32      HistorianID                                                   *
-        // * 4          4-7        Single     ExceptionLimit                                                *
-        // * 4          8-11       Int32      Enabled                                                       *
-        // * 4          12-15      Single     HighWarning                                                   *
-        // * 4          16-19      Single     LowWarning                                                    *
-        // * 4          20-23      Single     HighAlarm                                                     *
-        // * 4          24-27      Single     LowAlarm                                                      *
-        // * 4          28-31      Single     HighRange                                                     *
-        // * 4          32-35      Single     LowRange                                                      *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="MetadataRecordSummary"/>.
-        /// </summary>
-        public const int FixedLength = 36;
-
-        // Fields
-        private int m_historianID;
-        private float m_exceptionLimit;
-        private int m_enabled;
-        private float m_highWarning;
-        private float m_lowWarning;
-        private float m_highAlarm;
-        private float m_lowAlarm;
-        private float m_highRange;
-        private float m_lowRange;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecordSummary"/> class.
-        /// </summary>
-        /// <param name="record">A <see cref="MetadataRecord"/> object.</param>
-        public MetadataRecordSummary(MetadataRecord record)
-        {
-            HistorianID = record.HistorianID;
-            ExceptionLimit = record.AnalogFields.ExceptionLimit;
-            Enabled = record.GeneralFlags.Enabled;
-            HighWarning = record.AnalogFields.HighWarning;
-            LowWarning = record.AnalogFields.LowWarning;
-            HighAlarm = record.AnalogFields.HighAlarm;
-            LowAlarm = record.AnalogFields.LowAlarm;
-            HighRange = record.AnalogFields.HighRange;
-            LowRange = record.AnalogFields.LowRange;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataRecordSummary"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordSummary"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public MetadataRecordSummary(byte[] buffer, int startIndex, int length)
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecord.HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
-        public int HistorianID
-        {
-            get
-            {
-                return m_historianID;
-            }
-            private set
-            {
-                if (value < 1 && value != -1)
-                    throw new ArgumentException("Value must be positive or -1");
-
-                m_historianID = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordAnalogFields.ExceptionLimit"/>.
-        /// </summary>
-        public float ExceptionLimit
-        {
-            get
-            {
-                return m_exceptionLimit;
-            }
-            private set
-            {
-                m_exceptionLimit = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordGeneralFlags.Enabled"/>.
-        /// </summary>
-        public bool Enabled
-        {
-            get
-            {
-                return Convert.ToBoolean(m_enabled);
-            }
-            private set
-            {
-                m_enabled = Convert.ToInt32(value);
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordAnalogFields.HighWarning"/>.
-        /// </summary>
-        public float HighWarning
-        {
-            get
-            {
-                return m_highWarning;
-            }
-            private set
-            {
-                m_highWarning = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordAnalogFields.LowWarning"/>.
-        /// </summary>
-        public float LowWarning
-        {
-            get
-            {
-                return m_lowWarning;
-            }
-            private set
-            {
-                m_lowWarning = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordAnalogFields.HighAlarm"/>.
-        /// </summary>
-        public float HighAlarm
-        {
-            get
-            {
-                return m_highAlarm;
-            }
-            private set
-            {
-                m_highAlarm = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordAnalogFields.LowAlarm"/>.
-        /// </summary>
-        public float LowAlarm
-        {
-            get
-            {
-                return m_lowAlarm;
-            }
-            private set
-            {
-                m_lowAlarm = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordAnalogFields.HighRange"/>.
-        /// </summary>
-        public float HighRange
-        {
-            get
-            {
-                return m_highRange;
-            }
-            private set
-            {
-                m_highRange = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="MetadataRecordAnalogFields.LowRange"/>.
-        /// </summary>
-        public float LowRange
-        {
-            get
-            {
-                return m_lowRange;
-            }
-            private set
-            {
-                m_lowRange = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="MetadataRecordSummary"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="MetadataRecordSummary"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordSummary"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordSummary"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                HistorianID = LittleEndian.ToInt32(buffer, startIndex + 0);
-                ExceptionLimit = LittleEndian.ToSingle(buffer, startIndex + 4);
-                Enabled = Convert.ToBoolean(LittleEndian.ToInt32(buffer, startIndex + 8));
-                HighWarning = LittleEndian.ToSingle(buffer, startIndex + 12);
-                LowWarning = LittleEndian.ToSingle(buffer, startIndex + 16);
-                HighAlarm = LittleEndian.ToSingle(buffer, startIndex + 20);
-                LowAlarm = LittleEndian.ToSingle(buffer, startIndex + 24);
-                HighRange = LittleEndian.ToSingle(buffer, startIndex + 28);
-                LowRange = LittleEndian.ToSingle(buffer, startIndex + 32);
-
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="MetadataRecordSummary"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_exceptionLimit), 0, buffer, startIndex + 4, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(Convert.ToInt32(m_enabled)), 0, buffer, startIndex + 8, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highWarning), 0, buffer, startIndex + 12, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowWarning), 0, buffer, startIndex + 16, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highAlarm), 0, buffer, startIndex + 20, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowAlarm), 0, buffer, startIndex + 24, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_highRange), 0, buffer, startIndex + 28, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_lowRange), 0, buffer, startIndex + 32, 4);
-
-            return length;
-        }
-
-        #endregion
+        HistorianID = record.HistorianID;
+        ExceptionLimit = record.AnalogFields.ExceptionLimit;
+        Enabled = record.GeneralFlags.Enabled;
+        HighWarning = record.AnalogFields.HighWarning;
+        LowWarning = record.AnalogFields.LowWarning;
+        HighAlarm = record.AnalogFields.HighAlarm;
+        LowAlarm = record.AnalogFields.LowAlarm;
+        HighRange = record.AnalogFields.HighRange;
+        LowRange = record.AnalogFields.LowRange;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataRecordSummary"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordSummary"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public MetadataRecordSummary(byte[] buffer, int startIndex, int length)
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecord.HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
+    public int HistorianID
+    {
+        get => m_historianID;
+        private set
+        {
+            if (value < 1 && value != -1)
+                throw new ArgumentException("Value must be positive or -1");
+
+            m_historianID = value;
+        }
+    }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordAnalogFields.ExceptionLimit"/>.
+    /// </summary>
+    public float ExceptionLimit { get; private set; }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordGeneralFlags.Enabled"/>.
+    /// </summary>
+    public bool Enabled
+    {
+        get => Convert.ToBoolean(m_enabled);
+        private set => m_enabled = Convert.ToInt32(value);
+    }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordAnalogFields.HighWarning"/>.
+    /// </summary>
+    public float HighWarning { get; private set; }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordAnalogFields.LowWarning"/>.
+    /// </summary>
+    public float LowWarning { get; private set; }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordAnalogFields.HighAlarm"/>.
+    /// </summary>
+    public float HighAlarm { get; private set; }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordAnalogFields.LowAlarm"/>.
+    /// </summary>
+    public float LowAlarm { get; private set; }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordAnalogFields.HighRange"/>.
+    /// </summary>
+    public float HighRange { get; private set; }
+
+    /// <summary>
+    /// Same as <see cref="MetadataRecordAnalogFields.LowRange"/>.
+    /// </summary>
+    public float LowRange { get; private set; }
+
+    /// <summary>
+    /// Gets the length of the <see cref="MetadataRecordSummary"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="MetadataRecordSummary"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="MetadataRecordSummary"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="MetadataRecordSummary"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        HistorianID = LittleEndian.ToInt32(buffer, startIndex + 0);
+        ExceptionLimit = LittleEndian.ToSingle(buffer, startIndex + 4);
+        Enabled = Convert.ToBoolean(LittleEndian.ToInt32(buffer, startIndex + 8));
+        HighWarning = LittleEndian.ToSingle(buffer, startIndex + 12);
+        LowWarning = LittleEndian.ToSingle(buffer, startIndex + 16);
+        HighAlarm = LittleEndian.ToSingle(buffer, startIndex + 20);
+        LowAlarm = LittleEndian.ToSingle(buffer, startIndex + 24);
+        HighRange = LittleEndian.ToSingle(buffer, startIndex + 28);
+        LowRange = LittleEndian.ToSingle(buffer, startIndex + 32);
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="MetadataRecordSummary"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public virtual int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(ExceptionLimit), 0, buffer, startIndex + 4, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(Convert.ToInt32(m_enabled)), 0, buffer, startIndex + 8, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighWarning), 0, buffer, startIndex + 12, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowWarning), 0, buffer, startIndex + 16, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighAlarm), 0, buffer, startIndex + 20, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowAlarm), 0, buffer, startIndex + 24, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(HighRange), 0, buffer, startIndex + 28, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(LowRange), 0, buffer, startIndex + 32, 4);
+
+        return length;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/Files/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Contains classes used for manipulating archive files.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains classes used for manipulating archive files.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/Files/StateFile.cs
+++ b/Source/Libraries/GSF.Historian/Files/StateFile.cs
@@ -34,48 +34,47 @@
 using System.Drawing;
 using GSF.IO;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a file containing <see cref="StateRecord"/>s.
+/// </summary>
+/// <seealso cref="StateRecord"/>
+[ToolboxBitmap(typeof(StateFile))]
+public class StateFile : IsamDataFileBase<StateRecord>
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a file containing <see cref="StateRecord"/>s.
+    /// Initializes a new instance of the <see cref="StateFile"/> class.
     /// </summary>
-    /// <seealso cref="StateRecord"/>
-    [ToolboxBitmap(typeof(StateFile))]
-    public class StateFile : IsamDataFileBase<StateRecord>
+    public StateFile()
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StateFile"/> class.
-        /// </summary>
-        public StateFile()
-        {
-            SettingsCategory = this.GetType().Name;
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Gets the binary size of a <see cref="StateRecord"/>.
-        /// </summary>
-        /// <returns>A 32-bit signed integer.</returns>
-        protected override int GetRecordSize()
-        {
-            return StateRecord.FixedLength;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="StateRecord"/> with the specified <paramref name="recordIndex"/>.
-        /// </summary>
-        /// <param name="recordIndex">1-based index of the <see cref="StateRecord"/>.</param>
-        /// <returns>A <see cref="StateRecord"/> object.</returns>
-        protected override StateRecord CreateNewRecord(int recordIndex)
-        {
-            return new StateRecord(recordIndex);
-        }
-
-        #endregion
+        SettingsCategory = GetType().Name;
     }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Gets the binary size of a <see cref="StateRecord"/>.
+    /// </summary>
+    /// <returns>A 32-bit signed integer.</returns>
+    protected override int GetRecordSize()
+    {
+        return StateRecord.FixedLength;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="StateRecord"/> with the specified <paramref name="recordIndex"/>.
+    /// </summary>
+    /// <param name="recordIndex">1-based index of the <see cref="StateRecord"/>.</param>
+    /// <returns>A <see cref="StateRecord"/> object.</returns>
+    protected override StateRecord CreateNewRecord(int recordIndex)
+    {
+        return new StateRecord(recordIndex);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/StateRecord.cs
+++ b/Source/Libraries/GSF.Historian/Files/StateRecord.cs
@@ -38,352 +38,254 @@
 using System;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Represents a record in the <see cref="StateFile"/> that contains the state information associated to a <see cref="HistorianID"/>.
+/// </summary>
+/// <seealso cref="StateFile"/>    
+/// <seealso cref="StateRecordSummary"/>
+/// <seealso cref="StateRecordDataPoint"/>
+public class StateRecord : ISupportBinaryImage, IComparable
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 16         0-15       Byte(16)   ArchivedData                                                  *
+    // * 16         16-31      Byte(16)   PreviousData                                                  *
+    // * 16         32-47      Byte(16)   CurrentData                                                   *
+    // * 4          48-51      Int32      ActiveDataBlockIndex                                          *
+    // * 4          52-55      Int32      ActiveDataBlockSlot                                           *
+    // * 8          56-63      Double     Slope1                                                        *
+    // * 8          64-71      Double     Slope2                                                        *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a record in the <see cref="StateFile"/> that contains the state information associated to a <see cref="HistorianID"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="StateRecord"/>.
     /// </summary>
-    /// <seealso cref="StateFile"/>    
-    /// <seealso cref="StateRecordSummary"/>
-    /// <seealso cref="StateRecordDataPoint"/>
-    public class StateRecord : ISupportBinaryImage, IComparable
+    public const int FixedLength = 72;
+
+    // Fields
+    private StateRecordDataPoint m_archivedData;
+    private StateRecordDataPoint m_previousData;
+    private StateRecordDataPoint m_currentData;
+    private int m_activeDataBlockIndex;
+    private int m_activeDataBlockSlot;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StateRecord"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="StateRecord"/>.</param>
+    public StateRecord(int historianID)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 16         0-15       Byte(16)   ArchivedData                                                  *
-        // * 16         16-31      Byte(16)   PreviousData                                                  *
-        // * 16         32-47      Byte(16)   CurrentData                                                   *
-        // * 4          48-51      Int32      ActiveDataBlockIndex                                          *
-        // * 4          52-55      Int32      ActiveDataBlockSlot                                           *
-        // * 8          56-63      Double     Slope1                                                        *
-        // * 8          64-71      Double     Slope2                                                        *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="StateRecord"/>.
-        /// </summary>
-        public const int FixedLength = 72;
-
-        // Fields
-        private readonly int m_historianID;
-        private StateRecordDataPoint m_archivedData;
-        private StateRecordDataPoint m_previousData;
-        private StateRecordDataPoint m_currentData;
-        private int m_activeDataBlockIndex;
-        private int m_activeDataBlockSlot;
-        private double m_slope1;
-        private double m_slope2;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StateRecord"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="StateRecord"/>.</param>
-        public StateRecord(int historianID)
-        {
-            m_historianID = historianID;
-            m_archivedData = new StateRecordDataPoint(m_historianID);
-            m_previousData = new StateRecordDataPoint(m_historianID);
-            m_currentData = new StateRecordDataPoint(m_historianID);
-            m_activeDataBlockIndex = -1;
-            m_activeDataBlockSlot = 1;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StateRecord"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="StateRecord"/>.</param>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecord"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public StateRecord(int historianID, byte[] buffer, int startIndex, int length)
-            : this(historianID)
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the most recently archived <see cref="StateRecordDataPoint"/> for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public StateRecordDataPoint ArchivedData
-        {
-            get
-            {
-                return m_archivedData;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_archivedData = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the previous <see cref="StateRecordDataPoint"/> received for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public StateRecordDataPoint PreviousData
-        {
-            get
-            {
-                return m_previousData;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_previousData = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the most current <see cref="StateRecordDataPoint"/> received for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public StateRecordDataPoint CurrentData
-        {
-            get
-            {
-                return m_currentData;
-            }
-            set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_currentData = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the 0-based index of the active <see cref="ArchiveDataBlock"/> for the <see cref="HistorianID"/>.
-        /// </summary>
-        /// <remarks>Index is persisted to disk as 1-based index for backwards compatibility.</remarks>
-        public int ActiveDataBlockIndex
-        {
-            get
-            {
-                if (m_activeDataBlockIndex < 0)
-                    return m_activeDataBlockIndex;
-                else
-                    return m_activeDataBlockIndex - 1;
-            }
-            set
-            {
-                if (value < 0)
-                    m_activeDataBlockIndex = -1;
-                else
-                    m_activeDataBlockIndex = value + 1;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the next slot position in the active <see cref="ArchiveDataBlock"/> for the <see cref="HistorianID"/> where data can be written.
-        /// </summary>
-        public int ActiveDataBlockSlot
-        {
-            get
-            {
-                return m_activeDataBlockSlot;
-            }
-            set
-            {
-                if (value <= 0)
-                    m_activeDataBlockSlot = 1;
-                else
-                    m_activeDataBlockSlot = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets slope #1 used in the piece-wise linear compression of data.
-        /// </summary>
-        public double Slope1
-        {
-            get
-            {
-                return m_slope1;
-            }
-            set
-            {
-                m_slope1 = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets slope #2 used in the piece-wise linear compression of data.
-        /// </summary>
-        public double Slope2
-        {
-            get
-            {
-                return m_slope2;
-            }
-            set
-            {
-                m_slope2 = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the historian identifier of <see cref="StateRecord"/>.
-        /// </summary>
-        public int HistorianID
-        {
-            get
-            {
-                return m_historianID;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="StateRecordSummary"/> object for <see cref="StateRecord"/>.
-        /// </summary>
-        public StateRecordSummary Summary
-        {
-            get
-            {
-                return new StateRecordSummary(this);
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="StateRecord"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="StateRecord"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecord"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="StateRecord"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                m_archivedData.ParseBinaryImage(buffer, startIndex, length);
-                m_previousData.ParseBinaryImage(buffer, startIndex + 16, length - 16);
-                m_currentData.ParseBinaryImage(buffer, startIndex + 32, length - 32);
-                ActiveDataBlockIndex = LittleEndian.ToInt32(buffer, startIndex + 48) - 1;
-                ActiveDataBlockSlot = LittleEndian.ToInt32(buffer, startIndex + 52);
-                Slope1 = LittleEndian.ToDouble(buffer, startIndex + 56);
-                Slope2 = LittleEndian.ToDouble(buffer, startIndex + 64);
-
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="StateRecord"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            m_archivedData.GenerateBinaryImage(buffer, startIndex);
-            m_previousData.GenerateBinaryImage(buffer, startIndex + 16);
-            m_currentData.GenerateBinaryImage(buffer, startIndex + 32);
-
-            LittleEndian.CopyBytes(m_activeDataBlockIndex, buffer, startIndex + 48);
-            LittleEndian.CopyBytes(m_activeDataBlockSlot, buffer, startIndex + 52);
-            LittleEndian.CopyBytes(m_slope1, buffer, startIndex + 56);
-            LittleEndian.CopyBytes(m_slope2, buffer, startIndex + 64);
-
-            return length;
-        }
-
-        /// <summary>
-        /// Compares the current <see cref="StateRecord"/> object to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="StateRecord"/> object is to be compared.</param>
-        /// <returns>
-        /// Negative value if the current <see cref="StateRecord"/> object is less than <paramref name="obj"/>, 
-        /// Zero if the current <see cref="StateRecord"/> object is equal to <paramref name="obj"/>, 
-        /// Positive value if the current <see cref="StateRecord"/> object is greater than <paramref name="obj"/>.
-        /// </returns>
-        public virtual int CompareTo(object obj)
-        {
-            StateRecord other = obj as StateRecord;
-            if (other == null)
-                return 1;
-            else
-                return m_historianID.CompareTo(other.HistorianID);
-        }
-
-        /// <summary>
-        /// Determines whether the current <see cref="StateRecord"/> object is equal to <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">Object against which the current <see cref="StateRecord"/> object is to be compared for equality.</param>
-        /// <returns>true if the current <see cref="StateRecord"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
-        public override bool Equals(object obj)
-        {
-            return (CompareTo(obj) == 0);
-        }
-
-        /// <summary>
-        /// Returns the text representation of <see cref="StateRecord"/> object.
-        /// </summary>
-        /// <returns>A <see cref="string"/> value.</returns>
-        public override string ToString()
-        {
-            return string.Format("ID={0}; ActiveDataBlock={1}", m_historianID, m_activeDataBlockIndex);
-        }
-
-        /// <summary>
-        /// Returns the hash code for the current <see cref="StateRecord"/> object.
-        /// </summary>
-        /// <returns>A 32-bit signed integer value.</returns>
-        public override int GetHashCode()
-        {
-            return m_historianID.GetHashCode();
-        }
-
-        #endregion
+        HistorianID = historianID;
+        m_archivedData = new StateRecordDataPoint(HistorianID);
+        m_previousData = new StateRecordDataPoint(HistorianID);
+        m_currentData = new StateRecordDataPoint(HistorianID);
+        m_activeDataBlockIndex = -1;
+        m_activeDataBlockSlot = 1;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StateRecord"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="StateRecord"/>.</param>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecord"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public StateRecord(int historianID, byte[] buffer, int startIndex, int length)
+        : this(historianID)
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the most recently archived <see cref="StateRecordDataPoint"/> for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public StateRecordDataPoint ArchivedData
+    {
+        get => m_archivedData;
+        set => m_archivedData = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the previous <see cref="StateRecordDataPoint"/> received for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public StateRecordDataPoint PreviousData
+    {
+        get => m_previousData;
+        set => m_previousData = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the most current <see cref="StateRecordDataPoint"/> received for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public StateRecordDataPoint CurrentData
+    {
+        get => m_currentData;
+        set => m_currentData = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the 0-based index of the active <see cref="ArchiveDataBlock"/> for the <see cref="HistorianID"/>.
+    /// </summary>
+    /// <remarks>Index is persisted to disk as 1-based index for backwards compatibility.</remarks>
+    public int ActiveDataBlockIndex
+    {
+        get => m_activeDataBlockIndex < 0 ? m_activeDataBlockIndex : m_activeDataBlockIndex - 1;
+        set => m_activeDataBlockIndex = value < 0 ? -1 : value + 1;
+    }
+
+    /// <summary>
+    /// Gets or sets the next slot position in the active <see cref="ArchiveDataBlock"/> for the <see cref="HistorianID"/> where data can be written.
+    /// </summary>
+    public int ActiveDataBlockSlot
+    {
+        get => m_activeDataBlockSlot;
+        set => m_activeDataBlockSlot = value <= 0 ? 1 : value;
+    }
+
+    /// <summary>
+    /// Gets or sets slope #1 used in the piece-wise linear compression of data.
+    /// </summary>
+    public double Slope1 { get; set; }
+
+    /// <summary>
+    /// Gets or sets slope #2 used in the piece-wise linear compression of data.
+    /// </summary>
+    public double Slope2 { get; set; }
+
+    /// <summary>
+    /// Gets the historian identifier of <see cref="StateRecord"/>.
+    /// </summary>
+    public int HistorianID { get; }
+
+    /// <summary>
+    /// Gets the <see cref="StateRecordSummary"/> object for <see cref="StateRecord"/>.
+    /// </summary>
+    public StateRecordSummary Summary => new(this);
+
+    /// <summary>
+    /// Gets the length of the <see cref="StateRecord"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="StateRecord"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecord"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="StateRecord"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        m_archivedData.ParseBinaryImage(buffer, startIndex, length);
+        m_previousData.ParseBinaryImage(buffer, startIndex + 16, length - 16);
+        m_currentData.ParseBinaryImage(buffer, startIndex + 32, length - 32);
+        ActiveDataBlockIndex = LittleEndian.ToInt32(buffer, startIndex + 48) - 1;
+        ActiveDataBlockSlot = LittleEndian.ToInt32(buffer, startIndex + 52);
+        Slope1 = LittleEndian.ToDouble(buffer, startIndex + 56);
+        Slope2 = LittleEndian.ToDouble(buffer, startIndex + 64);
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="StateRecord"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        m_archivedData.GenerateBinaryImage(buffer, startIndex);
+        m_previousData.GenerateBinaryImage(buffer, startIndex + 16);
+        m_currentData.GenerateBinaryImage(buffer, startIndex + 32);
+
+        LittleEndian.CopyBytes(m_activeDataBlockIndex, buffer, startIndex + 48);
+        LittleEndian.CopyBytes(m_activeDataBlockSlot, buffer, startIndex + 52);
+        LittleEndian.CopyBytes(Slope1, buffer, startIndex + 56);
+        LittleEndian.CopyBytes(Slope2, buffer, startIndex + 64);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Compares the current <see cref="StateRecord"/> object to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="StateRecord"/> object is to be compared.</param>
+    /// <returns>
+    /// Negative value if the current <see cref="StateRecord"/> object is less than <paramref name="obj"/>, 
+    /// Zero if the current <see cref="StateRecord"/> object is equal to <paramref name="obj"/>, 
+    /// Positive value if the current <see cref="StateRecord"/> object is greater than <paramref name="obj"/>.
+    /// </returns>
+    public virtual int CompareTo(object obj)
+    {
+        return obj is not StateRecord other ? 1 : HistorianID.CompareTo(other.HistorianID);
+    }
+
+    /// <summary>
+    /// Determines whether the current <see cref="StateRecord"/> object is equal to <paramref name="obj"/>.
+    /// </summary>
+    /// <param name="obj">Object against which the current <see cref="StateRecord"/> object is to be compared for equality.</param>
+    /// <returns>true if the current <see cref="StateRecord"/> object is equal to <paramref name="obj"/>; otherwise false.</returns>
+    public override bool Equals(object obj)
+    {
+        return CompareTo(obj) == 0;
+    }
+
+    /// <summary>
+    /// Returns the text representation of <see cref="StateRecord"/> object.
+    /// </summary>
+    /// <returns>A <see cref="string"/> value.</returns>
+    public override string ToString()
+    {
+        return $"ID={HistorianID}; ActiveDataBlock={m_activeDataBlockIndex}";
+    }
+
+    /// <summary>
+    /// Returns the hash code for the current <see cref="StateRecord"/> object.
+    /// </summary>
+    /// <returns>A 32-bit signed integer value.</returns>
+    public override int GetHashCode()
+    {
+        return HistorianID.GetHashCode();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/StateRecordSummary.cs
+++ b/Source/Libraries/GSF.Historian/Files/StateRecordSummary.cs
@@ -34,167 +34,144 @@
 using System;
 using GSF.Parsing;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// A class with just <see cref="StateRecord.CurrentData"/>. The generated binary image of <see cref="MetadataRecordSummary"/> 
+/// is sent back as a reply to <see cref="Historian.Packets.PacketType11"/>.
+/// </summary>
+/// <seealso cref="StateRecord"/>
+/// <seealso cref="Historian.Packets.PacketType11"/>
+public class StateRecordSummary : ISupportBinaryImage
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 4          0-3        Int32      HistorianID                                                   *
+    // * 16         4-19       Byte(16)   CurrentData                                                   *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// A class with just <see cref="StateRecord.CurrentData"/>. The generated binary image of <see cref="MetadataRecordSummary"/> 
-    /// is sent back as a reply to <see cref="Historian.Packets.PacketType11"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="StateRecordSummary"/>.
     /// </summary>
-    /// <seealso cref="StateRecord"/>
-    /// <seealso cref="Historian.Packets.PacketType11"/>
-    public class StateRecordSummary : ISupportBinaryImage
+    public const int FixedLength = 20;
+
+    // Fields
+    private int m_historianID;
+    private StateRecordDataPoint m_currentData;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StateRecordSummary"/> class.
+    /// </summary>
+    /// <param name="record">A <see cref="StateRecord"/> object.</param>
+    public StateRecordSummary(StateRecord record)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 4          0-3        Int32      HistorianID                                                   *
-        // * 16         4-19       Byte(16)   CurrentData                                                   *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="StateRecordSummary"/>.
-        /// </summary>
-        public const int FixedLength = 20;
-
-        // Fields
-        private int m_historianID;
-        private StateRecordDataPoint m_currentData;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StateRecordSummary"/> class.
-        /// </summary>
-        /// <param name="record">A <see cref="StateRecord"/> object.</param>
-        public StateRecordSummary(StateRecord record)
-        {
-            HistorianID = record.HistorianID;
-            CurrentData = record.CurrentData;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StateRecordSummary"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecordSummary"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public StateRecordSummary(byte[] buffer, int startIndex, int length)
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Same as <see cref="StateRecord.HistorianID"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
-        public int HistorianID
-        {
-            get
-            {
-                return m_historianID;
-            }
-            private set
-            {
-                if (value < 1 && value != -1)
-                    throw new ArgumentException("Value must be positive or -1");
-
-                m_historianID = value;
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="StateRecord.CurrentData"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
-        public StateRecordDataPoint CurrentData
-        {
-            get
-            {
-                return m_currentData;
-            }
-            private set
-            {
-                if ((object)value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                m_currentData = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="StateRecordSummary"/>.
-        /// </summary>
-        public int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="StateRecordSummary"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecordSummary"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="StateRecordSummary"/>.</returns>
-        public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                HistorianID = LittleEndian.ToInt32(buffer, startIndex);
-                CurrentData = new StateRecordDataPoint(HistorianID, buffer, startIndex + 4, length - 4);
-
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="StateRecordSummary"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex, 4);
-            m_currentData.GenerateBinaryImage(buffer, startIndex + 4);
-
-            return length;
-        }
-
-        #endregion
+        HistorianID = record.HistorianID;
+        CurrentData = record.CurrentData;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StateRecordSummary"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecordSummary"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public StateRecordSummary(byte[] buffer, int startIndex, int length)
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Same as <see cref="StateRecord.HistorianID"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive or -1.</exception>
+    public int HistorianID
+    {
+        get => m_historianID;
+        private set
+        {
+            if (value < 1 && value != -1)
+                throw new ArgumentException("Value must be positive or -1");
+
+            m_historianID = value;
+        }
+    }
+
+    /// <summary>
+    /// Same as <see cref="StateRecord.CurrentData"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is null.</exception>
+    public StateRecordDataPoint CurrentData
+    {
+        get => m_currentData;
+        private set => m_currentData = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets the length of the <see cref="StateRecordSummary"/>.
+    /// </summary>
+    public int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="StateRecordSummary"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="StateRecordSummary"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="StateRecordSummary"/>.</returns>
+    public int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        HistorianID = LittleEndian.ToInt32(buffer, startIndex);
+        CurrentData = new StateRecordDataPoint(HistorianID, buffer, startIndex + 4, length - 4);
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="StateRecordSummary"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex, 4);
+        m_currentData.GenerateBinaryImage(buffer, startIndex + 4);
+
+        return length;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Files/TimeSortedArchiveFileScanner.cs
+++ b/Source/Libraries/GSF.Historian/Files/TimeSortedArchiveFileScanner.cs
@@ -29,257 +29,188 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GSF.Historian.Files
+namespace GSF.Historian.Files;
+
+/// <summary>
+/// Reads a series of data points from an <see cref="ArchiveFile"/> in sorted order.
+/// </summary>
+public class TimeSortedArchiveFileScanner : IArchiveFileScanner
 {
+    #region [ Properties ]
+
     /// <summary>
-    /// Reads a series of data points from an <see cref="ArchiveFile"/> in sorted order.
+    /// Gets or sets the file allocation table of
+    /// the file that this scanner is reading from.
     /// </summary>
-    public class TimeSortedArchiveFileScanner : IArchiveFileScanner
+    public ArchiveFileAllocationTable FileAllocationTable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection of
+    /// point IDs to be scanned from the file.
+    /// </summary>
+    public IEnumerable<int> HistorianIDs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum value of the timestamps
+    /// of the data points returned by the scanner.
+    /// </summary>
+    public TimeTag StartTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum value of the timestamps
+    /// of the data points returned by the scanner.
+    /// </summary>
+    public TimeTag EndTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the data point from which to resume
+    /// the scan if it was interrupted by a rollover.
+    /// </summary>
+    public IDataPoint ResumeFrom { get; set; }
+
+    /// <summary>
+    /// Gets or sets the handler used to handle
+    /// errors that occur while scanning the file.
+    /// </summary>
+    public EventHandler<EventArgs<Exception>> DataReadExceptionHandler { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Reads all <see cref="IDataPoint"/>s in time sorted order for the specified historian IDs.
+    /// </summary>
+    /// <returns>Each <see cref="IDataPoint"/> for the specified historian IDs.</returns>
+    public IEnumerable<IDataPoint> Read()
     {
-        #region [ Members ]
+        List<IEnumerator<IDataPoint>> enumerators = [];
 
-        // Fields
-        private ArchiveFileAllocationTable m_fileAllocationTable;
-        private IEnumerable<int> m_historianIDs;
-        private TimeTag m_startTime;
-        private TimeTag m_endTime;
-        private IDataPoint m_resumeFrom;
-        private EventHandler<EventArgs<Exception>> m_dataReadExceptionHandler;
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the file allocation table of
-        /// the file that this scanner is reading from.
-        /// </summary>
-        public ArchiveFileAllocationTable FileAllocationTable
+        // Setup enumerators for scanners that have data
+        foreach (DataPointScanner scanner in GetScanners())
         {
-            get
-            {
-                return m_fileAllocationTable;
-            }
-            set
-            {
-                m_fileAllocationTable = value;
-            }
+            IEnumerator<IDataPoint> enumerator = scanner.Read().GetEnumerator();
+
+            // Add enumerator to the list if it has at least one value
+            if (enumerator.MoveNext())
+                enumerators.Add(enumerator);
+            else
+                enumerator.Dispose();
         }
 
-        /// <summary>
-        /// Gets or sets the collection of
-        /// point IDs to be scanned from the file.
-        /// </summary>
-        public IEnumerable<int> HistorianIDs
+        if (enumerators.Count <= 0)
+            yield break;
+        
+        List<int> completed = [];
+
+        // Start publishing data points in time-sorted order
+        do
         {
-            get
-            {
-                return m_historianIDs;
-            }
-            set
-            {
-                m_historianIDs = value;
-            }
-        }
+            TimeTag publishTime = TimeTag.MaxValue;
 
-        /// <summary>
-        /// Gets or sets the minimum value of the timestamps
-        /// of the data points returned by the scanner.
-        /// </summary>
-        public TimeTag StartTime
-        {
-            get
-            {
-                return m_startTime;
-            }
-            set
-            {
-                m_startTime = value;
-            }
-        }
+            // Find minimum publication time for current values
+            IDataPoint dataPoint;
 
-        /// <summary>
-        /// Gets or sets the maximum value of the timestamps
-        /// of the data points returned by the scanner.
-        /// </summary>
-        public TimeTag EndTime
-        {
-            get
+            foreach (IEnumerator<IDataPoint> enumerator in enumerators)
             {
-                return m_endTime;
-            }
-            set
-            {
-                m_endTime = value;
-            }
-        }
+                dataPoint = enumerator.Current;
 
-        /// <summary>
-        /// Gets or sets the data point from which to resume
-        /// the scan if it was interrupted by a rollover.
-        /// </summary>
-        public IDataPoint ResumeFrom
-        {
-            get
-            {
-                return m_resumeFrom;
-            }
-            set
-            {
-                m_resumeFrom = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the handler used to handle
-        /// errors that occur while scanning the file.
-        /// </summary>
-        public EventHandler<EventArgs<Exception>> DataReadExceptionHandler
-        {
-            get
-            {
-                return m_dataReadExceptionHandler;
-            }
-            set
-            {
-                m_dataReadExceptionHandler = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Reads all <see cref="IDataPoint"/>s in time sorted order for the specified historian IDs.
-        /// </summary>
-        /// <returns>Each <see cref="IDataPoint"/> for the specified historian IDs.</returns>
-        public IEnumerable<IDataPoint> Read()
-        {
-            List<IEnumerator<IDataPoint>> enumerators = new List<IEnumerator<IDataPoint>>();
-
-            // Setup enumerators for scanners that have data
-            foreach (DataPointScanner scanner in GetScanners())
-            {
-                IEnumerator<IDataPoint> enumerator = scanner.Read().GetEnumerator();
-
-                // Add enumerator to the list if it has at least one value
-                if (enumerator.MoveNext())
-                    enumerators.Add(enumerator);
+                if (dataPoint?.Time.CompareTo(publishTime) < 0)
+                    publishTime = dataPoint.Time;
             }
 
-            // Start publishing data points in time-sorted order
-            if (enumerators.Count > 0)
-            {
-                List<int> completed = new List<int>();
-                IDataPoint dataPoint;
+            int index = 0;
 
-                do
+            // Publish all values at the current time
+            foreach (IEnumerator<IDataPoint> enumerator in enumerators)
+            {
+                bool enumerationComplete = false;
+                dataPoint = enumerator.Current;
+
+                if (dataPoint?.Time.CompareTo(publishTime) <= 0)
                 {
-                    TimeTag publishTime = TimeTag.MaxValue;
-
-                    // Find minimum publication time for current values
-                    foreach (IEnumerator<IDataPoint> enumerator in enumerators)
+                    // Attempt to advance to next data point, tracking completed enumerators
+                    if (!enumerator.MoveNext())
                     {
-                        dataPoint = enumerator.Current;
-
-                        if (dataPoint?.Time.CompareTo(publishTime) < 0)
-                            publishTime = dataPoint.Time;
+                        enumerationComplete = true;
+                        completed.Add(index);
                     }
 
-                    int index = 0;
+                    yield return dataPoint;
 
-                    // Publish all values at the current time
-                    foreach (IEnumerator<IDataPoint> enumerator in enumerators)
+                    // Make sure any point IDs with duplicated times directly follow
+                    if (!enumerationComplete)
                     {
-                        bool enumerationComplete = false;
-                        dataPoint = enumerator.Current;
-
-                        if (dataPoint?.Time.CompareTo(publishTime) <= 0)
+                        while (enumerator.Current?.Time.CompareTo(publishTime) <= 0)
                         {
-                            // Attempt to advance to next data point, tracking completed enumerators
+                            yield return enumerator.Current;
+
                             if (!enumerator.MoveNext())
                             {
-                                enumerationComplete = true;
                                 completed.Add(index);
-                            }
-
-                            yield return dataPoint;
-
-                            // Make sure any point IDs with duplicated times directly follow
-                            if (!enumerationComplete)
-                            {
-                                while (enumerator.Current?.Time.CompareTo(publishTime) <= 0)
-                                {
-                                    yield return enumerator.Current;
-
-                                    if (!enumerator.MoveNext())
-                                    {
-                                        completed.Add(index);
-                                        break;
-                                    }
-                                }
+                                break;
                             }
                         }
-
-                        index++;
-                    }
-
-                    // Remove completed enumerators
-                    if (completed.Count > 0)
-                    {
-                        completed.Sort();
-
-                        for (int i = completed.Count - 1; i >= 0; i--)
-                        {
-                            enumerators.RemoveAt(completed[i]);
-                        }
-
-                        completed.Clear();
                     }
                 }
-                while (enumerators.Count > 0);
+
+                index++;
             }
-        }
 
-        // Gets the list of data point scanners used to
-        // scan the file for data belonging to this query.
-        private List<DataPointScanner> GetScanners()
-        {
-            List<DataPointScanner> dataPointScanners = new List<DataPointScanner>();
+            if (completed.Count == 0)
+                continue;
 
-            if (m_historianIDs != null && m_historianIDs.Any())
+            // Remove completed enumerators
+            completed.Sort();
+
+            for (int i = completed.Count - 1; i >= 0; i--)
             {
-                TimeTag startTime = m_startTime ?? TimeTag.MinValue;
-                TimeTag endTime = m_endTime ?? TimeTag.MaxValue;
-                int resumeFromHistorianID = 0;
-                bool includeStartTime = true;
-
-                // Set up parameters needed to properly resume a query after rollover
-                if ((object)m_resumeFrom != null)
-                {
-                    resumeFromHistorianID = m_resumeFrom.HistorianID;
-                    startTime = m_resumeFrom.Time ?? startTime;
-                    includeStartTime = false;
-                }
-
-                // Create data point scanners for each historian ID
-                List<int> historianIDs = m_historianIDs.ToList();
-
-                historianIDs.Sort();
-
-                foreach (int historianID in historianIDs)
-                {
-                    dataPointScanners.Add(new DataPointScanner(m_fileAllocationTable, historianID, startTime, endTime, includeStartTime, m_dataReadExceptionHandler));
-
-                    if (historianID == resumeFromHistorianID)
-                        includeStartTime = true;
-                }
+                enumerators[completed[i]].Dispose();
+                enumerators.RemoveAt(completed[i]);
             }
 
-            return dataPointScanners;
+            completed.Clear();
+        }
+        while (enumerators.Count > 0);
+    }
+
+    // Gets the list of data point scanners used to
+    // scan the file for data belonging to this query.
+    private List<DataPointScanner> GetScanners()
+    {
+        if (HistorianIDs is null || !HistorianIDs.Any())
+            return [];
+
+        List<DataPointScanner> dataPointScanners = [];
+
+        TimeTag startTime = StartTime ?? TimeTag.MinValue;
+        TimeTag endTime = EndTime ?? TimeTag.MaxValue;
+        int resumeFromHistorianID = 0;
+        bool includeStartTime = true;
+
+        // Set up parameters needed to properly resume a query after rollover
+        if (ResumeFrom is not null)
+        {
+            resumeFromHistorianID = ResumeFrom.HistorianID;
+            startTime = ResumeFrom.Time ?? startTime;
+            includeStartTime = false;
         }
 
-        #endregion
+        // Create data point scanners for each historian ID
+        List<int> historianIDs = HistorianIDs.ToList();
+
+        historianIDs.Sort();
+
+        foreach (int historianID in historianIDs)
+        {
+            dataPointScanners.Add(new DataPointScanner(FileAllocationTable, historianID, startTime, endTime, includeStartTime, DataReadExceptionHandler));
+
+            if (historianID == resumeFromHistorianID)
+                includeStartTime = true;
+        }
+
+        return dataPointScanners;
     }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/IArchive.cs
+++ b/Source/Libraries/GSF.Historian/IArchive.cs
@@ -32,115 +32,114 @@
 using System;
 using System.Collections.Generic;
 
-namespace GSF.Historian
+namespace GSF.Historian;
+
+/// <summary>
+/// Defines a repository where time-series data is warehoused by a historian.
+/// </summary>
+/// <seealso cref="IDataPoint"/>
+public interface IArchive
 {
     /// <summary>
-    /// Defines a repository where time-series data is warehoused by a historian.
+    /// Occurs when associated Metadata file is updated.
     /// </summary>
-    /// <seealso cref="IDataPoint"/>
-    public interface IArchive
-    {
-        /// <summary>
-        /// Occurs when associated Metadata file is updated.
-        /// </summary>
-        event EventHandler MetadataUpdated;
+    event EventHandler MetadataUpdated;
 
-        /// <summary>
-        /// Opens the repository.
-        /// </summary>
-        void Open();
+    /// <summary>
+    /// Opens the repository.
+    /// </summary>
+    void Open();
 
-        /// <summary>
-        /// Closes the repository.
-        /// </summary>
-        void Close();
+    /// <summary>
+    /// Closes the repository.
+    /// </summary>
+    void Close();
 
-        /// <summary>
-        /// Writes time-series data to the repository.
-        /// </summary>
-        /// <param name="dataPoint"><see cref="IDataPoint"/> to be written.</param>
-        void WriteData(IDataPoint dataPoint);
+    /// <summary>
+    /// Writes time-series data to the repository.
+    /// </summary>
+    /// <param name="dataPoint"><see cref="IDataPoint"/> to be written.</param>
+    void WriteData(IDataPoint dataPoint);
 
-        /// <summary>
-        /// Writes meta information for the specified <paramref name="historianID"/> to the repository.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="metaData">Binary image of the meta information.</param>
-        void WriteMetaData(int historianID, byte[] metaData);
+    /// <summary>
+    /// Writes meta information for the specified <paramref name="historianID"/> to the repository.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="metaData">Binary image of the meta information.</param>
+    void WriteMetaData(int historianID, byte[] metaData);
 
-        /// <summary>
-        /// Writes state information for the specified <paramref name="historianID"/> to the repository.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <param name="stateData">Binary image of the state information.</param>
-        void WriteStateData(int historianID, byte[] stateData);
+    /// <summary>
+    /// Writes state information for the specified <paramref name="historianID"/> to the repository.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <param name="stateData">Binary image of the state information.</param>
+    void WriteStateData(int historianID, byte[] stateData);
 
-        /// <summary>
-        /// Reads time-series data from the repository.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which <see cref="IDataPoint"/>s are to be read.</param>
-        /// <param name="startTime"><see cref="System.String"/> representation of the start time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
-        /// <param name="endTime"><see cref="System.String"/> representation of the end time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="IDataPoint"/>s.</returns>
-        IEnumerable<IDataPoint> ReadData(int historianID, string startTime, string endTime, bool timeSorted = true);
+    /// <summary>
+    /// Reads time-series data from the repository.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which <see cref="IDataPoint"/>s are to be read.</param>
+    /// <param name="startTime"><see cref="System.String"/> representation of the start time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
+    /// <param name="endTime"><see cref="System.String"/> representation of the end time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="IDataPoint"/>s.</returns>
+    IEnumerable<IDataPoint> ReadData(int historianID, string startTime, string endTime, bool timeSorted = true);
 
-        /// <summary>
-        /// Reads time-series data from the repository.
-        /// </summary>
-        /// <param name="historianID">Historian identifier for which time-series data are to be retrieved.</param>
-        /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
-        /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more time-series data.</returns>
-        IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, DateTime endTime, bool timeSorted = true);
+    /// <summary>
+    /// Reads time-series data from the repository.
+    /// </summary>
+    /// <param name="historianID">Historian identifier for which time-series data are to be retrieved.</param>
+    /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
+    /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more time-series data.</returns>
+    IEnumerable<IDataPoint> ReadData(int historianID, DateTime startTime, DateTime endTime, bool timeSorted = true);
 
-        /// <summary>
-        /// Reads time-series data from the repository.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="IDataPoint"/>s are to be read.</param>
-        /// <param name="startTime"><see cref="System.String"/> representation of the start time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
-        /// <param name="endTime"><see cref="System.String"/> representation of the end time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="IDataPoint"/>s.</returns>
-        IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, string endTime, bool timeSorted = true);
+    /// <summary>
+    /// Reads time-series data from the repository.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="IDataPoint"/>s are to be read.</param>
+    /// <param name="startTime"><see cref="System.String"/> representation of the start time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
+    /// <param name="endTime"><see cref="System.String"/> representation of the end time (in UTC) of the timespan for which <see cref="IDataPoint"/>s are to be read.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="IDataPoint"/>s.</returns>
+    IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, string startTime, string endTime, bool timeSorted = true);
 
-        /// <summary>
-        /// Reads time-series data from the repository.
-        /// </summary>
-        /// <param name="historianIDs">Historian identifiers for which <see cref="IDataPoint"/>s are to be read.</param>
-        /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
-        /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
-        /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
-        /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="IDataPoint"/>s.</returns>
-        IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, DateTime endTime, bool timeSorted = true);
+    /// <summary>
+    /// Reads time-series data from the repository.
+    /// </summary>
+    /// <param name="historianIDs">Historian identifiers for which <see cref="IDataPoint"/>s are to be read.</param>
+    /// <param name="startTime">Start <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
+    /// <param name="endTime">End <see cref="DateTime"/> (in UTC) for the time-series data to be retrieved.</param>
+    /// <param name="timeSorted">Indicates whether the data retrieved from the archive should be time sorted.</param>
+    /// <returns><see cref="IEnumerable{T}"/> object containing zero or more <see cref="IDataPoint"/>s.</returns>
+    IEnumerable<IDataPoint> ReadData(IEnumerable<int> historianIDs, DateTime startTime, DateTime endTime, bool timeSorted = true);
 
-        /// <summary>
-        /// Read meta information for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing meta information.</returns>
-        byte[] ReadMetaData(int historianID);
+    /// <summary>
+    /// Read meta information for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing meta information.</returns>
+    byte[] ReadMetaData(int historianID);
 
-        /// <summary>
-        /// Reads state information for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing state information.</returns>
-        byte[] ReadStateData(int historianID);
+    /// <summary>
+    /// Reads state information for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing state information.</returns>
+    byte[] ReadStateData(int historianID);
 
-        /// <summary>
-        /// Reads meta information summary for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing meta information summary.</returns>
-        byte[] ReadMetaDataSummary(int historianID);
+    /// <summary>
+    /// Reads meta information summary for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing meta information summary.</returns>
+    byte[] ReadMetaDataSummary(int historianID);
 
-        /// <summary>
-        /// Read state information summary for the specified <paramref name="historianID"/>.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        /// <returns>A <see cref="byte"/> array containing state information summary.</returns>
-        byte[] ReadStateDataSummary(int historianID);
-    }
+    /// <summary>
+    /// Read state information summary for the specified <paramref name="historianID"/>.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    /// <returns>A <see cref="byte"/> array containing state information summary.</returns>
+    byte[] ReadStateDataSummary(int historianID);
 }

--- a/Source/Libraries/GSF.Historian/IDataPoint.cs
+++ b/Source/Libraries/GSF.Historian/IDataPoint.cs
@@ -36,230 +36,213 @@ using GSF.Historian.Files;
 using GSF.Parsing;
 using GSF.TimeSeries;
 
-namespace GSF.Historian
+namespace GSF.Historian;
+
+#region [ Enumerations ]
+
+/// <summary>
+/// Indicates the quality of time-series data.
+/// </summary>
+public enum Quality
 {
-    #region [ Enumerations ]
-
     /// <summary>
-    /// Indicates the quality of time-series data.
+    /// Unknown
     /// </summary>
-    public enum Quality
-    {
-        /// <summary>
-        /// Unknown
-        /// </summary>
-        Unknown,
-        /// <summary>
-        /// DeletedFromProcessing
-        /// </summary>
-        DeletedFromProcessing,
-        /// <summary>
-        /// CouldNotCalculate
-        /// </summary>
-        CouldNotCalculate,
-        /// <summary>
-        /// FrontEndHardwareError
-        /// </summary>
-        FrontEndHardwareError,
-        /// <summary>
-        /// SensorReadError
-        /// </summary>
-        SensorReadError,
-        /// <summary>
-        /// OpenThermocouple
-        /// </summary>
-        OpenThermocouple,
-        /// <summary>
-        /// InputCountsOutOfSensorRange
-        /// </summary>
-        InputCountsOutOfSensorRange,
-        /// <summary>
-        /// UnreasonableHigh
-        /// </summary>
-        UnreasonableHigh,
-        /// <summary>
-        /// UnreasonableLow
-        /// </summary>
-        UnreasonableLow,
-        /// <summary>
-        /// Old
-        /// </summary>
-        Old,
-        /// <summary>
-        /// SuspectValueAboveHiHiLimit
-        /// </summary>
-        SuspectValueAboveHiHiLimit,
-        /// <summary>
-        /// SuspectValueBelowLoLoLimit
-        /// </summary>
-        SuspectValueBelowLoLoLimit,
-        /// <summary>
-        /// SuspectValueAboveHiLimit
-        /// </summary>
-        SuspectValueAboveHiLimit,
-        /// <summary>
-        /// SuspectValueBelowLoLimit
-        /// </summary>
-        SuspectValueBelowLoLimit,
-        /// <summary>
-        /// SuspectData
-        /// </summary>
-        SuspectData,
-        /// <summary>
-        /// DigitalSuspectAlarm
-        /// </summary>
-        DigitalSuspectAlarm,
-        /// <summary>
-        /// InsertedValueAboveHiHiLimit
-        /// </summary>
-        InsertedValueAboveHiHiLimit,
-        /// <summary>
-        /// InsertedValueBelowLoLoLimit
-        /// </summary>
-        InsertedValueBelowLoLoLimit,
-        /// <summary>
-        /// InsertedValueAboveHiLimit
-        /// </summary>
-        InsertedValueAboveHiLimit,
-        /// <summary>
-        /// InsertedValueBelowLoLimit
-        /// </summary>
-        InsertedValueBelowLoLimit,
-        /// <summary>
-        /// InsertedValue
-        /// </summary>
-        InsertedValue,
-        /// <summary>
-        /// DigitalInsertedStatusInAlarm
-        /// </summary>
-        DigitalInsertedStatusInAlarm,
-        /// <summary>
-        /// LogicalAlarm
-        /// </summary>
-        LogicalAlarm,
-        /// <summary>
-        /// ValueAboveHiHiAlarm
-        /// </summary>
-        ValueAboveHiHiAlarm,
-        /// <summary>
-        /// ValueBelowLoLoAlarm
-        /// </summary>
-        ValueBelowLoLoAlarm,
-        /// <summary>
-        /// ValueAboveHiAlarm
-        /// </summary>
-        ValueAboveHiAlarm,
-        /// <summary>
-        /// ValueBelowLoAlarm
-        /// </summary>
-        ValueBelowLoAlarm,
-        /// <summary>
-        /// DeletedFromAlarmChecks
-        /// </summary>
-        DeletedFromAlarmChecks,
-        /// <summary>
-        /// InhibitedByCutoutPoint
-        /// </summary>
-        InhibitedByCutoutPoint,
-        /// <summary>
-        /// Good
-        /// </summary>
-        Good
-    }
-
+    Unknown,
     /// <summary>
-    /// Defines extension methods for (and related to) <see cref="Quality"/> enumeration.
+    /// DeletedFromProcessing
     /// </summary>
-    public static class QualityExtensions
+    DeletedFromProcessing,
+    /// <summary>
+    /// CouldNotCalculate
+    /// </summary>
+    CouldNotCalculate,
+    /// <summary>
+    /// FrontEndHardwareError
+    /// </summary>
+    FrontEndHardwareError,
+    /// <summary>
+    /// SensorReadError
+    /// </summary>
+    SensorReadError,
+    /// <summary>
+    /// OpenThermocouple
+    /// </summary>
+    OpenThermocouple,
+    /// <summary>
+    /// InputCountsOutOfSensorRange
+    /// </summary>
+    InputCountsOutOfSensorRange,
+    /// <summary>
+    /// UnreasonableHigh
+    /// </summary>
+    UnreasonableHigh,
+    /// <summary>
+    /// UnreasonableLow
+    /// </summary>
+    UnreasonableLow,
+    /// <summary>
+    /// Old
+    /// </summary>
+    Old,
+    /// <summary>
+    /// SuspectValueAboveHiHiLimit
+    /// </summary>
+    SuspectValueAboveHiHiLimit,
+    /// <summary>
+    /// SuspectValueBelowLoLoLimit
+    /// </summary>
+    SuspectValueBelowLoLoLimit,
+    /// <summary>
+    /// SuspectValueAboveHiLimit
+    /// </summary>
+    SuspectValueAboveHiLimit,
+    /// <summary>
+    /// SuspectValueBelowLoLimit
+    /// </summary>
+    SuspectValueBelowLoLimit,
+    /// <summary>
+    /// SuspectData
+    /// </summary>
+    SuspectData,
+    /// <summary>
+    /// DigitalSuspectAlarm
+    /// </summary>
+    DigitalSuspectAlarm,
+    /// <summary>
+    /// InsertedValueAboveHiHiLimit
+    /// </summary>
+    InsertedValueAboveHiHiLimit,
+    /// <summary>
+    /// InsertedValueBelowLoLoLimit
+    /// </summary>
+    InsertedValueBelowLoLoLimit,
+    /// <summary>
+    /// InsertedValueAboveHiLimit
+    /// </summary>
+    InsertedValueAboveHiLimit,
+    /// <summary>
+    /// InsertedValueBelowLoLimit
+    /// </summary>
+    InsertedValueBelowLoLimit,
+    /// <summary>
+    /// InsertedValue
+    /// </summary>
+    InsertedValue,
+    /// <summary>
+    /// DigitalInsertedStatusInAlarm
+    /// </summary>
+    DigitalInsertedStatusInAlarm,
+    /// <summary>
+    /// LogicalAlarm
+    /// </summary>
+    LogicalAlarm,
+    /// <summary>
+    /// ValueAboveHiHiAlarm
+    /// </summary>
+    ValueAboveHiHiAlarm,
+    /// <summary>
+    /// ValueBelowLoLoAlarm
+    /// </summary>
+    ValueBelowLoLoAlarm,
+    /// <summary>
+    /// ValueAboveHiAlarm
+    /// </summary>
+    ValueAboveHiAlarm,
+    /// <summary>
+    /// ValueBelowLoAlarm
+    /// </summary>
+    ValueBelowLoAlarm,
+    /// <summary>
+    /// DeletedFromAlarmChecks
+    /// </summary>
+    DeletedFromAlarmChecks,
+    /// <summary>
+    /// InhibitedByCutoutPoint
+    /// </summary>
+    InhibitedByCutoutPoint,
+    /// <summary>
+    /// Good
+    /// </summary>
+    Good
+}
+
+/// <summary>
+/// Defines extension methods for (and related to) <see cref="Quality"/> enumeration.
+/// </summary>
+public static class QualityExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="MeasurementStateFlags"/> value from a <see cref="Quality"/> value.
+    /// </summary>
+    /// <param name="quality"><see cref="Quality"/> value to interpret.</param>
+    /// <returns><see cref="MeasurementStateFlags"/> value from a <see cref="Quality"/> value.</returns>
+    public static MeasurementStateFlags MeasurementQuality(this Quality quality)
     {
-        /// <summary>
-        /// Gets a <see cref="MeasurementStateFlags"/> value from a <see cref="Quality"/> value.
-        /// </summary>
-        /// <param name="quality"><see cref="Quality"/> value to interpret.</param>
-        /// <returns><see cref="MeasurementStateFlags"/> value from a <see cref="Quality"/> value.</returns>
-        public static MeasurementStateFlags MeasurementQuality(this Quality quality)
+        MeasurementStateFlags stateFlags = MeasurementStateFlags.Normal;
+
+        switch (quality)
         {
-            MeasurementStateFlags stateFlags = MeasurementStateFlags.Normal;
-
-            if (quality == Quality.DeletedFromProcessing)
+            case Quality.DeletedFromProcessing:
                 stateFlags |= MeasurementStateFlags.DiscardedValue;
-
-            if (quality == Quality.Old)
+                break;
+            case Quality.Old:
                 stateFlags |= MeasurementStateFlags.BadTime;
-
-            if (quality == Quality.SuspectData)
+                break;
+            case Quality.SuspectData:
                 stateFlags |= MeasurementStateFlags.BadData;
-
-            return stateFlags;
+                break;
         }
 
-        /// <summary>
-        /// Gets a <see cref="Quality"/> value from a <see cref="IMeasurement"/> value.
-        /// </summary>
-        /// <param name="measurement"><see cref="IMeasurement"/> value to interpret.</param>
-        /// <returns><see cref="Quality"/> value from a <see cref="IMeasurement"/> value.</returns>
-        public static Quality HistorianQuality(this IMeasurement measurement)
-        {
-            return measurement.IsDiscarded() ? Quality.DeletedFromProcessing : (measurement.ValueQualityIsGood() ? (measurement.TimestampQualityIsGood() ? Quality.Good : Quality.Old) : Quality.SuspectData);
-        }
+        return stateFlags;
     }
+
+    /// <summary>
+    /// Gets a <see cref="Quality"/> value from a <see cref="IMeasurement"/> value.
+    /// </summary>
+    /// <param name="measurement"><see cref="IMeasurement"/> value to interpret.</param>
+    /// <returns><see cref="Quality"/> value from a <see cref="IMeasurement"/> value.</returns>
+    public static Quality HistorianQuality(this IMeasurement measurement)
+    {
+        return measurement.IsDiscarded() ? Quality.DeletedFromProcessing : measurement.ValueQualityIsGood() ? measurement.TimestampQualityIsGood() ? Quality.Good : Quality.Old : Quality.SuspectData;
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Defines time-series data warehoused by a historian.
+/// </summary>
+/// <seealso cref="TimeTag"/>
+/// <seealso cref="Quality"/>
+public interface IDataPoint : ISupportBinaryImage, IComparable, IFormattable
+{
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the historian identifier of the time-series data point.
+    /// </summary>
+    int HistorianID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="TimeTag"/> of the time-series data point.
+    /// </summary>
+    TimeTag Time { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of the time-series data point.
+    /// </summary>
+    float Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Quality"/> of the time-series data point.
+    /// </summary>
+    Quality Quality { get; set; }
+
+    /// <summary>
+    /// Gets or sets associated <see cref="MetadataRecord"/> of the time-series data point.
+    /// </summary>
+    MetadataRecord Metadata { get; set; }
 
     #endregion
-
-    /// <summary>
-    /// Defines time-series data warehoused by a historian.
-    /// </summary>
-    /// <seealso cref="TimeTag"/>
-    /// <seealso cref="Quality"/>
-    public interface IDataPoint : ISupportBinaryImage, IComparable, IFormattable
-    {
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the historian identifier of the time-series data point.
-        /// </summary>
-        int HistorianID
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="TimeTag"/> of the time-series data point.
-        /// </summary>
-        TimeTag Time
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the time-series data point.
-        /// </summary>
-        float Value
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Quality"/> of the time-series data point.
-        /// </summary>
-        Quality Quality
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets associated <see cref="MetadataRecord"/> of the time-series data point.
-        /// </summary>
-        MetadataRecord Metadata
-        {
-            get;
-            set;
-        }
-
-        #endregion
-    }
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/AdoMetadataProvider.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/AdoMetadataProvider.cs
@@ -39,228 +39,189 @@ using GSF.Configuration;
 using GSF.Data;
 using GSF.IO;
 
-namespace GSF.Historian.MetadataProviders
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// Represents a provider of data to a <see cref="GSF.Historian.Files.MetadataFile"/> from any ADO.NET based data store.
+/// </summary>
+/// <seealso cref="MetadataUpdater"/>
+public class AdoMetadataProvider : MetadataProviderBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a provider of data to a <see cref="GSF.Historian.Files.MetadataFile"/> from any ADO.NET based data store.
+    /// Initializes a new instance of the <see cref="AdoMetadataProvider"/> class.
     /// </summary>
-    /// <seealso cref="MetadataUpdater"/>
-    public class AdoMetadataProvider : MetadataProviderBase
+    public AdoMetadataProvider()
     {
-        #region [ Members ]
-
-        // Fields
-        private string m_connectionString;
-        private string m_dataProviderString;
-        private string m_selectString;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AdoMetadataProvider"/> class.
-        /// </summary>
-        public AdoMetadataProvider()
-        {
-            m_connectionString = string.Empty;
-            m_dataProviderString = string.Empty;
-            m_selectString = string.Empty;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the connection string for connecting to the ADO.NET based data store of metadata.
-        /// </summary>
-        public string ConnectionString
-        {
-            get
-            {
-                return m_connectionString;
-            }
-            set
-            {
-                m_connectionString = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the ADO.NET data provider assembly type creation string.
-        /// </summary>
-        /// <remarks>
-        /// Expected keys: AssemblyName;ConnectionType<br/>
-        /// Examples:
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Database Connection Type</term>
-        ///         <description>Example ADO.NET Data Provider String</description>
-        ///     </listheader>
-        ///     <item>
-        ///         <term>SQL Server</term>
-        ///         <description>AssemblyName={System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.SqlClient.SqlConnection</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>MySQL</term>
-        ///         <description>AssemblyName={MySql.Data, Version=5.2.7.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d};ConnectionType=MySql.Data.MySqlClient.MySqlConnection</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>Oracle</term>
-        ///         <description>AssemblyName={System.Data.OracleClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.OracleClient.OracleConnection</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>OleDb</term>
-        ///         <description>AssemblyName={System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.OleDb.OleDbConnection</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>ODBC</term>
-        ///         <description>AssemblyName={System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.Odbc.OdbcConnection</description>
-        ///     </item>
-        /// </list>
-        /// </remarks>
-        public string DataProviderString
-        {
-            get
-            {
-                return m_dataProviderString;
-            }
-            set
-            {
-                m_dataProviderString = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the SELECT statement for retrieving metadata from the ADO.NET based data store.
-        /// </summary>
-        public string SelectString
-        {
-            get
-            {
-                return m_selectString;
-            }
-            set
-            {
-                m_selectString = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Saves <see cref="AdoMetadataProvider"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["ConnectionString", true].Update(m_connectionString);
-                settings["DataProviderString", true].Update(m_dataProviderString);
-                settings["SelectString", true].Update(m_selectString);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved <see cref="AdoMetadataProvider"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("ConnectionString", "Eval(SystemSettings.ConnectionString)", "Connection string for connecting to the ADO.NET based data store of metadata.");
-                settings.Add("DataProviderString", "Eval(SystemSettings.DataProviderString)", "The ADO.NET data provider assembly type creation string used to create a connection to the data store of metadata.");
-                settings.Add("SelectString", m_selectString, "SELECT statement for retrieving metadata from the ADO.NET based data store.");
-                DataProviderString = settings["DataProviderString"].ValueAs(m_dataProviderString);
-                SelectString = settings["SelectString"].ValueAs(m_selectString);
-
-                // Load the connection string from the specified category.
-                string connectionString = settings["ConnectionString"].ValueAs(m_connectionString);
-                Dictionary<string, string> connectionSettings = connectionString.ParseKeyValuePairs();
-                string connectionSetting;
-
-                if (connectionSettings.TryGetValue("Provider", out connectionSetting))
-                {
-                    // Check if provider is for Access
-                    if (connectionSetting.StartsWith("Microsoft.Jet.OLEDB", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Make sure path to Access database is fully qualified
-                        if (connectionSettings.TryGetValue("Data Source", out connectionSetting))
-                        {
-                            connectionSettings["Data Source"] = FilePath.GetAbsolutePath(connectionSetting);
-                            connectionString = connectionSettings.JoinKeyValuePairs();
-                        }
-                    }
-                }
-
-                ConnectionString = connectionString;
-            }
-        }
-
-        /// <summary>
-        /// Refreshes the <see cref="MetadataProviderBase.Metadata"/> from an ADO.NET based data store.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><see cref="ConnectionString"/> or <see cref="SelectString"/> is set to a null or empty string.</exception>
-        protected override void RefreshMetadata()
-        {
-            if (string.IsNullOrEmpty(m_connectionString))
-                throw new ArgumentNullException("ConnectionString");
-
-            if (string.IsNullOrEmpty(m_selectString))
-                throw new ArgumentNullException("SelectString");
-            
-            // Attempt to load configuration from an ADO.NET database connection
-            IDbConnection connection = null;
-            Dictionary<string, string> settings;
-            string assemblyName, connectionTypeName, adapterTypeName;
-            Assembly assembly;
-            Type connectionType, adapterType;
-
-            try
-            {
-                settings = m_dataProviderString.ParseKeyValuePairs();
-                assemblyName = settings["AssemblyName"].ToNonNullString();
-                connectionTypeName = settings["ConnectionType"].ToNonNullString();
-                adapterTypeName = settings["AdapterType"].ToNonNullString();
-
-                if (string.IsNullOrEmpty(connectionTypeName))
-                    throw new InvalidOperationException("Database connection type was not defined");
-
-                if (string.IsNullOrEmpty(adapterTypeName))
-                    throw new InvalidOperationException("Database adapter type was not defined");
-
-                assembly = Assembly.Load(new AssemblyName(assemblyName));
-                connectionType = assembly.GetType(connectionTypeName);
-                adapterType = assembly.GetType(adapterTypeName);
-
-                // Open ADO.NET provider connection
-                connection = (IDbConnection)Activator.CreateInstance(connectionType);
-                connection.ConnectionString = m_connectionString;
-                connection.Open();
-
-                // Update existing metadata
-                MetadataUpdater metadataUpdater = new MetadataUpdater(Metadata);
-                metadataUpdater.UpdateMetadata(connection.ExecuteReader(m_selectString));
-            }
-            finally
-            {
-                if (connection != null)
-                    connection.Dispose();
-            }
-        }
-
-        #endregion
+        ConnectionString = string.Empty;
+        DataProviderString = string.Empty;
+        SelectString = string.Empty;
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the connection string for connecting to the ADO.NET based data store of metadata.
+    /// </summary>
+    public string ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ADO.NET data provider assembly type creation string.
+    /// </summary>
+    /// <remarks>
+    /// Expected keys: AssemblyName;ConnectionType<br/>
+    /// Examples:
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Database Connection Type</term>
+    ///         <description>Example ADO.NET Data Provider String</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>SQL Server</term>
+    ///         <description>AssemblyName={System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.SqlClient.SqlConnection</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>MySQL</term>
+    ///         <description>AssemblyName={MySql.Data, Version=5.2.7.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d};ConnectionType=MySql.Data.MySqlClient.MySqlConnection</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Oracle</term>
+    ///         <description>AssemblyName={System.Data.OracleClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.OracleClient.OracleConnection</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>OleDb</term>
+    ///         <description>AssemblyName={System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.OleDb.OleDbConnection</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>ODBC</term>
+    ///         <description>AssemblyName={System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089};ConnectionType=System.Data.Odbc.OdbcConnection</description>
+    ///     </item>
+    /// </list>
+    /// </remarks>
+    public string DataProviderString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SELECT statement for retrieving metadata from the ADO.NET based data store.
+    /// </summary>
+    public string SelectString { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Saves <see cref="AdoMetadataProvider"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+        
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(ConnectionString), true].Update(ConnectionString);
+        settings[nameof(DataProviderString), true].Update(DataProviderString);
+        settings[nameof(SelectString), true].Update(SelectString);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved <see cref="AdoMetadataProvider"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(ConnectionString), "Eval(SystemSettings.ConnectionString)", "Connection string for connecting to the ADO.NET based data store of metadata.");
+        settings.Add(nameof(DataProviderString), "Eval(SystemSettings.DataProviderString)", "The ADO.NET data provider assembly type creation string used to create a connection to the data store of metadata.");
+        settings.Add(nameof(SelectString), SelectString, "SELECT statement for retrieving metadata from the ADO.NET based data store.");
+        
+        DataProviderString = settings[nameof(DataProviderString)].ValueAs(DataProviderString);
+        SelectString = settings[nameof(SelectString)].ValueAs(SelectString);
+
+        // Load the connection string from the specified category.
+        string connectionString = settings[nameof(ConnectionString)].ValueAs(ConnectionString);
+        Dictionary<string, string> connectionSettings = connectionString.ParseKeyValuePairs();
+
+        if (connectionSettings.TryGetValue("Provider", out string connectionSetting))
+        {
+            // Check if provider is for Access
+            if (connectionSetting.StartsWith("Microsoft.Jet.OLEDB", StringComparison.OrdinalIgnoreCase))
+            {
+                // Make sure path to Access database is fully qualified
+                if (connectionSettings.TryGetValue("Data Source", out connectionSetting))
+                {
+                    connectionSettings["Data Source"] = FilePath.GetAbsolutePath(connectionSetting);
+                    connectionString = connectionSettings.JoinKeyValuePairs();
+                }
+            }
+        }
+
+        ConnectionString = connectionString;
+    }
+
+    /// <summary>
+    /// Refreshes the <see cref="MetadataProviderBase.Metadata"/> from an ADO.NET based data store.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><see cref="ConnectionString"/> or <see cref="SelectString"/> is set to a null or empty string.</exception>
+    protected override void RefreshMetadata()
+    {
+        if (string.IsNullOrEmpty(ConnectionString))
+            throw new ArgumentNullException(nameof(ConnectionString));
+
+        if (string.IsNullOrEmpty(SelectString))
+            throw new ArgumentNullException(nameof(SelectString));
+            
+        // Attempt to load configuration from an ADO.NET database connection
+        IDbConnection connection = null;
+
+        try
+        {
+            Dictionary<string, string> settings = DataProviderString.ParseKeyValuePairs();
+            string assemblyName = settings[nameof(AssemblyName)].ToNonNullString();
+            string connectionTypeName = settings["ConnectionType"].ToNonNullString();
+            string adapterTypeName = settings["AdapterType"].ToNonNullString();
+
+            if (string.IsNullOrEmpty(connectionTypeName))
+                throw new InvalidOperationException("Database connection type was not defined");
+
+            if (string.IsNullOrEmpty(adapterTypeName))
+                throw new InvalidOperationException("Database adapter type was not defined");
+
+            Assembly assembly = Assembly.Load(new AssemblyName(assemblyName));
+            Type connectionType = assembly.GetType(connectionTypeName);
+
+            assembly.GetType(adapterTypeName);
+
+            // Open ADO.NET provider connection
+            connection = (IDbConnection)Activator.CreateInstance(connectionType);
+            connection.ConnectionString = ConnectionString;
+            connection.Open();
+
+            // Update existing metadata
+            MetadataUpdater metadataUpdater = new(Metadata);
+            metadataUpdater.UpdateMetadata(connection.ExecuteReader(SelectString));
+        }
+        finally
+        {
+            connection?.Dispose();
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/IMetadataProvider.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/IMetadataProvider.cs
@@ -31,67 +31,66 @@ using System;
 using GSF.Adapters;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.MetadataProviders
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// Defines a provider of updates to the data in a <see cref="MetadataFile"/>.
+/// </summary>
+/// <seealso cref="MetadataFile"/>
+public interface IMetadataProvider : IAdapter
 {
+    #region [ Members ]
+
+    // Events
+
     /// <summary>
-    /// Defines a provider of updates to the data in a <see cref="MetadataFile"/>.
+    /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is started.
     /// </summary>
-    /// <seealso cref="MetadataFile"/>
-    public interface IMetadataProvider : IAdapter
-    {
-        #region [ Members ]
+    event EventHandler MetadataRefreshStart;
 
-        // Events
+    /// <summary>
+    /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is completed.
+    /// </summary>
+    event EventHandler MetadataRefreshComplete;
 
-        /// <summary>
-        /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is started.
-        /// </summary>
-        event EventHandler MetadataRefreshStart;
+    /// <summary>
+    /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> times out.
+    /// </summary>
+    event EventHandler MetadataRefreshTimeout;
 
-        /// <summary>
-        /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is completed.
-        /// </summary>
-        event EventHandler MetadataRefreshComplete;
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered during <see cref="Refresh()"/> of <see cref="Metadata"/>.
+    /// </summary>
+    event EventHandler<EventArgs<Exception>> MetadataRefreshException;
 
-        /// <summary>
-        /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> times out.
-        /// </summary>
-        event EventHandler MetadataRefreshTimeout;
+    #endregion
 
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered during <see cref="Refresh()"/> of <see cref="Metadata"/>.
-        /// </summary>
-        event EventHandler<EventArgs<Exception>> MetadataRefreshException;
+    #region [ Properties ]
 
-        #endregion
+    /// <summary>
+    /// Gets or sets the number of seconds to wait for the <see cref="Refresh()"/> to complete.
+    /// </summary>
+    int RefreshTimeout { get; set; }
 
-        #region [ Properties ]
+    /// <summary>
+    /// Gets or sets the number of minutes at which the <see cref="Metadata"/> if to be refreshed automatically.
+    /// </summary>
+    int RefreshInterval { get; set; }
 
-        /// <summary>
-        /// Gets or sets the number of seconds to wait for the <see cref="Refresh()"/> to complete.
-        /// </summary>
-        int RefreshTimeout { get; set; }
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataFile"/> to be refreshed by the metadata provider.
+    /// </summary>
+    MetadataFile Metadata { get; set; }
 
-        /// <summary>
-        /// Gets or sets the number of minutes at which the <see cref="Metadata"/> if to be refreshed automatically.
-        /// </summary>
-        int RefreshInterval { get; set; }
+    #endregion
 
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataFile"/> to be refreshed by the metadata provider.
-        /// </summary>
-        MetadataFile Metadata { get; set; }
+    #region [ Methods ]
 
-        #endregion
+    /// <summary>
+    /// Refreshes the <see cref="Metadata"/> from an external source.
+    /// </summary>
+    /// <returns>true if the <see cref="Metadata"/> is refreshed; otherwise false.</returns>
+    bool Refresh();
 
-        #region [ Methods ]
-
-        /// <summary>
-        /// Refreshes the <see cref="Metadata"/> from an external source.
-        /// </summary>
-        /// <returns>true if the <see cref="Metadata"/> is refreshed; otherwise false.</returns>
-        bool Refresh();
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/MetadataProviderBase.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/MetadataProviderBase.cs
@@ -44,321 +44,292 @@ using GSF.Configuration;
 using GSF.Historian.Files;
 using Timer = System.Timers.Timer;
 
-namespace GSF.Historian.MetadataProviders
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// Base class for a provider of updates to the data in a <see cref="MetadataFile"/>.
+/// </summary>
+public abstract class MetadataProviderBase : Adapter, IMetadataProvider
 {
+    #region [ Members ]
+
+    // Events
+
     /// <summary>
-    /// Base class for a provider of updates to the data in a <see cref="MetadataFile"/>.
+    /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is started.
     /// </summary>
-    public abstract class MetadataProviderBase : Adapter, IMetadataProvider
+    public event EventHandler MetadataRefreshStart;
+
+    /// <summary>
+    /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is completed.
+    /// </summary>
+    public event EventHandler MetadataRefreshComplete;
+
+    /// <summary>
+    /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> times out.
+    /// </summary>
+    public event EventHandler MetadataRefreshTimeout;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered during <see cref="Refresh()"/> of <see cref="Metadata"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Exception"/> encountered during <see cref="Refresh()"/>.
+    /// </remarks>
+    public event EventHandler<EventArgs<Exception>> MetadataRefreshException;
+
+    // Fields
+    private int m_refreshInterval;
+    private int m_refreshTimeout;
+    private Thread m_refreshThread;
+    private Timer m_refreshTimer;
+    private bool m_disposed;
+    private bool m_initialized;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the metadata provider.
+    /// </summary>
+    protected MetadataProviderBase()
     {
-        #region [ Members ]
-
-        // Events
-
-        /// <summary>
-        /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is started.
-        /// </summary>
-        public event EventHandler MetadataRefreshStart;
-
-        /// <summary>
-        /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> is completed.
-        /// </summary>
-        public event EventHandler MetadataRefreshComplete;
-
-        /// <summary>
-        /// Occurs when <see cref="Refresh()"/> of <see cref="Metadata"/> times out.
-        /// </summary>
-        public event EventHandler MetadataRefreshTimeout;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered during <see cref="Refresh()"/> of <see cref="Metadata"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the <see cref="Exception"/> encountered during <see cref="Refresh()"/>.
-        /// </remarks>
-        public event EventHandler<EventArgs<Exception>> MetadataRefreshException;
-
-        // Fields
-        private int m_refreshInterval;
-        private int m_refreshTimeout;
-        private MetadataFile m_metadata;
-        private Thread m_refreshThread;
-        private Timer m_refreshTimer;
-        private bool m_disposed;
-        private bool m_initialized;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the metadata provider.
-        /// </summary>
-        protected MetadataProviderBase()
-        {
-            m_refreshInterval = -1;
-            m_refreshTimeout = 60;
-            PersistSettings = true;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the number of seconds to wait for the <see cref="Refresh()"/> to complete.
-        /// </summary>
-        /// <remarks>
-        /// Set <see cref="RefreshTimeout"/> to -1 to wait indefinitely on <see cref="Refresh()"/>.
-        /// </remarks>
-        public int RefreshTimeout
-        {
-            get
-            {
-                return m_refreshTimeout;
-            }
-            set
-            {
-                if (value < 1)
-                    m_refreshTimeout = -1;
-                else
-                    m_refreshTimeout = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the interval in minutes at which the <see cref="Metadata"/> if to be refreshed automatically.
-        /// </summary>
-        /// <remarks>
-        /// Set <see cref="RefreshInterval"/> to -1 to disable auto <see cref="Refresh()"/>.
-        /// </remarks>
-        public int RefreshInterval
-        {
-            get
-            {
-                return m_refreshInterval;
-            }
-            set
-            {
-                if (value < 1)
-                    m_refreshInterval = -1;
-                else
-                    m_refreshInterval = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetadataFile"/> to be refreshed by the metadata provider.
-        /// </summary>
-        public MetadataFile Metadata
-        {
-            get
-            {
-                return m_metadata;
-            }
-            set
-            {
-                m_metadata = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// When overridden in a derived class, refreshes the <see cref="Metadata"/> from an external source.
-        /// </summary>
-        protected abstract void RefreshMetadata();
-
-        /// <summary>
-        /// Initializes the metadata provider.
-        /// </summary>
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            if (!m_initialized)
-            {
-                // Start refresh timer for auto-refresh.
-                if (Enabled && m_refreshInterval > 0)
-                {
-                    m_refreshTimer = new Timer(m_refreshInterval * 60000);
-                    m_refreshTimer.Elapsed += RefreshTimer_Elapsed;
-                    m_refreshTimer.Start();
-                }
-
-                // Initialize only once.
-                m_initialized = true;
-            }
-        }
-
-        /// <summary>
-        /// Saves metadata provider settings to the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["Enabled", true].Update(Enabled);
-                settings["RefreshTimeout", true].Update(m_refreshTimeout);
-                settings["RefreshInterval", true].Update(m_refreshInterval);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved metadata provider settings from the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("Enabled", Enabled, "True if this metadata provider is enabled; otherwise False.");
-                settings.Add("RefreshTimeout", m_refreshTimeout, "Number of seconds to wait for metadata refresh to complete.");
-                settings.Add("RefreshInterval", m_refreshInterval, "Interval in minutes at which the metadata is to be refreshed.");
-                Enabled = settings["Enabled"].ValueAs(Enabled);
-                RefreshTimeout = settings["RefreshTimeout"].ValueAs(m_refreshTimeout);
-                RefreshInterval = settings["RefreshInterval"].ValueAs(m_refreshInterval);
-            }
-        }
-
-        /// <summary>
-        /// Refreshes the <see cref="Metadata"/> from an external source.
-        /// </summary>
-        /// <returns>true if the <see cref="Metadata"/> is refreshed; otherwise false.</returns>
-        /// <exception cref="ArgumentNullException"><see cref="Metadata"/> is null.</exception>
-        public bool Refresh()
-        {
-            if (!Enabled || (m_refreshThread != null && m_refreshThread.IsAlive))
-                return false;
-
-            if (m_metadata == null)
-                throw new ArgumentNullException("Metadata");
-
-            m_refreshThread = new Thread(RefreshInternal);
-            m_refreshThread.Start();
-            if (m_refreshTimeout < 1)
-            {
-                // Wait indefinetely on the refresh.
-                m_refreshThread.Join(Timeout.Infinite);
-            }
-            else
-            {
-                // Wait for the specified time on refresh.
-                if (!m_refreshThread.Join(m_refreshTimeout * 1000))
-                {
-                    m_refreshThread.Abort();
-
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the metadata provider and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (!m_disposed)
-            {
-                try
-                {
-                    if (disposing)
-                    {
-                        if (m_refreshThread != null)
-                            m_refreshThread.Abort();
-
-                        if (m_refreshTimer != null)
-                        {
-                            m_refreshTimer.Elapsed -= RefreshTimer_Elapsed;
-                            m_refreshTimer.Dispose();
-                        }
-                    }
-                }
-                finally
-                {
-                    m_disposed = true;  // Prevent duplicate dispose.
-                    base.Dispose(disposing);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Raises the <see cref="MetadataRefreshStart"/> event.
-        /// </summary>
-        protected virtual void OnMetadataRefreshStart()
-        {
-            if (MetadataRefreshStart != null)
-                MetadataRefreshStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="MetadataRefreshComplete"/> event.
-        /// </summary>
-        protected virtual void OnMetadataRefreshComplete()
-        {
-            if (MetadataRefreshComplete != null)
-                MetadataRefreshComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="MetadataRefreshTimeout"/> event.
-        /// </summary>
-        protected virtual void OnMetadataRefreshTimeout()
-        {
-            if (MetadataRefreshTimeout != null)
-                MetadataRefreshTimeout(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="MetadataRefreshException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="MetadataRefreshException"/> event.</param>
-        protected virtual void OnMetadataRefreshException(Exception ex)
-        {
-            if (MetadataRefreshException != null)
-                MetadataRefreshException(this, new EventArgs<Exception>(ex));
-        }
-
-        private void RefreshInternal()
-        {
-            try
-            {
-                OnMetadataRefreshStart();
-                RefreshMetadata();
-                OnMetadataRefreshComplete();
-            }
-            catch (ThreadAbortException)
-            {
-                OnMetadataRefreshTimeout();
-            }
-            catch (Exception ex)
-            {
-                OnMetadataRefreshException(ex);
-            }
-        }
-
-        private void RefreshTimer_Elapsed(object sender, ElapsedEventArgs e)
-        {
-            Refresh();
-        }
-
-        #endregion
+        m_refreshInterval = -1;
+        m_refreshTimeout = 60;
+        PersistSettings = true;
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the number of seconds to wait for the <see cref="Refresh()"/> to complete.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="RefreshTimeout"/> to -1 to wait indefinitely on <see cref="Refresh()"/>.
+    /// </remarks>
+    public int RefreshTimeout
+    {
+        get => m_refreshTimeout;
+        set => m_refreshTimeout = value < 1 ? -1 : value;
+    }
+
+    /// <summary>
+    /// Gets or sets the interval in minutes at which the <see cref="Metadata"/> if to be refreshed automatically.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="RefreshInterval"/> to -1 to disable auto <see cref="Refresh()"/>.
+    /// </remarks>
+    public int RefreshInterval
+    {
+        get => m_refreshInterval;
+        set => m_refreshInterval = value < 1 ? -1 : value;
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetadataFile"/> to be refreshed by the metadata provider.
+    /// </summary>
+    public MetadataFile Metadata { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// When overridden in a derived class, refreshes the <see cref="Metadata"/> from an external source.
+    /// </summary>
+    protected abstract void RefreshMetadata();
+
+    /// <summary>
+    /// Initializes the metadata provider.
+    /// </summary>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        if (m_initialized)
+            return;
+        
+        // Start refresh timer for auto-refresh.
+        if (Enabled && m_refreshInterval > 0)
+        {
+            m_refreshTimer = new Timer(m_refreshInterval * 60000);
+            m_refreshTimer.Elapsed += RefreshTimer_Elapsed;
+            m_refreshTimer.Start();
+        }
+
+        // Initialize only once.
+        m_initialized = true;
+    }
+
+    /// <summary>
+    /// Saves metadata provider settings to the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(Enabled), true].Update(Enabled);
+        settings[nameof(RefreshTimeout), true].Update(m_refreshTimeout);
+        settings[nameof(RefreshInterval), true].Update(m_refreshInterval);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved metadata provider settings from the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(Enabled), Enabled, "True if this metadata provider is enabled; otherwise False.");
+        settings.Add(nameof(RefreshTimeout), m_refreshTimeout, "Number of seconds to wait for metadata refresh to complete.");
+        settings.Add(nameof(RefreshInterval), m_refreshInterval, "Interval in minutes at which the metadata is to be refreshed.");
+        
+        Enabled = settings[nameof(Enabled)].ValueAs(Enabled);
+        RefreshTimeout = settings[nameof(RefreshTimeout)].ValueAs(m_refreshTimeout);
+        RefreshInterval = settings[nameof(RefreshInterval)].ValueAs(m_refreshInterval);
+    }
+
+    /// <summary>
+    /// Refreshes the <see cref="Metadata"/> from an external source.
+    /// </summary>
+    /// <returns>true if the <see cref="Metadata"/> is refreshed; otherwise false.</returns>
+    /// <exception cref="ArgumentNullException"><see cref="Metadata"/> is null.</exception>
+    public bool Refresh()
+    {
+        if (!Enabled || (m_refreshThread is not null && m_refreshThread.IsAlive))
+            return false;
+
+        if (Metadata is null)
+            throw new ArgumentNullException(nameof(Metadata));
+
+        m_refreshThread = new Thread(RefreshInternal);
+        m_refreshThread.Start();
+
+        if (m_refreshTimeout < 1)
+        {
+            // Wait indefinitely on the refresh.
+            m_refreshThread.Join(Timeout.Infinite);
+        }
+        else
+        {
+            // Wait for the specified time on refresh.
+            if (m_refreshThread.Join(m_refreshTimeout * 1000))
+                return true;
+            
+            m_refreshThread.Abort();
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the metadata provider and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (m_disposed)
+            return;
+        
+        try
+        {
+            if (!disposing)
+                return;
+            
+            m_refreshThread?.Abort();
+
+            if (m_refreshTimer is not null)
+            {
+                m_refreshTimer.Elapsed -= RefreshTimer_Elapsed;
+                m_refreshTimer.Dispose();
+            }
+        }
+        finally
+        {
+            m_disposed = true;  // Prevent duplicate dispose.
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Raises the <see cref="MetadataRefreshStart"/> event.
+    /// </summary>
+    protected virtual void OnMetadataRefreshStart()
+    {
+        MetadataRefreshStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="MetadataRefreshComplete"/> event.
+    /// </summary>
+    protected virtual void OnMetadataRefreshComplete()
+    {
+        MetadataRefreshComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="MetadataRefreshTimeout"/> event.
+    /// </summary>
+    protected virtual void OnMetadataRefreshTimeout()
+    {
+        MetadataRefreshTimeout?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="MetadataRefreshException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="MetadataRefreshException"/> event.</param>
+    protected virtual void OnMetadataRefreshException(Exception ex)
+    {
+        MetadataRefreshException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    private void RefreshInternal()
+    {
+        try
+        {
+            OnMetadataRefreshStart();
+            RefreshMetadata();
+            OnMetadataRefreshComplete();
+        }
+        catch (ThreadAbortException)
+        {
+            OnMetadataRefreshTimeout();
+        }
+        catch (Exception ex)
+        {
+            OnMetadataRefreshException(ex);
+        }
+    }
+
+    private void RefreshTimer_Elapsed(object sender, ElapsedEventArgs e)
+    {
+        Refresh();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/MetadataProviders.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/MetadataProviders.cs
@@ -33,48 +33,47 @@
 using System;
 using GSF.Adapters;
 
-namespace GSF.Historian.MetadataProviders
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// A class that loads all <see cref="IMetadataProvider">Metadata Provider</see> adapters.
+/// </summary>
+/// <seealso cref="IMetadataProvider"/>
+public class MetadataProviders : AdapterLoader<IMetadataProvider>
 {
+    #region [ Methods ]
+
     /// <summary>
-    /// A class that loads all <see cref="IMetadataProvider">Metadata Provider</see> adapters.
+    /// <see cref="IMetadataProvider.Refresh()"/>es the <see cref="IMetadataProvider.Metadata"/> using all loaded metadata provider <see cref="AdapterLoader{T}.Adapters"/>.
     /// </summary>
-    /// <seealso cref="IMetadataProvider"/>
-    public class MetadataProviders : AdapterLoader<IMetadataProvider>
+    public void RefreshAll()
     {
-        #region [ Methods ]
-
-        /// <summary>
-        /// <see cref="IMetadataProvider.Refresh()"/>es the <see cref="IMetadataProvider.Metadata"/> using all loaded metadata provider <see cref="AdapterLoader{T}.Adapters"/>.
-        /// </summary>
-        public void RefreshAll()
-        {
-            OperationQueue.Enqueue(null);
-        }
-
-        /// <summary>
-        /// <see cref="IMetadataProvider.Refresh()"/>es the <see cref="IMetadataProvider.Metadata"/> using the specified <paramref name="provider"/> from the loaded metadata provider <see cref="AdapterLoader{T}.Adapters"/>.
-        /// </summary>
-        /// <param name="provider">Name of the <see cref="IMetadataProvider"/> to use for the <see cref="IMetadataProvider.Refresh()"/>.</param>
-        public void RefreshOne(string provider)
-        {
-            OperationQueue.Enqueue(provider);
-        }
-
-        /// <summary>
-        /// Executes <see cref="IMetadataProvider.Refresh()"/> on the specified metadata provider <paramref name="adapter"/>.
-        /// </summary>
-        /// <param name="adapter">An <see cref="IMetadataProvider"/> object.</param>
-        /// <param name="data"><see cref="System.Reflection.MemberInfo.Name"/> of the <paramref name="adapter"/>.</param>
-        protected override void ExecuteAdapterOperation(IMetadataProvider adapter, object data)
-        {
-            if (adapter.Enabled && 
-                (string.IsNullOrEmpty(Convert.ToString(data)) || 
-                 string.Compare(data.ToString(), adapter.GetType().Name, true) == 0))
-            {
-                adapter.Refresh();
-            }
-        }
-
-        #endregion        
+        OperationQueue.Enqueue(null);
     }
+
+    /// <summary>
+    /// <see cref="IMetadataProvider.Refresh()"/>es the <see cref="IMetadataProvider.Metadata"/> using the specified <paramref name="provider"/> from the loaded metadata provider <see cref="AdapterLoader{T}.Adapters"/>.
+    /// </summary>
+    /// <param name="provider">Name of the <see cref="IMetadataProvider"/> to use for the <see cref="IMetadataProvider.Refresh()"/>.</param>
+    public void RefreshOne(string provider)
+    {
+        OperationQueue.Enqueue(provider);
+    }
+
+    /// <summary>
+    /// Executes <see cref="IMetadataProvider.Refresh()"/> on the specified metadata provider <paramref name="adapter"/>.
+    /// </summary>
+    /// <param name="adapter">An <see cref="IMetadataProvider"/> object.</param>
+    /// <param name="data"><see cref="System.Reflection.MemberInfo.Name"/> of the <paramref name="adapter"/>.</param>
+    protected override void ExecuteAdapterOperation(IMetadataProvider adapter, object data)
+    {
+        if (adapter.Enabled && 
+            (string.IsNullOrEmpty(Convert.ToString(data)) || 
+             string.Compare(data.ToString(), adapter.GetType().Name, StringComparison.OrdinalIgnoreCase) == 0))
+        {
+            adapter.Refresh();
+        }
+    }
+
+    #endregion        
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/MetadataUpdater.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/MetadataUpdater.cs
@@ -40,431 +40,424 @@ using System.IO;
 using GSF.Historian.DataServices;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.MetadataProviders
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// A class that can update data in a <see cref="MetadataFile"/>.
+/// </summary>
+/// <seealso cref="MetadataFile"/>
+public class MetadataUpdater
 {
+
+    #region [ Constructors ]
+
     /// <summary>
-    /// A class that can update data in a <see cref="MetadataFile"/>.
+    /// Initializes a new instance of the <see cref="MetadataUpdater"/> class.
     /// </summary>
-    /// <seealso cref="MetadataFile"/>
-    public class MetadataUpdater
+    /// <param name="metadata"><see cref="MetadataFile"/> that is to be updated.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="metadata"/> is null</exception>
+    public MetadataUpdater(MetadataFile metadata)
     {
-        #region [ Members ]
-
-        // Fields
-        private readonly MetadataFile m_metadata;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MetadataUpdater"/> class.
-        /// </summary>
-        /// <param name="metadata"><see cref="MetadataFile"/> that is to be updated.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="metadata"/> is null</exception>
-        public MetadataUpdater(MetadataFile metadata)
-        {
-            m_metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets the <see cref="MetadataFile"/> to be updated.
-        /// </summary>
-        public MetadataFile Metadata => m_metadata;
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Updates the <see cref="Metadata"/> from <paramref name="tableData"/>
-        /// </summary>
-        /// <param name="tableData"><see cref="DataTable"/> containing the new metadata.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="tableData"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="tableData"/> does not contain 43 columns.</exception>
-        public void UpdateMetadata(DataTable tableData)
-        {
-            if (tableData is null)
-                throw new ArgumentNullException(nameof(tableData));
-
-            if (tableData.Rows[0].ItemArray.Length != 43)
-                throw new ArgumentException("tableData must contain 43 columns");
-
-            // Column 00: HistorianID
-            // Column 01: DataType
-            // Column 02: Name
-            // Column 03: Synonym1
-            // Column 04: Synonym2
-            // Column 05: Synonym3
-            // Column 06: Description
-            // Column 07: HardwareInfo
-            // Column 08: Remarks
-            // Column 09: PlantCode
-            // Column 10: UnitNumber
-            // Column 11: SystemName
-            // Column 12: SourceID
-            // Column 13: Enabled
-            // Column 14: ScanRate
-            // Column 15: CompressionMinTime
-            // Column 16: CompressionMaxTime
-            // Column 17: EngineeringUnits
-            // Column 18: LowWarning
-            // Column 19: HighWarning
-            // Column 20: LowAlarm
-            // Column 21: HighAlarm
-            // Column 22: LowRange
-            // Column 23: HighRange
-            // Column 24: CompressionLimit
-            // Column 25: ExceptionLimit
-            // Column 26: DisplayDigits
-            // Column 27: SetDescription
-            // Column 28: ClearDescription
-            // Column 29: AlarmState
-            // Column 30: ChangeSecurity
-            // Column 31: AccessSecurity
-            // Column 32: StepCheck
-            // Column 33: AlarmEnabled
-            // Column 34: AlarmFlags
-            // Column 35: AlarmDelay
-            // Column 36: AlarmToFile
-            // Column 37: AlarmByEmail
-            // Column 38: AlarmByPager
-            // Column 39: AlarmByPhone
-            // Column 40: AlarmEmails
-            // Column 41: AlarmPagers
-            // Column 42: AlarmPhones
-
-            MetadataRecord newMetadataRecord;
-
-            foreach (MetadataRecord existingMetadataRecord in m_metadata.Read())
-                existingMetadataRecord.GeneralFlags.Enabled = false;
-
-            foreach (DataRow row in tableData.Rows)
-            {
-                newMetadataRecord = new MetadataRecord(Convert.ToInt32(row[0]), MetadataFileLegacyMode.Enabled);
-               
-                if (!Convert.IsDBNull(row[1]))
-                    newMetadataRecord.GeneralFlags.DataType = (DataType)Convert.ToInt32(row[1]);
-                
-                if (!Convert.IsDBNull(row[2]))
-                    newMetadataRecord.Name = Convert.ToString(row[2]);
-                
-                if (!Convert.IsDBNull(row[3]))
-                    newMetadataRecord.Synonym1 = Convert.ToString(row[3]);
-                
-                if (!Convert.IsDBNull(row[4]))
-                    newMetadataRecord.Synonym2 = Convert.ToString(row[4]);
-                
-                if (!Convert.IsDBNull(row[5]))
-                    newMetadataRecord.Synonym3 = Convert.ToString(row[5]);
-                
-                if (!Convert.IsDBNull(row[6]))
-                    newMetadataRecord.Description = Convert.ToString(row[6]);
-                
-                if (!Convert.IsDBNull(row[7]))
-                    newMetadataRecord.HardwareInfo = Convert.ToString(row[7]);
-                
-                if (!Convert.IsDBNull(row[8]))
-                    newMetadataRecord.Remarks = Convert.ToString(row[8]);
-                
-                if (!Convert.IsDBNull(row[9]))
-                    newMetadataRecord.PlantCode = Convert.ToString(row[9]);
-                
-                if (!Convert.IsDBNull(row[10]))
-                    newMetadataRecord.UnitNumber = Convert.ToInt32(row[10]);
-                
-                if (!Convert.IsDBNull(row[11]))
-                    newMetadataRecord.SystemName = Convert.ToString(row[11]);
-                
-                if (!Convert.IsDBNull(row[12]))
-                    newMetadataRecord.SourceID = Convert.ToInt32(row[12]);
-                
-                if (!Convert.IsDBNull(row[13]))
-                    newMetadataRecord.GeneralFlags.Enabled = Convert.ToBoolean(row[13]);
-                
-                if (!Convert.IsDBNull(row[14]))
-                    newMetadataRecord.ScanRate = Convert.ToSingle(row[14]);
-                
-                if (!Convert.IsDBNull(row[15]))
-                    newMetadataRecord.CompressionMinTime = Convert.ToInt32(row[15]);
-                
-                if (!Convert.IsDBNull(row[16]))
-                    newMetadataRecord.CompressionMaxTime = Convert.ToInt32(row[16]);
-                
-                if (!Convert.IsDBNull(row[30]))
-                    newMetadataRecord.SecurityFlags.ChangeSecurity = Convert.ToInt32(row[30]);
-                
-                if (!Convert.IsDBNull(row[31]))
-                    newMetadataRecord.SecurityFlags.AccessSecurity = Convert.ToInt32(row[31]);
-                
-                if (!Convert.IsDBNull(row[32]))
-                    newMetadataRecord.GeneralFlags.StepCheck = Convert.ToBoolean(row[32]);
-                
-                if (!Convert.IsDBNull(row[33]))
-                    newMetadataRecord.GeneralFlags.AlarmEnabled = Convert.ToBoolean(row[33]);
-                
-                if (!Convert.IsDBNull(row[34]))
-                    newMetadataRecord.AlarmFlags.Value = Convert.ToInt32(row[34]);
-                
-                if (!Convert.IsDBNull(row[36]))
-                    newMetadataRecord.GeneralFlags.AlarmToFile = Convert.ToBoolean(row[36]);
-                
-                if (!Convert.IsDBNull(row[37]))
-                    newMetadataRecord.GeneralFlags.AlarmByEmail = Convert.ToBoolean(row[37]);
-                
-                if (!Convert.IsDBNull(row[38]))
-                    newMetadataRecord.GeneralFlags.AlarmByPager = Convert.ToBoolean(row[38]);
-                
-                if (!Convert.IsDBNull(row[39]))
-                    newMetadataRecord.GeneralFlags.AlarmByPhone = Convert.ToBoolean(row[39]);
-                
-                if (!Convert.IsDBNull(row[40]))
-                    newMetadataRecord.AlarmEmails = Convert.ToString(row[40]);
-                
-                if (!Convert.IsDBNull(row[41]))
-                    newMetadataRecord.AlarmPagers = Convert.ToString(row[41]);
-                
-                if (!Convert.IsDBNull(row[42]))
-                    newMetadataRecord.AlarmPhones = Convert.ToString(row[42]);
-                
-                if (newMetadataRecord.GeneralFlags.DataType == DataType.Analog)
-                {
-                    if (!Convert.IsDBNull(row[17]))
-                        newMetadataRecord.AnalogFields.EngineeringUnits = Convert.ToString(row[17]);
-                    
-                    if (!Convert.IsDBNull(row[18]))
-                        newMetadataRecord.AnalogFields.LowWarning = Convert.ToSingle(row[18]);
-                    
-                    if (!Convert.IsDBNull(row[19]))
-                        newMetadataRecord.AnalogFields.HighWarning = Convert.ToSingle(row[19]);
-                    
-                    if (!Convert.IsDBNull(row[20]))
-                        newMetadataRecord.AnalogFields.LowAlarm = Convert.ToSingle(row[20]);
-                    
-                    if (!Convert.IsDBNull(row[21]))
-                        newMetadataRecord.AnalogFields.HighAlarm = Convert.ToSingle(row[21]);
-                    
-                    if (!Convert.IsDBNull(row[22]))
-                        newMetadataRecord.AnalogFields.LowRange = Convert.ToSingle(row[22]);
-                    
-                    if (!Convert.IsDBNull(row[23]))
-                        newMetadataRecord.AnalogFields.HighRange = Convert.ToSingle(row[23]);
-                    
-                    if (!Convert.IsDBNull(row[24]))
-                        newMetadataRecord.AnalogFields.CompressionLimit = Convert.ToSingle(row[24]);
-                    
-                    if (!Convert.IsDBNull(row[25]))
-                        newMetadataRecord.AnalogFields.ExceptionLimit = Convert.ToSingle(row[25]);
-                    
-                    if (!Convert.IsDBNull(row[26]))
-                        newMetadataRecord.AnalogFields.DisplayDigits = Convert.ToInt32(row[26]);
-                    
-                    if (!Convert.IsDBNull(row[35]))
-                        newMetadataRecord.AnalogFields.AlarmDelay = Convert.ToSingle(row[35]);
-                }
-                else if (newMetadataRecord.GeneralFlags.DataType == DataType.Digital)
-                {
-                    if (!Convert.IsDBNull(row[27]))
-                        newMetadataRecord.DigitalFields.SetDescription = Convert.ToString(row[27]);
-                    
-                    if (!Convert.IsDBNull(row[28]))
-                        newMetadataRecord.DigitalFields.ClearDescription = Convert.ToString(row[28]);
-                    
-                    if (!Convert.IsDBNull(row[29]))
-                        newMetadataRecord.DigitalFields.AlarmState = Convert.ToInt32(row[29]);
-                    
-                    if (!Convert.IsDBNull(row[35]))
-                        newMetadataRecord.DigitalFields.AlarmDelay = Convert.ToSingle(row[35]);
-                }
-
-                m_metadata.Write(newMetadataRecord.HistorianID, newMetadataRecord);
-            }
-
-            m_metadata.Save();
-        }
-
-        /// <summary>
-        /// Updates the <see cref="Metadata"/> from <paramref name="readerData"/>
-        /// </summary>
-        /// <param name="readerData"><see cref="IDataReader"/> providing the new metadata.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="readerData"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="readerData"/> does not contain 43 columns.</exception>
-        public void UpdateMetadata(IDataReader readerData)
-        {
-            if (readerData is null)
-                throw new ArgumentNullException(nameof(readerData));
-
-            if (readerData.FieldCount != 43)
-                throw new ArgumentException("readerData must contain 43 columns");
-
-            foreach (MetadataRecord existingMetadataRecord in m_metadata.Read())
-                existingMetadataRecord.GeneralFlags.Enabled = false;
-
-            while (readerData.Read())
-            {
-                MetadataRecord newMetadataRecord = new MetadataRecord(Convert.ToInt32(readerData[0]), m_metadata.LegacyMode);
-
-                if (!Convert.IsDBNull(readerData[1]))
-                    newMetadataRecord.GeneralFlags.DataType = (DataType)Convert.ToInt32(readerData[1]);
-                
-                if (!Convert.IsDBNull(readerData[2]))
-                    newMetadataRecord.Name = Convert.ToString(readerData[2]);
-                
-                if (!Convert.IsDBNull(readerData[3]))
-                    newMetadataRecord.Synonym1 = Convert.ToString(readerData[3]);
-                
-                if (!Convert.IsDBNull(readerData[4]))
-                    newMetadataRecord.Synonym2 = Convert.ToString(readerData[4]);
-                
-                if (!Convert.IsDBNull(readerData[5]))
-                    newMetadataRecord.Synonym3 = Convert.ToString(readerData[5]);
-                
-                if (!Convert.IsDBNull(readerData[6]))
-                    newMetadataRecord.Description = Convert.ToString(readerData[6]);
-                
-                if (!Convert.IsDBNull(readerData[7]))
-                    newMetadataRecord.HardwareInfo = Convert.ToString(readerData[7]);
-                
-                if (!Convert.IsDBNull(readerData[8]))
-                    newMetadataRecord.Remarks = Convert.ToString(readerData[8]);
-                
-                if (!Convert.IsDBNull(readerData[9]))
-                    newMetadataRecord.PlantCode = Convert.ToString(readerData[9]);
-                
-                if (!Convert.IsDBNull(readerData[10]))
-                    newMetadataRecord.UnitNumber = Convert.ToInt32(readerData[10]);
-                
-                if (!Convert.IsDBNull(readerData[11]))
-                    newMetadataRecord.SystemName = Convert.ToString(readerData[11]);
-                
-                if (!Convert.IsDBNull(readerData[12]))
-                    newMetadataRecord.SourceID = Convert.ToInt32(readerData[12]);
-                
-                if (!Convert.IsDBNull(readerData[13]))
-                    newMetadataRecord.GeneralFlags.Enabled = Convert.ToBoolean(readerData[13]);
-                
-                if (!Convert.IsDBNull(readerData[14]))
-                    newMetadataRecord.ScanRate = Convert.ToSingle(readerData[14]);
-                
-                if (!Convert.IsDBNull(readerData[15]))
-                    newMetadataRecord.CompressionMinTime = Convert.ToInt32(readerData[15]);
-                
-                if (!Convert.IsDBNull(readerData[16]))
-                    newMetadataRecord.CompressionMaxTime = Convert.ToInt32(readerData[16]);
-                
-                if (!Convert.IsDBNull(readerData[30]))
-                    newMetadataRecord.SecurityFlags.ChangeSecurity = Convert.ToInt32(readerData[30]);
-                
-                if (!Convert.IsDBNull(readerData[31]))
-                    newMetadataRecord.SecurityFlags.AccessSecurity = Convert.ToInt32(readerData[31]);
-                
-                if (!Convert.IsDBNull(readerData[32]))
-                    newMetadataRecord.GeneralFlags.StepCheck = Convert.ToBoolean(readerData[32]);
-                
-                if (!Convert.IsDBNull(readerData[33]))
-                    newMetadataRecord.GeneralFlags.AlarmEnabled = Convert.ToBoolean(readerData[33]);
-                
-                if (!Convert.IsDBNull(readerData[34]))
-                    newMetadataRecord.AlarmFlags.Value = Convert.ToInt32(readerData[34]);
-                
-                if (!Convert.IsDBNull(readerData[36]))
-                    newMetadataRecord.GeneralFlags.AlarmToFile = Convert.ToBoolean(readerData[36]);
-                
-                if (!Convert.IsDBNull(readerData[37]))
-                    newMetadataRecord.GeneralFlags.AlarmByEmail = Convert.ToBoolean(readerData[37]);
-                
-                if (!Convert.IsDBNull(readerData[38]))
-                    newMetadataRecord.GeneralFlags.AlarmByPager = Convert.ToBoolean(readerData[38]);
-                
-                if (!Convert.IsDBNull(readerData[39]))
-                    newMetadataRecord.GeneralFlags.AlarmByPhone = Convert.ToBoolean(readerData[39]);
-                
-                if (!Convert.IsDBNull(readerData[40]))
-                    newMetadataRecord.AlarmEmails = Convert.ToString(readerData[40]);
-                
-                if (!Convert.IsDBNull(readerData[41]))
-                    newMetadataRecord.AlarmPagers = Convert.ToString(readerData[41]);
-                
-                if (!Convert.IsDBNull(readerData[42]))
-                    newMetadataRecord.AlarmPhones = Convert.ToString(readerData[42]);
-
-                if (newMetadataRecord.GeneralFlags.DataType == DataType.Analog)
-                {
-                    if (!Convert.IsDBNull(readerData[17]))
-                        newMetadataRecord.AnalogFields.EngineeringUnits = Convert.ToString(readerData[17]);
-                    
-                    if (!Convert.IsDBNull(readerData[18]))
-                        newMetadataRecord.AnalogFields.LowWarning = Convert.ToSingle(readerData[18]);
-                    
-                    if (!Convert.IsDBNull(readerData[19]))
-                        newMetadataRecord.AnalogFields.HighWarning = Convert.ToSingle(readerData[19]);
-                    
-                    if (!Convert.IsDBNull(readerData[20]))
-                        newMetadataRecord.AnalogFields.LowAlarm = Convert.ToSingle(readerData[20]);
-                    
-                    if (!Convert.IsDBNull(readerData[21]))
-                        newMetadataRecord.AnalogFields.HighAlarm = Convert.ToSingle(readerData[21]);
-                    
-                    if (!Convert.IsDBNull(readerData[22]))
-                        newMetadataRecord.AnalogFields.LowRange = Convert.ToSingle(readerData[22]);
-                    
-                    if (!Convert.IsDBNull(readerData[23]))
-                        newMetadataRecord.AnalogFields.HighRange = Convert.ToSingle(readerData[23]);
-                    
-                    if (!Convert.IsDBNull(readerData[24]))
-                        newMetadataRecord.AnalogFields.CompressionLimit = Convert.ToSingle(readerData[24]);
-                    
-                    if (!Convert.IsDBNull(readerData[25]))
-                        newMetadataRecord.AnalogFields.ExceptionLimit = Convert.ToSingle(readerData[25]);
-                    
-                    if (!Convert.IsDBNull(readerData[26]))
-                        newMetadataRecord.AnalogFields.DisplayDigits = Convert.ToInt32(readerData[26]);
-                    
-                    if (!Convert.IsDBNull(readerData[35]))
-                        newMetadataRecord.AnalogFields.AlarmDelay = Convert.ToSingle(readerData[35]);
-                }
-                else if (newMetadataRecord.GeneralFlags.DataType == DataType.Digital)
-                {
-                    if (!Convert.IsDBNull(readerData[27]))
-                        newMetadataRecord.DigitalFields.SetDescription = Convert.ToString(readerData[27]);
-                    
-                    if (!Convert.IsDBNull(readerData[28]))
-                        newMetadataRecord.DigitalFields.ClearDescription = Convert.ToString(readerData[28]);
-                    
-                    if (!Convert.IsDBNull(readerData[29]))
-                        newMetadataRecord.DigitalFields.AlarmState = Convert.ToInt32(readerData[29]);
-                    
-                    if (!Convert.IsDBNull(readerData[35]))
-                        newMetadataRecord.DigitalFields.AlarmDelay = Convert.ToSingle(readerData[35]);
-                }
-
-                m_metadata.Write(newMetadataRecord.HistorianID, newMetadataRecord);
-            }
-
-            m_metadata.Save();
-        }
-
-        /// <summary>
-        /// Updates the <see cref="Metadata"/> from <paramref name="streamData"/>
-        /// </summary>
-        /// <param name="streamData"><see cref="Stream"/> containing serialized <see cref="SerializableMetadata"/>.</param>
-        /// <param name="dataFormat"><see cref="SerializationFormat"/> in which the <see cref="SerializableMetadata"/> was serialized to <paramref name="streamData"/>.</param>
-        public void UpdateMetadata(Stream streamData, SerializationFormat dataFormat)
-        {
-            // Deserialize serialized metadata.
-            SerializableMetadata deserializedMetadata = Serialization.Deserialize<SerializableMetadata>(streamData, dataFormat);
-
-            // Update metadata from the deserialized metadata.
-            foreach (SerializableMetadataRecord deserializedMetadataRecord in deserializedMetadata.MetadataRecords)
-                m_metadata.Write(deserializedMetadataRecord.HistorianID, deserializedMetadataRecord.Deflate());
-
-            m_metadata.Save();
-        }
-
-        #endregion
+        Metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets the <see cref="MetadataFile"/> to be updated.
+    /// </summary>
+    public MetadataFile Metadata { get; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Updates the <see cref="Metadata"/> from <paramref name="tableData"/>
+    /// </summary>
+    /// <param name="tableData"><see cref="DataTable"/> containing the new metadata.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="tableData"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="tableData"/> does not contain 43 columns.</exception>
+    public void UpdateMetadata(DataTable tableData)
+    {
+        if (tableData is null)
+            throw new ArgumentNullException(nameof(tableData));
+
+        if (tableData.Rows[0].ItemArray.Length != 43)
+            throw new ArgumentException("tableData must contain 43 columns");
+
+        // Column 00: HistorianID
+        // Column 01: DataType
+        // Column 02: Name
+        // Column 03: Synonym1
+        // Column 04: Synonym2
+        // Column 05: Synonym3
+        // Column 06: Description
+        // Column 07: HardwareInfo
+        // Column 08: Remarks
+        // Column 09: PlantCode
+        // Column 10: UnitNumber
+        // Column 11: SystemName
+        // Column 12: SourceID
+        // Column 13: Enabled
+        // Column 14: ScanRate
+        // Column 15: CompressionMinTime
+        // Column 16: CompressionMaxTime
+        // Column 17: EngineeringUnits
+        // Column 18: LowWarning
+        // Column 19: HighWarning
+        // Column 20: LowAlarm
+        // Column 21: HighAlarm
+        // Column 22: LowRange
+        // Column 23: HighRange
+        // Column 24: CompressionLimit
+        // Column 25: ExceptionLimit
+        // Column 26: DisplayDigits
+        // Column 27: SetDescription
+        // Column 28: ClearDescription
+        // Column 29: AlarmState
+        // Column 30: ChangeSecurity
+        // Column 31: AccessSecurity
+        // Column 32: StepCheck
+        // Column 33: AlarmEnabled
+        // Column 34: AlarmFlags
+        // Column 35: AlarmDelay
+        // Column 36: AlarmToFile
+        // Column 37: AlarmByEmail
+        // Column 38: AlarmByPager
+        // Column 39: AlarmByPhone
+        // Column 40: AlarmEmails
+        // Column 41: AlarmPagers
+        // Column 42: AlarmPhones
+
+        MetadataRecord newMetadataRecord;
+
+        foreach (MetadataRecord existingMetadataRecord in Metadata.Read())
+            existingMetadataRecord.GeneralFlags.Enabled = false;
+
+        foreach (DataRow row in tableData.Rows)
+        {
+            newMetadataRecord = new MetadataRecord(Convert.ToInt32(row[0]), MetadataFileLegacyMode.Enabled);
+               
+            if (!Convert.IsDBNull(row[1]))
+                newMetadataRecord.GeneralFlags.DataType = (DataType)Convert.ToInt32(row[1]);
+                
+            if (!Convert.IsDBNull(row[2]))
+                newMetadataRecord.Name = Convert.ToString(row[2]);
+                
+            if (!Convert.IsDBNull(row[3]))
+                newMetadataRecord.Synonym1 = Convert.ToString(row[3]);
+                
+            if (!Convert.IsDBNull(row[4]))
+                newMetadataRecord.Synonym2 = Convert.ToString(row[4]);
+                
+            if (!Convert.IsDBNull(row[5]))
+                newMetadataRecord.Synonym3 = Convert.ToString(row[5]);
+                
+            if (!Convert.IsDBNull(row[6]))
+                newMetadataRecord.Description = Convert.ToString(row[6]);
+                
+            if (!Convert.IsDBNull(row[7]))
+                newMetadataRecord.HardwareInfo = Convert.ToString(row[7]);
+                
+            if (!Convert.IsDBNull(row[8]))
+                newMetadataRecord.Remarks = Convert.ToString(row[8]);
+                
+            if (!Convert.IsDBNull(row[9]))
+                newMetadataRecord.PlantCode = Convert.ToString(row[9]);
+                
+            if (!Convert.IsDBNull(row[10]))
+                newMetadataRecord.UnitNumber = Convert.ToInt32(row[10]);
+                
+            if (!Convert.IsDBNull(row[11]))
+                newMetadataRecord.SystemName = Convert.ToString(row[11]);
+                
+            if (!Convert.IsDBNull(row[12]))
+                newMetadataRecord.SourceID = Convert.ToInt32(row[12]);
+                
+            if (!Convert.IsDBNull(row[13]))
+                newMetadataRecord.GeneralFlags.Enabled = Convert.ToBoolean(row[13]);
+                
+            if (!Convert.IsDBNull(row[14]))
+                newMetadataRecord.ScanRate = Convert.ToSingle(row[14]);
+                
+            if (!Convert.IsDBNull(row[15]))
+                newMetadataRecord.CompressionMinTime = Convert.ToInt32(row[15]);
+                
+            if (!Convert.IsDBNull(row[16]))
+                newMetadataRecord.CompressionMaxTime = Convert.ToInt32(row[16]);
+                
+            if (!Convert.IsDBNull(row[30]))
+                newMetadataRecord.SecurityFlags.ChangeSecurity = Convert.ToInt32(row[30]);
+                
+            if (!Convert.IsDBNull(row[31]))
+                newMetadataRecord.SecurityFlags.AccessSecurity = Convert.ToInt32(row[31]);
+                
+            if (!Convert.IsDBNull(row[32]))
+                newMetadataRecord.GeneralFlags.StepCheck = Convert.ToBoolean(row[32]);
+                
+            if (!Convert.IsDBNull(row[33]))
+                newMetadataRecord.GeneralFlags.AlarmEnabled = Convert.ToBoolean(row[33]);
+                
+            if (!Convert.IsDBNull(row[34]))
+                newMetadataRecord.AlarmFlags.Value = Convert.ToInt32(row[34]);
+                
+            if (!Convert.IsDBNull(row[36]))
+                newMetadataRecord.GeneralFlags.AlarmToFile = Convert.ToBoolean(row[36]);
+                
+            if (!Convert.IsDBNull(row[37]))
+                newMetadataRecord.GeneralFlags.AlarmByEmail = Convert.ToBoolean(row[37]);
+                
+            if (!Convert.IsDBNull(row[38]))
+                newMetadataRecord.GeneralFlags.AlarmByPager = Convert.ToBoolean(row[38]);
+                
+            if (!Convert.IsDBNull(row[39]))
+                newMetadataRecord.GeneralFlags.AlarmByPhone = Convert.ToBoolean(row[39]);
+                
+            if (!Convert.IsDBNull(row[40]))
+                newMetadataRecord.AlarmEmails = Convert.ToString(row[40]);
+                
+            if (!Convert.IsDBNull(row[41]))
+                newMetadataRecord.AlarmPagers = Convert.ToString(row[41]);
+                
+            if (!Convert.IsDBNull(row[42]))
+                newMetadataRecord.AlarmPhones = Convert.ToString(row[42]);
+                
+            if (newMetadataRecord.GeneralFlags.DataType == DataType.Analog)
+            {
+                if (!Convert.IsDBNull(row[17]))
+                    newMetadataRecord.AnalogFields.EngineeringUnits = Convert.ToString(row[17]);
+                    
+                if (!Convert.IsDBNull(row[18]))
+                    newMetadataRecord.AnalogFields.LowWarning = Convert.ToSingle(row[18]);
+                    
+                if (!Convert.IsDBNull(row[19]))
+                    newMetadataRecord.AnalogFields.HighWarning = Convert.ToSingle(row[19]);
+                    
+                if (!Convert.IsDBNull(row[20]))
+                    newMetadataRecord.AnalogFields.LowAlarm = Convert.ToSingle(row[20]);
+                    
+                if (!Convert.IsDBNull(row[21]))
+                    newMetadataRecord.AnalogFields.HighAlarm = Convert.ToSingle(row[21]);
+                    
+                if (!Convert.IsDBNull(row[22]))
+                    newMetadataRecord.AnalogFields.LowRange = Convert.ToSingle(row[22]);
+                    
+                if (!Convert.IsDBNull(row[23]))
+                    newMetadataRecord.AnalogFields.HighRange = Convert.ToSingle(row[23]);
+                    
+                if (!Convert.IsDBNull(row[24]))
+                    newMetadataRecord.AnalogFields.CompressionLimit = Convert.ToSingle(row[24]);
+                    
+                if (!Convert.IsDBNull(row[25]))
+                    newMetadataRecord.AnalogFields.ExceptionLimit = Convert.ToSingle(row[25]);
+                    
+                if (!Convert.IsDBNull(row[26]))
+                    newMetadataRecord.AnalogFields.DisplayDigits = Convert.ToInt32(row[26]);
+                    
+                if (!Convert.IsDBNull(row[35]))
+                    newMetadataRecord.AnalogFields.AlarmDelay = Convert.ToSingle(row[35]);
+            }
+            else if (newMetadataRecord.GeneralFlags.DataType == DataType.Digital)
+            {
+                if (!Convert.IsDBNull(row[27]))
+                    newMetadataRecord.DigitalFields.SetDescription = Convert.ToString(row[27]);
+                    
+                if (!Convert.IsDBNull(row[28]))
+                    newMetadataRecord.DigitalFields.ClearDescription = Convert.ToString(row[28]);
+                    
+                if (!Convert.IsDBNull(row[29]))
+                    newMetadataRecord.DigitalFields.AlarmState = Convert.ToInt32(row[29]);
+                    
+                if (!Convert.IsDBNull(row[35]))
+                    newMetadataRecord.DigitalFields.AlarmDelay = Convert.ToSingle(row[35]);
+            }
+
+            Metadata.Write(newMetadataRecord.HistorianID, newMetadataRecord);
+        }
+
+        Metadata.Save();
+    }
+
+    /// <summary>
+    /// Updates the <see cref="Metadata"/> from <paramref name="readerData"/>
+    /// </summary>
+    /// <param name="readerData"><see cref="IDataReader"/> providing the new metadata.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="readerData"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="readerData"/> does not contain 43 columns.</exception>
+    public void UpdateMetadata(IDataReader readerData)
+    {
+        if (readerData is null)
+            throw new ArgumentNullException(nameof(readerData));
+
+        if (readerData.FieldCount != 43)
+            throw new ArgumentException("readerData must contain 43 columns");
+
+        foreach (MetadataRecord existingMetadataRecord in Metadata.Read())
+            existingMetadataRecord.GeneralFlags.Enabled = false;
+
+        while (readerData.Read())
+        {
+            MetadataRecord newMetadataRecord = new(Convert.ToInt32(readerData[0]), Metadata.LegacyMode);
+
+            if (!Convert.IsDBNull(readerData[1]))
+                newMetadataRecord.GeneralFlags.DataType = (DataType)Convert.ToInt32(readerData[1]);
+                
+            if (!Convert.IsDBNull(readerData[2]))
+                newMetadataRecord.Name = Convert.ToString(readerData[2]);
+                
+            if (!Convert.IsDBNull(readerData[3]))
+                newMetadataRecord.Synonym1 = Convert.ToString(readerData[3]);
+                
+            if (!Convert.IsDBNull(readerData[4]))
+                newMetadataRecord.Synonym2 = Convert.ToString(readerData[4]);
+                
+            if (!Convert.IsDBNull(readerData[5]))
+                newMetadataRecord.Synonym3 = Convert.ToString(readerData[5]);
+                
+            if (!Convert.IsDBNull(readerData[6]))
+                newMetadataRecord.Description = Convert.ToString(readerData[6]);
+                
+            if (!Convert.IsDBNull(readerData[7]))
+                newMetadataRecord.HardwareInfo = Convert.ToString(readerData[7]);
+                
+            if (!Convert.IsDBNull(readerData[8]))
+                newMetadataRecord.Remarks = Convert.ToString(readerData[8]);
+                
+            if (!Convert.IsDBNull(readerData[9]))
+                newMetadataRecord.PlantCode = Convert.ToString(readerData[9]);
+                
+            if (!Convert.IsDBNull(readerData[10]))
+                newMetadataRecord.UnitNumber = Convert.ToInt32(readerData[10]);
+                
+            if (!Convert.IsDBNull(readerData[11]))
+                newMetadataRecord.SystemName = Convert.ToString(readerData[11]);
+                
+            if (!Convert.IsDBNull(readerData[12]))
+                newMetadataRecord.SourceID = Convert.ToInt32(readerData[12]);
+                
+            if (!Convert.IsDBNull(readerData[13]))
+                newMetadataRecord.GeneralFlags.Enabled = Convert.ToBoolean(readerData[13]);
+                
+            if (!Convert.IsDBNull(readerData[14]))
+                newMetadataRecord.ScanRate = Convert.ToSingle(readerData[14]);
+                
+            if (!Convert.IsDBNull(readerData[15]))
+                newMetadataRecord.CompressionMinTime = Convert.ToInt32(readerData[15]);
+                
+            if (!Convert.IsDBNull(readerData[16]))
+                newMetadataRecord.CompressionMaxTime = Convert.ToInt32(readerData[16]);
+                
+            if (!Convert.IsDBNull(readerData[30]))
+                newMetadataRecord.SecurityFlags.ChangeSecurity = Convert.ToInt32(readerData[30]);
+                
+            if (!Convert.IsDBNull(readerData[31]))
+                newMetadataRecord.SecurityFlags.AccessSecurity = Convert.ToInt32(readerData[31]);
+                
+            if (!Convert.IsDBNull(readerData[32]))
+                newMetadataRecord.GeneralFlags.StepCheck = Convert.ToBoolean(readerData[32]);
+                
+            if (!Convert.IsDBNull(readerData[33]))
+                newMetadataRecord.GeneralFlags.AlarmEnabled = Convert.ToBoolean(readerData[33]);
+                
+            if (!Convert.IsDBNull(readerData[34]))
+                newMetadataRecord.AlarmFlags.Value = Convert.ToInt32(readerData[34]);
+                
+            if (!Convert.IsDBNull(readerData[36]))
+                newMetadataRecord.GeneralFlags.AlarmToFile = Convert.ToBoolean(readerData[36]);
+                
+            if (!Convert.IsDBNull(readerData[37]))
+                newMetadataRecord.GeneralFlags.AlarmByEmail = Convert.ToBoolean(readerData[37]);
+                
+            if (!Convert.IsDBNull(readerData[38]))
+                newMetadataRecord.GeneralFlags.AlarmByPager = Convert.ToBoolean(readerData[38]);
+                
+            if (!Convert.IsDBNull(readerData[39]))
+                newMetadataRecord.GeneralFlags.AlarmByPhone = Convert.ToBoolean(readerData[39]);
+                
+            if (!Convert.IsDBNull(readerData[40]))
+                newMetadataRecord.AlarmEmails = Convert.ToString(readerData[40]);
+                
+            if (!Convert.IsDBNull(readerData[41]))
+                newMetadataRecord.AlarmPagers = Convert.ToString(readerData[41]);
+                
+            if (!Convert.IsDBNull(readerData[42]))
+                newMetadataRecord.AlarmPhones = Convert.ToString(readerData[42]);
+
+            if (newMetadataRecord.GeneralFlags.DataType == DataType.Analog)
+            {
+                if (!Convert.IsDBNull(readerData[17]))
+                    newMetadataRecord.AnalogFields.EngineeringUnits = Convert.ToString(readerData[17]);
+                    
+                if (!Convert.IsDBNull(readerData[18]))
+                    newMetadataRecord.AnalogFields.LowWarning = Convert.ToSingle(readerData[18]);
+                    
+                if (!Convert.IsDBNull(readerData[19]))
+                    newMetadataRecord.AnalogFields.HighWarning = Convert.ToSingle(readerData[19]);
+                    
+                if (!Convert.IsDBNull(readerData[20]))
+                    newMetadataRecord.AnalogFields.LowAlarm = Convert.ToSingle(readerData[20]);
+                    
+                if (!Convert.IsDBNull(readerData[21]))
+                    newMetadataRecord.AnalogFields.HighAlarm = Convert.ToSingle(readerData[21]);
+                    
+                if (!Convert.IsDBNull(readerData[22]))
+                    newMetadataRecord.AnalogFields.LowRange = Convert.ToSingle(readerData[22]);
+                    
+                if (!Convert.IsDBNull(readerData[23]))
+                    newMetadataRecord.AnalogFields.HighRange = Convert.ToSingle(readerData[23]);
+                    
+                if (!Convert.IsDBNull(readerData[24]))
+                    newMetadataRecord.AnalogFields.CompressionLimit = Convert.ToSingle(readerData[24]);
+                    
+                if (!Convert.IsDBNull(readerData[25]))
+                    newMetadataRecord.AnalogFields.ExceptionLimit = Convert.ToSingle(readerData[25]);
+                    
+                if (!Convert.IsDBNull(readerData[26]))
+                    newMetadataRecord.AnalogFields.DisplayDigits = Convert.ToInt32(readerData[26]);
+                    
+                if (!Convert.IsDBNull(readerData[35]))
+                    newMetadataRecord.AnalogFields.AlarmDelay = Convert.ToSingle(readerData[35]);
+            }
+            else if (newMetadataRecord.GeneralFlags.DataType == DataType.Digital)
+            {
+                if (!Convert.IsDBNull(readerData[27]))
+                    newMetadataRecord.DigitalFields.SetDescription = Convert.ToString(readerData[27]);
+                    
+                if (!Convert.IsDBNull(readerData[28]))
+                    newMetadataRecord.DigitalFields.ClearDescription = Convert.ToString(readerData[28]);
+                    
+                if (!Convert.IsDBNull(readerData[29]))
+                    newMetadataRecord.DigitalFields.AlarmState = Convert.ToInt32(readerData[29]);
+                    
+                if (!Convert.IsDBNull(readerData[35]))
+                    newMetadataRecord.DigitalFields.AlarmDelay = Convert.ToSingle(readerData[35]);
+            }
+
+            Metadata.Write(newMetadataRecord.HistorianID, newMetadataRecord);
+        }
+
+        Metadata.Save();
+    }
+
+    /// <summary>
+    /// Updates the <see cref="Metadata"/> from <paramref name="streamData"/>
+    /// </summary>
+    /// <param name="streamData"><see cref="Stream"/> containing serialized <see cref="SerializableMetadata"/>.</param>
+    /// <param name="dataFormat"><see cref="SerializationFormat"/> in which the <see cref="SerializableMetadata"/> was serialized to <paramref name="streamData"/>.</param>
+    public void UpdateMetadata(Stream streamData, SerializationFormat dataFormat)
+    {
+        // Deserialize serialized metadata.
+        SerializableMetadata deserializedMetadata = Serialization.Deserialize<SerializableMetadata>(streamData, dataFormat);
+
+        // Update metadata from the deserialized metadata.
+        foreach (SerializableMetadataRecord deserializedMetadataRecord in deserializedMetadata.MetadataRecords)
+            Metadata.Write(deserializedMetadataRecord.HistorianID, deserializedMetadataRecord.Deflate());
+
+        Metadata.Save();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian.MetadataProviders
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// Contains classes that allow the historian to collect its required point metadata definitions from a variety of sources.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains classes that allow the historian to collect its required point metadata definitions from a variety of sources.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/OleDbMetadataProvider.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/OleDbMetadataProvider.cs
@@ -36,136 +36,112 @@ using System.Data.OleDb;
 using GSF.Configuration;
 using GSF.Data;
 
-namespace GSF.Historian.MetadataProviders
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// Represents a provider of data to a <see cref="GSF.Historian.Files.MetadataFile"/> from any OLE DB data store.
+/// </summary>
+/// <seealso cref="MetadataUpdater"/>
+public class OleDbMetadataProvider : MetadataProviderBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a provider of data to a <see cref="GSF.Historian.Files.MetadataFile"/> from any OLE DB data store.
+    /// Initializes a new instance of the <see cref="OleDbMetadataProvider"/> class.
     /// </summary>
-    /// <seealso cref="MetadataUpdater"/>
-    public class OleDbMetadataProvider : MetadataProviderBase
+    public OleDbMetadataProvider()
     {
-        #region [ Members ]
-
-        // Fields
-        private string m_connectionString;
-        private string m_selectString;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OleDbMetadataProvider"/> class.
-        /// </summary>
-        public OleDbMetadataProvider()
-        {
-            m_connectionString = string.Empty;
-            m_selectString = string.Empty;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the connection string for connecting to the OLE DB data store of metadata.
-        /// </summary>
-        public string ConnectionString
-        {
-            get
-            {
-                return m_connectionString;
-            }
-            set
-            {
-                m_connectionString = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the SELECT statement for retrieving metadata from the OLE DB data store.
-        /// </summary>
-        public string SelectString
-        {
-            get
-            {
-                return m_selectString;
-            }
-            set
-            {
-                m_selectString = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Saves <see cref="OleDbMetadataProvider"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["ConnectionString", true].Update(m_connectionString);
-                settings["SelectString", true].Update(m_selectString);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved <see cref="OleDbMetadataProvider"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("ConnectionString", m_connectionString, "Connection string for connecting to the OLE DB data store of metadata.");
-                settings.Add("SelectString", m_selectString, "SELECT statement for retrieving metadata from the OLE DB data store.");
-                ConnectionString = settings["ConnectionString"].ValueAs(m_connectionString);
-                SelectString = settings["SelectString"].ValueAs(m_selectString);
-            }
-        }
-
-        /// <summary>
-        /// Refreshes the <see cref="MetadataProviderBase.Metadata"/> from an OLE DB data store.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><see cref="ConnectionString"/> or <see cref="SelectString"/> is set to a null or empty string.</exception>
-        protected override void RefreshMetadata()
-        {
-            if (string.IsNullOrEmpty(m_connectionString))
-                throw new ArgumentNullException("ConnectionString");
-
-            if (string.IsNullOrEmpty(m_selectString))
-                throw new ArgumentNullException("SelectString");
-
-            OleDbConnection connection = new OleDbConnection(m_connectionString);
-
-            try
-            {
-                // Open OleDb connection.
-                connection.Open();
-
-                // Update existing metadata.
-                MetadataUpdater metadataUpdater = new MetadataUpdater(Metadata);
-                metadataUpdater.UpdateMetadata(connection.ExecuteReader(m_selectString));
-            }
-            finally
-            {
-                if (connection != null)
-                    connection.Dispose();
-            }
-        }
-
-        #endregion
+        ConnectionString = string.Empty;
+        SelectString = string.Empty;
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the connection string for connecting to the OLE DB data store of metadata.
+    /// </summary>
+    public string ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SELECT statement for retrieving metadata from the OLE DB data store.
+    /// </summary>
+    public string SelectString { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Saves <see cref="OleDbMetadataProvider"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(ConnectionString), true].Update(ConnectionString);
+        settings[nameof(SelectString), true].Update(SelectString);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved <see cref="OleDbMetadataProvider"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(ConnectionString), ConnectionString, "Connection string for connecting to the OLE DB data store of metadata.");
+        settings.Add(nameof(SelectString), SelectString, "SELECT statement for retrieving metadata from the OLE DB data store.");
+        
+        ConnectionString = settings[nameof(ConnectionString)].ValueAs(ConnectionString);
+        SelectString = settings[nameof(SelectString)].ValueAs(SelectString);
+    }
+
+    /// <summary>
+    /// Refreshes the <see cref="MetadataProviderBase.Metadata"/> from an OLE DB data store.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><see cref="ConnectionString"/> or <see cref="SelectString"/> is set to a null or empty string.</exception>
+    protected override void RefreshMetadata()
+    {
+        if (string.IsNullOrEmpty(ConnectionString))
+            throw new ArgumentNullException(nameof(ConnectionString));
+
+        if (string.IsNullOrEmpty(SelectString))
+            throw new ArgumentNullException(nameof(SelectString));
+
+        OleDbConnection connection = new(ConnectionString);
+
+        try
+        {
+            // Open OleDb connection.
+            connection.Open();
+
+            // Update existing metadata.
+            MetadataUpdater metadataUpdater = new(Metadata);
+            metadataUpdater.UpdateMetadata(connection.ExecuteReader(SelectString));
+        }
+        finally
+        {
+            connection?.Dispose();
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/MetadataProviders/RestWebServiceMetadataProvider.cs
+++ b/Source/Libraries/GSF.Historian/MetadataProviders/RestWebServiceMetadataProvider.cs
@@ -36,137 +36,112 @@ using System.IO;
 using System.Net;
 using GSF.Configuration;
 
-namespace GSF.Historian.MetadataProviders
-{   
+namespace GSF.Historian.MetadataProviders;
+
+/// <summary>
+/// Represents a provider of data to a <see cref="GSF.Historian.Files.MetadataFile"/> from a REST (Representational State Transfer) web service.
+/// </summary>
+/// <seealso cref="MetadataUpdater"/>
+public class RestWebServiceMetadataProvider : MetadataProviderBase
+{
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a provider of data to a <see cref="GSF.Historian.Files.MetadataFile"/> from a REST (Representational State Transfer) web service.
+    /// Initializes a new instance of the <see cref="RestWebServiceMetadataProvider"/> class.
     /// </summary>
-    /// <seealso cref="MetadataUpdater"/>
-    public class RestWebServiceMetadataProvider : MetadataProviderBase
+    public RestWebServiceMetadataProvider()
     {
-        #region [ Members ]
-
-        // Fields
-        private string m_serviceUri;
-        private SerializationFormat m_serviceDataFormat;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RestWebServiceMetadataProvider"/> class.
-        /// </summary>
-        public RestWebServiceMetadataProvider()
-        {
-            m_serviceUri = string.Empty;
-            m_serviceDataFormat = SerializationFormat.Xml;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the URI where the REST web service is hosted.
-        /// </summary>
-        public string ServiceUri
-        {
-            get
-            {
-                return m_serviceUri;
-            }
-            set
-            {
-                m_serviceUri = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="SerializationFormat"/> in which the REST web service exposes the data.
-        /// </summary>
-        public SerializationFormat ServiceDataFormat
-        {
-            get
-            {
-                return m_serviceDataFormat;
-            }
-            set
-            {
-                m_serviceDataFormat = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Saves <see cref="RestWebServiceMetadataProvider"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["ServiceUri", true].Update(m_serviceUri);
-                settings["ServiceDataFormat", true].Update(m_serviceDataFormat);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved <see cref="RestWebServiceMetadataProvider"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("ServiceUri", m_serviceUri, "URI where the REST web service is hosted.");
-                settings.Add("ServiceDataFormat", m_serviceDataFormat, "Format (Json; PoxAsmx; PoxRest) in which the REST web service exposes the data.");
-                ServiceUri = settings["ServiceUri"].ValueAs(m_serviceUri);
-                ServiceDataFormat = settings["ServiceDataFormat"].ValueAs(m_serviceDataFormat);
-            }
-        }
-
-        /// <summary>
-        /// Refreshes the <see cref="MetadataProviderBase.Metadata"/> from a REST web service.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><see cref="ServiceUri"/> is set to a null or empty string.</exception>
-        protected override void RefreshMetadata()
-        {
-            if (string.IsNullOrEmpty(m_serviceUri))
-                throw new ArgumentNullException("ServiceUri");
-
-            WebResponse response = null;
-            Stream responseStream = null;
-            try
-            {
-                // Retrieve new metadata.
-                response = WebRequest.Create(m_serviceUri).GetResponse();
-                responseStream = response.GetResponseStream();
-
-                // Update existing metadata.
-                MetadataUpdater metadataUpdater = new MetadataUpdater(Metadata);
-                metadataUpdater.UpdateMetadata(responseStream, m_serviceDataFormat);
-            }
-            finally
-            {
-                if (response != null)
-                    response.Close();
-
-                if (responseStream != null)
-                    responseStream.Dispose();
-            }
-        }
-
-        #endregion
+        ServiceUri = string.Empty;
+        ServiceDataFormat = SerializationFormat.Xml;
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the URI where the REST web service is hosted.
+    /// </summary>
+    public string ServiceUri { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="SerializationFormat"/> in which the REST web service exposes the data.
+    /// </summary>
+    public SerializationFormat ServiceDataFormat { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Saves <see cref="RestWebServiceMetadataProvider"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(ServiceUri), true].Update(ServiceUri);
+        settings[nameof(ServiceDataFormat), true].Update(ServiceDataFormat);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved <see cref="RestWebServiceMetadataProvider"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(ServiceUri), ServiceUri, "URI where the REST web service is hosted.");
+        settings.Add(nameof(ServiceDataFormat), ServiceDataFormat, "Format (Json; PoxAsmx; PoxRest) in which the REST web service exposes the data.");
+        
+        ServiceUri = settings[nameof(ServiceUri)].ValueAs(ServiceUri);
+        ServiceDataFormat = settings[nameof(ServiceDataFormat)].ValueAs(ServiceDataFormat);
+    }
+
+    /// <summary>
+    /// Refreshes the <see cref="MetadataProviderBase.Metadata"/> from a REST web service.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><see cref="ServiceUri"/> is set to a null or empty string.</exception>
+    protected override void RefreshMetadata()
+    {
+        if (string.IsNullOrEmpty(ServiceUri))
+            throw new ArgumentNullException(nameof(ServiceUri));
+
+        WebResponse response = null;
+        Stream responseStream = null;
+
+        try
+        {
+            // Retrieve new metadata.
+            response = WebRequest.Create(ServiceUri).GetResponse();
+            responseStream = response.GetResponseStream();
+
+            // Update existing metadata.
+            MetadataUpdater metadataUpdater = new(Metadata);
+            metadataUpdater.UpdateMetadata(responseStream, ServiceDataFormat);
+        }
+        finally
+        {
+            response?.Close();
+            responseStream?.Dispose();
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian
+namespace GSF.Historian;
+
+/// <summary>
+/// Contains fundamental classes used by all historian code.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains fundamental classes used by all historian code.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/Notifiers/EmailNotifier.cs
+++ b/Source/Libraries/GSF.Historian/Notifiers/EmailNotifier.cs
@@ -33,213 +33,203 @@ using System;
 using GSF.Configuration;
 using GSF.Net.Smtp;
 
-namespace GSF.Historian.Notifiers
+namespace GSF.Historian.Notifiers;
+
+/// <summary>
+/// Represents a notifier that can send notifications in email messages.
+/// </summary>
+public class EmailNotifier : NotifierBase
 {
+    #region [ Members ]
+
+    // Fields
+    private string m_emailServer;
+    private string m_emailSender;
+
+    #endregion
+
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a notifier that can send notifications in email messages.
+    /// Initializes a new instance of the <see cref="EmailNotifier"/> class.
     /// </summary>
-    public class EmailNotifier : NotifierBase
+    public EmailNotifier()
+        : base(NotificationTypes.Information | NotificationTypes.Warning | NotificationTypes.Alarm)
     {
-        #region [ Members ]
-
-        // Fields
-        private string m_emailServer;
-        private string m_emailSender;
-        private string m_emailRecipients;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EmailNotifier"/> class.
-        /// </summary>
-        public EmailNotifier()
-            : base(NotificationTypes.Information | NotificationTypes.Warning | NotificationTypes.Alarm)
-        {
-            m_emailServer = Mail.DefaultSmtpServer;
-            m_emailSender = string.Format("{0}@{1}.local", Environment.UserName, Environment.UserDomainName);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the SMTP server to use for sending the email messages.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        public string EmailServer
-        {
-            get
-            {
-                return m_emailServer;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_emailServer = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the email address to be used for sending the email messages.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
-        public string EmailSender
-        {
-            get
-            {
-                return m_emailSender;
-            }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    throw new ArgumentNullException(nameof(value));
-
-                m_emailSender = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the email addresses (comma or semicolon delimited) where the email messages are to be sent.
-        /// </summary>
-        /// <remarks>
-        /// Email address can be provided in the &lt;Email Address&gt;:sms format (Example: 123456789@provider.com:sms), 
-        /// to indicate that the reciepient is a mobile device and a very brief email message is to be sent.
-        /// </remarks>
-        public string EmailRecipients
-        {
-            get
-            {
-                return m_emailRecipients;
-            }
-            set
-            {
-                m_emailRecipients = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Saves <see cref="EmailNotifier"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>        
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["EmailServer", true].Update(m_emailServer);
-                settings["EmailSender", true].Update(m_emailSender);
-                settings["EmailRecipients", true].Update(m_emailRecipients);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved <see cref="EmailNotifier"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
-        /// </summary>        
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("EmailServer", m_emailServer, "SMTP server to use for sending the email notifications.");
-                settings.Add("EmailSender", m_emailSender, "Email address to be used for sending the email notifications.");
-                settings.Add("EmailRecipients", m_emailRecipients, "Email addresses (comma or semicolon delimited) where the email notifications are to be sent.");
-                EmailServer = settings["EmailServer"].ValueAs(m_emailServer);
-                EmailSender = settings["EmailSender"].ValueAs(m_emailSender);
-                EmailRecipients = settings["EmailRecipients"].ValueAs(m_emailRecipients);
-            }
-        }
-
-        /// <summary>
-        /// Processes a <see cref="NotificationTypes.Alarm"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected override void NotifyAlarm(string subject, string message, string details)
-        {
-            SendEmail("ALRM: " + subject, message, details);
-        }
-
-        /// <summary>
-        /// Processes a <see cref="NotificationTypes.Warning"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected override void NotifyWarning(string subject, string message, string details)
-        {
-            SendEmail("WARN: " + subject, message, details);
-        }
-
-        /// <summary>
-        /// Processes a <see cref="NotificationTypes.Information"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected override void NotifyInformation(string subject, string message, string details)
-        {
-            SendEmail("INFO: " + subject, message, details);
-        }
-
-        /// <summary>
-        /// Processes a <see cref="NotificationTypes.Heartbeat"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected override void NotifyHeartbeat(string subject, string message, string details)
-        {
-            throw new NotSupportedException();
-        }
-
-        private void SendEmail(string subject, string message, string details)
-        {
-            if (string.IsNullOrEmpty(m_emailRecipients))
-                throw new ArgumentNullException("EmailRecipients");
-
-            Mail briefMessage = new Mail(m_emailSender, m_emailSender, m_emailServer);
-            Mail detailedMessage = new Mail(m_emailSender, m_emailSender, m_emailServer);
-
-            briefMessage.Subject = subject;
-            detailedMessage.Subject = subject;
-            detailedMessage.Body = message + "\r\n\r\n" + details;
-            foreach (string recipient in m_emailRecipients.Replace(" ", "").Split(';', ','))
-            {
-                string[] addressParts = recipient.Split(':');
-                if (addressParts.Length > 1)
-                {
-                    if (string.Compare(addressParts[1], "sms", true) == 0)
-                    {
-                        // A brief message is to be sent.
-                        briefMessage.ToRecipients = addressParts[0];
-                        briefMessage.Send();
-                    }
-                }
-                else
-                {
-                    // A detailed message is to be sent.
-                    detailedMessage.ToRecipients = recipient;
-                    detailedMessage.Send();
-                }
-            }
-        }
-
-        #endregion
+        m_emailServer = Mail.DefaultSmtpServer;
+        m_emailSender = $"{Environment.UserName}@{Environment.UserDomainName}.local";
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the SMTP server to use for sending the email messages.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    public string EmailServer
+    {
+        get => m_emailServer;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_emailServer = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the email address to be used for sending the email messages.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value being assigned is a null or empty string.</exception>
+    public string EmailSender
+    {
+        get => m_emailSender;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentNullException(nameof(value));
+
+            m_emailSender = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the email addresses (comma or semicolon delimited) where the email messages are to be sent.
+    /// </summary>
+    /// <remarks>
+    /// Email address can be provided in the &lt;Email Address&gt;:sms format (Example: 123456789@provider.com:sms), 
+    /// to indicate that the recipient is a mobile device and a very brief email message is to be sent.
+    /// </remarks>
+    public string EmailRecipients { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Saves <see cref="EmailNotifier"/> settings to the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>        
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(EmailServer), true].Update(m_emailServer);
+        settings[nameof(EmailSender), true].Update(m_emailSender);
+        settings[nameof(EmailRecipients), true].Update(EmailRecipients);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved <see cref="EmailNotifier"/> settings from the config file if the <see cref="GSF.Adapters.Adapter.PersistSettings"/> property is set to true.
+    /// </summary>        
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(EmailServer), m_emailServer, "SMTP server to use for sending the email notifications.");
+        settings.Add(nameof(EmailSender), m_emailSender, "Email address to be used for sending the email notifications.");
+        settings.Add(nameof(EmailRecipients), EmailRecipients, "Email addresses (comma or semicolon delimited) where the email notifications are to be sent.");
+        
+        EmailServer = settings[nameof(EmailServer)].ValueAs(m_emailServer);
+        EmailSender = settings[nameof(EmailSender)].ValueAs(m_emailSender);
+        EmailRecipients = settings[nameof(EmailRecipients)].ValueAs(EmailRecipients);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="NotificationTypes.Alarm"/> notification.
+    /// </summary>
+    /// <param name="subject">Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected override void NotifyAlarm(string subject, string message, string details)
+    {
+        SendEmail($"ALRM: {subject}", message, details);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="NotificationTypes.Warning"/> notification.
+    /// </summary>
+    /// <param name="subject">Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected override void NotifyWarning(string subject, string message, string details)
+    {
+        SendEmail($"WARN: {subject}", message, details);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="NotificationTypes.Information"/> notification.
+    /// </summary>
+    /// <param name="subject">Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected override void NotifyInformation(string subject, string message, string details)
+    {
+        SendEmail($"INFO: {subject}", message, details);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="NotificationTypes.Heartbeat"/> notification.
+    /// </summary>
+    /// <param name="subject">Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected override void NotifyHeartbeat(string subject, string message, string details)
+    {
+        throw new NotSupportedException();
+    }
+
+    private void SendEmail(string subject, string message, string details)
+    {
+        if (string.IsNullOrEmpty(EmailRecipients))
+            throw new ArgumentNullException(nameof(EmailRecipients));
+
+        Mail briefMessage = new(m_emailSender, m_emailSender, m_emailServer);
+        Mail detailedMessage = new(m_emailSender, m_emailSender, m_emailServer);
+
+        briefMessage.Subject = subject;
+        detailedMessage.Subject = subject;
+        detailedMessage.Body = $"{message}\r\n\r\n{details}";
+
+        foreach (string recipient in EmailRecipients.Replace(" ", "").Split(';', ','))
+        {
+            string[] addressParts = recipient.Split(':');
+
+            if (addressParts.Length > 1)
+            {
+                if (string.Compare(addressParts[1], "sms", StringComparison.OrdinalIgnoreCase) != 0)
+                    continue;
+                
+                // A brief message is to be sent.
+                briefMessage.ToRecipients = addressParts[0];
+                briefMessage.Send();
+            }
+            else
+            {
+                // A detailed message is to be sent.
+                detailedMessage.ToRecipients = recipient;
+                detailedMessage.Send();
+            }
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Notifiers/INotifier.cs
+++ b/Source/Libraries/GSF.Historian/Notifiers/INotifier.cs
@@ -32,98 +32,97 @@
 using System;
 using GSF.Adapters;
 
-namespace GSF.Historian.Notifiers
+namespace GSF.Historian.Notifiers;
+
+#region [ Enumerations ]
+
+/// <summary>
+/// Indicates the type of notification being sent using a <see cref="INotifier">Notifier</see>.
+/// </summary>
+[Flags]
+public enum NotificationTypes
 {
-    #region [ Enumerations ]
+    /// <summary>
+    /// Notification is of unknown type.
+    /// </summary>
+    Unknown = 0,
+    /// <summary>
+    /// Notification is informational in nature.
+    /// </summary>
+    Information = 1,
+    /// <summary>
+    /// Notification is being sent to report a warning.
+    /// </summary>
+    Warning = 2,
+    /// <summary>
+    /// Notification is being sent to report an alarm.
+    /// </summary>
+    Alarm = 4,
+    /// <summary>
+    /// Notification is being sent to report activity.
+    /// </summary>
+    Heartbeat = 8
+}
+
+#endregion
+
+/// <summary>
+/// Defines a notifier that can process notification messages.
+/// </summary>
+/// <seealso cref="NotificationTypes"/>
+public interface INotifier : IAdapter
+{
+    #region [ Members ]
+
+    // Events
 
     /// <summary>
-    /// Indicates the type of notification being sent using a <see cref="INotifier">Notifier</see>.
+    /// Occurs when a notification is being sent.
     /// </summary>
-    [Flags]
-    public enum NotificationTypes
-    {
-        /// <summary>
-        /// Notification is of unknown type.
-        /// </summary>
-        Unknown = 0,
-        /// <summary>
-        /// Notification is informational in nature.
-        /// </summary>
-        Information = 1,
-        /// <summary>
-        /// Notification is being sent to report a warning.
-        /// </summary>
-        Warning = 2,
-        /// <summary>
-        /// Notification is being sent to report an alarm.
-        /// </summary>
-        Alarm = 4,
-        /// <summary>
-        /// Notification is being sent to report activity.
-        /// </summary>
-        Heartbeat = 8
-    }
+    event EventHandler NotificationSendStart;
+
+    /// <summary>
+    /// Occurs when a notification has been sent.
+    /// </summary>
+    event EventHandler NotificationSendComplete;
+
+    /// <summary>
+    /// Occurs when a timeout is encountered while sending a notification.
+    /// </summary>
+    event EventHandler NotificationSendTimeout;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered while sending a notification.
+    /// </summary>
+    event EventHandler<EventArgs<Exception>> NotificationSendException;
 
     #endregion
 
+    #region [ Properties ]
+
     /// <summary>
-    /// Defines a notifier that can process notification messages.
+    /// Gets or sets the number of seconds to wait for <see cref="Notify"/> to complete.
     /// </summary>
-    /// <seealso cref="NotificationTypes"/>
-    public interface INotifier : IAdapter
-    {
-        #region [ Members ]
+    int NotifyTimeout { get; set; }
 
-        // Events
+    /// <summary>
+    /// Gets or set <see cref="NotificationTypes"/> that can be processed by the notifier.
+    /// </summary>
+    NotificationTypes NotifyOptions { get; set;}
 
-        /// <summary>
-        /// Occurs when a notification is being sent.
-        /// </summary>
-        event EventHandler NotificationSendStart;
+    #endregion
 
-        /// <summary>
-        /// Occurs when a notification has been sent.
-        /// </summary>
-        event EventHandler NotificationSendComplete;
+    #region [ Methods ]
 
-        /// <summary>
-        /// Occurs when a timeout is encountered while sending a notification.
-        /// </summary>
-        event EventHandler NotificationSendTimeout;
+    /// <summary>
+    /// Process a notification.
+    /// </summary>
+    /// <param name="subject">Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
+    /// <returns>true if notification is processed successfully; otherwise false.</returns>
+    bool Notify(string subject, string message, string details, NotificationTypes notificationType);
 
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered while sending a notification.
-        /// </summary>
-        event EventHandler<EventArgs<Exception>> NotificationSendException;
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the number of seconds to wait for <see cref="Notify"/> to complete.
-        /// </summary>
-        int NotifyTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or set <see cref="NotificationTypes"/> that can be processed by the notifier.
-        /// </summary>
-        NotificationTypes NotifyOptions { get; set;}
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Process a notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
-        /// <returns>true if notification is processed successfully; otherwise false.</returns>
-        bool Notify(string subject, string message, string details, NotificationTypes notificationType);
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Notifiers/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/Notifiers/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian.Notifiers
+namespace GSF.Historian.Notifiers;
+
+/// <summary>
+/// Contains classes and interfaces that allow standard and custom historian notifications about critical system events.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains classes and interfaces that allow standard and custom historian notifications about critical system events.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/Notifiers/NotifierBase.cs
+++ b/Source/Libraries/GSF.Historian/Notifiers/NotifierBase.cs
@@ -29,7 +29,7 @@
 //  10/11/2010 - Mihir Brahmbhatt
 //       Updated header and license agreement.
 //  12/14/2012 - Starlynn Danyelle Gilliam
-//       Modifeid Header.
+//       Modified Header.
 //
 //******************************************************************************************************
 
@@ -39,320 +39,296 @@ using System.Threading;
 using GSF.Adapters;
 using GSF.Configuration;
 
-namespace GSF.Historian.Notifiers
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Notifiers;
+
+/// <summary>
+/// Base class for a notifier that can process notification messages.
+/// </summary>
+/// <see cref="NotificationTypes"/>
+public abstract class NotifierBase : Adapter, INotifier
 {
+    #region [ Members ]
+
+    // Events
+
     /// <summary>
-    /// Base class for a notifier that can process notification messages.
+    /// Occurs when a notification is being sent.
     /// </summary>
-    /// <see cref="NotificationTypes"/>
-    public abstract class NotifierBase : Adapter, INotifier
+    public event EventHandler NotificationSendStart;
+
+    /// <summary>
+    /// Occurs when a notification has been sent.
+    /// </summary>
+    public event EventHandler NotificationSendComplete;
+
+    /// <summary>
+    /// Occurs when a timeout is encountered while sending a notification.
+    /// </summary>
+    public event EventHandler NotificationSendTimeout;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered while sending a notification.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventArgs{T}.Argument"/> is the exception encountered while sending a notification.
+    /// </remarks>
+    public event EventHandler<EventArgs<Exception>> NotificationSendException;
+
+    // Fields
+    private int m_notifyTimeout;
+    private Thread m_notifyThread;
+    private bool m_disposed;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the notifier.
+    /// </summary>
+    /// <param name="notifyOptions"><see cref="NotificationTypes"/> that can be processed by the notifier.</param>
+    protected NotifierBase(NotificationTypes notifyOptions)
     {
-        #region [ Members ]
-
-        // Events
-
-        /// <summary>
-        /// Occurs when a notification is being sent.
-        /// </summary>
-        public event EventHandler NotificationSendStart;
-
-        /// <summary>
-        /// Occurs when a notification has been sent.
-        /// </summary>
-        public event EventHandler NotificationSendComplete;
-
-        /// <summary>
-        /// Occurs when a timeout is encountered while sending a notification.
-        /// </summary>
-        public event EventHandler NotificationSendTimeout;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered while sending a notification.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="EventArgs{T}.Argument"/> is the exception encountered while sending a notification.
-        /// </remarks>
-        public event EventHandler<EventArgs<Exception>> NotificationSendException;
-
-        // Fields
-        private int m_notifyTimeout;
-        private NotificationTypes m_notifyOptions;
-        private Thread m_notifyThread;
-        private bool m_disposed;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the notifier.
-        /// </summary>
-        /// <param name="notifyOptions"><see cref="NotificationTypes"/> that can be processed by the notifier.</param>
-        public NotifierBase(NotificationTypes notifyOptions)
-        {
-            m_notifyOptions = notifyOptions;
-            m_notifyTimeout = 30;
-            PersistSettings = true;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the number of seconds to wait for <see cref="Notify"/> to complete.
-        /// </summary>
-        /// <remarks>
-        /// Set <see cref="NotifyTimeout"/> to -1 to wait indefinitely on <see cref="Notify"/>.
-        /// </remarks>
-        public int NotifyTimeout
-        {
-            get
-            {
-                return m_notifyTimeout;
-            }
-            set
-            {
-                if (value < 1)
-                    m_notifyTimeout = -1;
-                else
-                    m_notifyTimeout = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or set <see cref="NotificationTypes"/> that can be processed by the notifier.
-        /// </summary>
-        public NotificationTypes NotifyOptions
-        {
-            get
-            {
-                return m_notifyOptions;
-            }
-            set
-            {
-                m_notifyOptions = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// When overridden in a derived class, processes a <see cref="NotificationTypes.Alarm"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected abstract void NotifyAlarm(string subject, string message, string details);
-
-        /// <summary>
-        /// When overridden in a derived class, processes a <see cref="NotificationTypes.Warning"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected abstract void NotifyWarning(string subject, string message, string details);
-
-        /// <summary>
-        /// When overridden in a derived class, processes a <see cref="NotificationTypes.Information"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected abstract void NotifyInformation(string subject, string message, string details);
-
-        /// <summary>
-        /// When overridden in a derived class, processes a <see cref="NotificationTypes.Heartbeat"/> notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        protected abstract void NotifyHeartbeat(string subject, string message, string details);
-
-        /// <summary>
-        /// Saves notifier settings to the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["Enabled", true].Update(Enabled);
-                settings["NotifyTimeout", true].Update(m_notifyTimeout);
-                settings["NotifyOptions", true].Update(m_notifyOptions);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved notifier settings from the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("Enabled", Enabled, "True if this notifier is enabled; otherwise False.");
-                settings.Add("NotifyTimeout", m_notifyTimeout, "Number of seconds to wait for notification processing to complete.");
-                settings.Add("NotifyOptions", m_notifyOptions, "Types of notifications (Information; Warning; Alarm; Heartbeat) to be processed by this notifier.");
-                Enabled = settings["Enabled"].ValueAs(Enabled);
-                NotifyTimeout = settings["NotifyTimeout"].ValueAs(m_notifyTimeout);
-                NotifyOptions = settings["NotifyOptions"].ValueAs(m_notifyOptions);
-            }
-        }
-
-        /// <summary>
-        /// Process a notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
-        /// <returns>true if notification is processed successfully; otherwise false.</returns>
-        public bool Notify(string subject, string message, string details, NotificationTypes notificationType)
-        {
-            if (!Enabled || (m_notifyThread != null && m_notifyThread.IsAlive))
-                return false;
-
-            // Start notification thread with appropriate parameters.
-            m_notifyThread = new Thread(NotifyInternal);
-            if ((notificationType & NotificationTypes.Alarm) == NotificationTypes.Alarm &&
-                (m_notifyOptions & NotificationTypes.Alarm) == NotificationTypes.Alarm)
-                // Alarm notifications are supported.
-                m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyAlarm) , subject, message, details});
-            else if ((notificationType & NotificationTypes.Warning) == NotificationTypes.Warning && 
-                     (m_notifyOptions & NotificationTypes.Warning) == NotificationTypes.Warning)
-                // Warning notifications are supported.
-                m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyWarning), subject, message, details });
-            else if ((notificationType & NotificationTypes.Information) == NotificationTypes.Information && 
-                     (m_notifyOptions & NotificationTypes.Information) == NotificationTypes.Information)
-                // Information notifications are supported.
-                m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyInformation), subject, message, details });
-            else if ((notificationType & NotificationTypes.Heartbeat) == NotificationTypes.Heartbeat && 
-                     (m_notifyOptions & NotificationTypes.Heartbeat) == NotificationTypes.Heartbeat)
-                // Heartbeat notifications are supported.
-                m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyHeartbeat), subject, message, details });
-            else
-                // Specified notification type is not supported.
-                return false;
-
-            if (m_notifyTimeout < 1)
-            {
-                // Wait indefinetely on the refresh.
-                m_notifyThread.Join(Timeout.Infinite);
-            }
-            else
-            {
-                // Wait for the specified time on refresh.
-                if (!m_notifyThread.Join(m_notifyTimeout * 1000))
-                {
-                    m_notifyThread.Abort();
-
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the notifier and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (!m_disposed)
-            {
-                try
-                {
-                    if (disposing)
-                    {
-                        if (m_notifyThread != null)
-                            m_notifyThread.Abort();
-                    }
-                }
-                finally
-                {
-                    m_disposed = true;  // Prevent duplicate dispose.
-                    base.Dispose(disposing);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Raises the <see cref="NotificationSendStart"/> event.
-        /// </summary>
-        protected virtual void OnNotificationSendStart()
-        {
-            if (NotificationSendStart != null)
-                NotificationSendStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="NotificationSendComplete"/> event.
-        /// </summary>
-        protected virtual void OnNotificationSendComplete()
-        {
-            if (NotificationSendComplete != null)
-                NotificationSendComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="NotificationSendTimeout"/> event.
-        /// </summary>
-        protected virtual void OnNotificationSendTimeout()
-        {
-            if (NotificationSendTimeout != null)
-                NotificationSendTimeout(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="NotificationSendException"/> event.
-        /// </summary>
-        /// <param name="exception"><see cref="Exception"/> to send to <see cref="NotificationSendException"/> event.</param>
-        protected virtual void OnNotificationSendException(Exception exception)
-        {
-            if (NotificationSendException != null)
-                NotificationSendException(this, new EventArgs<Exception>(exception));
-        }
-
-        private void NotifyInternal(object state)
-        {
-            try
-            {
-                // Unpackage the parameters.
-                object[] args = (object[])state;
-                string subject = args[1].ToString();
-                string message = args[2].ToString();
-                string details = args[3].ToString();
-                Action<string, string, string> target = (Action<string, string, string>)args[0];
-
-                OnNotificationSendStart();
-                target(subject, message, details);
-                OnNotificationSendComplete();
-            }
-            catch (ThreadAbortException)
-            {
-                OnNotificationSendTimeout();
-            }
-            catch (Exception ex)
-            {
-                OnNotificationSendException(ex);
-            }
-        }
-
-        #endregion
+        NotifyOptions = notifyOptions;
+        m_notifyTimeout = 30;
+        PersistSettings = true;
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the number of seconds to wait for <see cref="Notify"/> to complete.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="NotifyTimeout"/> to -1 to wait indefinitely on <see cref="Notify"/>.
+    /// </remarks>
+    public int NotifyTimeout
+    {
+        get => m_notifyTimeout;
+        set => m_notifyTimeout = value < 1 ? -1 : value;
+    }
+
+    /// <summary>
+    /// Gets or set <see cref="NotificationTypes"/> that can be processed by the notifier.
+    /// </summary>
+    public NotificationTypes NotifyOptions { get; set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// When overridden in a derived class, processes a <see cref="NotificationTypes.Alarm"/> notification.
+    /// </summary>
+    /// <param name="subject">>Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected abstract void NotifyAlarm(string subject, string message, string details);
+
+    /// <summary>
+    /// When overridden in a derived class, processes a <see cref="NotificationTypes.Warning"/> notification.
+    /// </summary>
+    /// <param name="subject">>Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected abstract void NotifyWarning(string subject, string message, string details);
+
+    /// <summary>
+    /// When overridden in a derived class, processes a <see cref="NotificationTypes.Information"/> notification.
+    /// </summary>
+    /// <param name="subject">>Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected abstract void NotifyInformation(string subject, string message, string details);
+
+    /// <summary>
+    /// When overridden in a derived class, processes a <see cref="NotificationTypes.Heartbeat"/> notification.
+    /// </summary>
+    /// <param name="subject">>Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    protected abstract void NotifyHeartbeat(string subject, string message, string details);
+
+    /// <summary>
+    /// Saves notifier settings to the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(Enabled), true].Update(Enabled);
+        settings[nameof(NotifyTimeout), true].Update(m_notifyTimeout);
+        settings[nameof(NotifyOptions), true].Update(NotifyOptions);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved notifier settings from the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(Enabled), Enabled, "True if this notifier is enabled; otherwise False.");
+        settings.Add(nameof(NotifyTimeout), m_notifyTimeout, "Number of seconds to wait for notification processing to complete.");
+        settings.Add(nameof(NotifyOptions), NotifyOptions, "Types of notifications (Information; Warning; Alarm; Heartbeat) to be processed by this notifier.");
+        
+        Enabled = settings[nameof(Enabled)].ValueAs(Enabled);
+        NotifyTimeout = settings[nameof(NotifyTimeout)].ValueAs(m_notifyTimeout);
+        NotifyOptions = settings[nameof(NotifyOptions)].ValueAs(NotifyOptions);
+    }
+
+    /// <summary>
+    /// Process a notification.
+    /// </summary>
+    /// <param name="subject">>Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
+    /// <returns>true if notification is processed successfully; otherwise false.</returns>
+    public bool Notify(string subject, string message, string details, NotificationTypes notificationType)
+    {
+        if (!Enabled || (m_notifyThread is not null && m_notifyThread.IsAlive))
+            return false;
+
+        // Start notification thread with appropriate parameters.
+        m_notifyThread = new Thread(NotifyInternal);
+        
+        if ((notificationType & NotificationTypes.Alarm) == NotificationTypes.Alarm && (NotifyOptions & NotificationTypes.Alarm) == NotificationTypes.Alarm)
+            // Alarm notifications are supported.
+            m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyAlarm) , subject, message, details});
+        else if ((notificationType & NotificationTypes.Warning) == NotificationTypes.Warning && (NotifyOptions & NotificationTypes.Warning) == NotificationTypes.Warning)
+            // Warning notifications are supported.
+            m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyWarning), subject, message, details });
+        else if ((notificationType & NotificationTypes.Information) == NotificationTypes.Information && (NotifyOptions & NotificationTypes.Information) == NotificationTypes.Information)
+            // Information notifications are supported.
+            m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyInformation), subject, message, details });
+        else if ((notificationType & NotificationTypes.Heartbeat) == NotificationTypes.Heartbeat && (NotifyOptions & NotificationTypes.Heartbeat) == NotificationTypes.Heartbeat)
+            // Heartbeat notifications are supported.
+            m_notifyThread.Start(new object[] { new Action<string, string, string>(NotifyHeartbeat), subject, message, details });
+        else
+            // Specified notification type is not supported.
+            return false;
+
+        if (m_notifyTimeout < 1)
+        {
+            // Wait indefinitely on the refresh.
+            m_notifyThread.Join(Timeout.Infinite);
+        }
+        else
+        {
+            // Wait for the specified time on refresh.
+            if (m_notifyThread.Join(m_notifyTimeout * 1000))
+                return true;
+            
+            m_notifyThread.Abort();
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the notifier and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (m_disposed)
+            return;
+        
+        try
+        {
+            if (!disposing)
+                return;
+            
+            m_notifyThread?.Abort();
+        }
+        finally
+        {
+            m_disposed = true;  // Prevent duplicate dispose.
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Raises the <see cref="NotificationSendStart"/> event.
+    /// </summary>
+    protected virtual void OnNotificationSendStart()
+    {
+        NotificationSendStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="NotificationSendComplete"/> event.
+    /// </summary>
+    protected virtual void OnNotificationSendComplete()
+    {
+        NotificationSendComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="NotificationSendTimeout"/> event.
+    /// </summary>
+    protected virtual void OnNotificationSendTimeout()
+    {
+        NotificationSendTimeout?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="NotificationSendException"/> event.
+    /// </summary>
+    /// <param name="exception"><see cref="Exception"/> to send to <see cref="NotificationSendException"/> event.</param>
+    protected virtual void OnNotificationSendException(Exception exception)
+    {
+        NotificationSendException?.Invoke(this, new EventArgs<Exception>(exception));
+    }
+
+    private void NotifyInternal(object state)
+    {
+        try
+        {
+            // Unpack the parameters.
+            object[] args = (object[])state;
+            string subject = args[1].ToString();
+            string message = args[2].ToString();
+            string details = args[3].ToString();
+            Action<string, string, string> target = (Action<string, string, string>)args[0];
+
+            OnNotificationSendStart();
+            target(subject, message, details);
+            OnNotificationSendComplete();
+        }
+        catch (ThreadAbortException)
+        {
+            OnNotificationSendTimeout();
+        }
+        catch (Exception ex)
+        {
+            OnNotificationSendException(ex);
+        }
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Notifiers/Notifiers.cs
+++ b/Source/Libraries/GSF.Historian/Notifiers/Notifiers.cs
@@ -29,72 +29,71 @@
 
 using GSF.Adapters;
 
-namespace GSF.Historian.Notifiers
+namespace GSF.Historian.Notifiers;
+
+/// <summary>
+/// A class that loads all <see cref="INotifier">Notifier</see> adapters.
+/// </summary>
+/// <seealso cref="INotifier"/>
+public class Notifiers : AdapterLoader<INotifier>
 {
-    /// <summary>
-    /// A class that loads all <see cref="INotifier">Notifier</see> adapters.
-    /// </summary>
-    /// <seealso cref="INotifier"/>
-    public class Notifiers : AdapterLoader<INotifier>
+    #region [ Members ]
+
+    // Nested Types
+
+    private class Notification
     {
-        #region [ Members ]
-
-        // Nested Types
-
-        private class Notification
+        public Notification(string subject, string message, string details, NotificationTypes notificationType)
         {
-            public Notification(string subject, string message, string details, NotificationTypes notificationType)
-            {
-                this.Subject = subject;
-                this.Message = message;
-                this.Details = details;
-                this.NotificationType = notificationType;
-            }
-
-            public readonly string Subject;
-            public readonly string Message;
-            public readonly string Details;
-            public readonly NotificationTypes NotificationType;
+            Subject = subject;
+            Message = message;
+            Details = details;
+            NotificationType = notificationType;
         }
 
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Sends a notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
-        public void SendNotification(string subject, string message, NotificationTypes notificationType)
-        {
-            SendNotification(subject, message, "", notificationType);
-        }
-
-        /// <summary>
-        /// Sends a notification.
-        /// </summary>
-        /// <param name="subject">Subject matter for the notification.</param>
-        /// <param name="message">Brief message for the notification.</param>
-        /// <param name="details">Detailed message for the notification.</param>
-        /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
-        public void SendNotification(string subject, string message, string details, NotificationTypes notificationType)
-        {
-            OperationQueue.Enqueue(new Notification(subject, message, details, notificationType));
-        }
-
-        /// <summary>
-        /// Executes <see cref="INotifier.Notify"/> on the specified notifier <paramref name="adapter"/>.
-        /// </summary>
-        /// <param name="adapter">An <see cref="INotifier"/> object.</param>
-        /// <param name="data">Data about the notification.</param>
-        protected override void ExecuteAdapterOperation(INotifier adapter, object data)
-        {
-            Notification notification = (Notification)data;
-            adapter.Notify(notification.Subject, notification.Message, notification.Details, notification.NotificationType);
-        }
-
-        #endregion
+        public readonly string Subject;
+        public readonly string Message;
+        public readonly string Details;
+        public readonly NotificationTypes NotificationType;
     }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Sends a notification.
+    /// </summary>
+    /// <param name="subject">>Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
+    public void SendNotification(string subject, string message, NotificationTypes notificationType)
+    {
+        SendNotification(subject, message, "", notificationType);
+    }
+
+    /// <summary>
+    /// Sends a notification.
+    /// </summary>
+    /// <param name="subject">>Subject-matter for the notification.</param>
+    /// <param name="message">Brief message for the notification.</param>
+    /// <param name="details">Detailed message for the notification.</param>
+    /// <param name="notificationType">One of the <see cref="NotificationTypes"/> values.</param>
+    public void SendNotification(string subject, string message, string details, NotificationTypes notificationType)
+    {
+        OperationQueue.Enqueue(new Notification(subject, message, details, notificationType));
+    }
+
+    /// <summary>
+    /// Executes <see cref="INotifier.Notify"/> on the specified notifier <paramref name="adapter"/>.
+    /// </summary>
+    /// <param name="adapter">An <see cref="INotifier"/> object.</param>
+    /// <param name="data">Data about the notification.</param>
+    protected override void ExecuteAdapterOperation(INotifier adapter, object data)
+    {
+        Notification notification = (Notification)data;
+        adapter.Notify(notification.Subject, notification.Message, notification.Details, notification.NotificationType);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/IPacket.cs
+++ b/Source/Libraries/GSF.Historian/Packets/IPacket.cs
@@ -35,58 +35,45 @@ using System;
 using System.Collections.Generic;
 using GSF.Parsing;
 
-namespace GSF.Historian.Packets
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Defines a binary packet received by a historian.
+/// </summary>
+public interface IPacket : ISupportSourceIdentifiableFrameImage<Guid, short>
 {
+    #region [ Properties ]
+
     /// <summary>
-    /// Defines a binary packet received by a historian.
+    /// Gets or sets the current <see cref="IArchive"/>.
     /// </summary>
-    public interface IPacket : ISupportSourceIdentifiableFrameImage<Guid, short>
-    {
-        #region [ Properties ]
+    IArchive Archive { get; set; }
 
-        /// <summary>
-        /// Gets or sets the current <see cref="IArchive"/>.
-        /// </summary>
-        IArchive Archive
-        {
-            get;
-            set;
-        }
+    /// <summary>
+    /// Gets or sets the <see cref="Delegate"/> that processes the packet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
+    /// </remarks>
+    Func<IEnumerable<byte[]>> ProcessHandler { get; set; }
 
-        /// <summary>
-        /// Gets or sets the <see cref="Delegate"/> that processes the packet.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
-        /// </remarks>
-        Func<IEnumerable<byte[]>> ProcessHandler
-        {
-            get;
-            set;
-        }
+    /// <summary>
+    /// Gets or sets the <see cref="Delegate"/> that pre-processes the packet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
+    /// </remarks>
+    Func<IEnumerable<byte[]>> PreProcessHandler { get; set; }
 
-        /// <summary>
-        /// Gets or sets the <see cref="Delegate"/> that pre-processes the packet.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
-        /// </remarks>
-        Func<IEnumerable<byte[]>> PreProcessHandler
-        {
-            get;
-            set;
-        }
+    #endregion
 
-        #endregion
+    #region [ Methods ]
 
-        #region [ Methods ]
+    /// <summary>
+    /// Extracts time-series data from the packet.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="IDataPoint"/>s if the packet contains time-series data; otherwise null.</returns>
+    IEnumerable<IDataPoint> ExtractTimeSeriesData();
 
-        /// <summary>
-        /// Extracts time-series data from the packet.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="IDataPoint"/>s if the packet contains time-series data; otherwise null.</returns>
-        IEnumerable<IDataPoint> ExtractTimeSeriesData();
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/Packets/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian.Packets
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Contains classes that define packet definitions used for transmission of data points and metadata.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains classes that define packet definitions used for transmission of data points and metadata.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketBase.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketBase.cs
@@ -35,200 +35,126 @@ using System;
 using System.Collections.Generic;
 using GSF.Parsing;
 
-namespace GSF.Historian.Packets
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Base class for a binary packet received by a historian.
+/// </summary>
+/// <seealso cref="IPacket"/>
+public abstract class PacketBase : IPacket
 {
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Base class for a binary packet received by a historian.
+    /// Specifies the number of bytes in the binary image of the packet.
     /// </summary>
-    /// <seealso cref="IPacket"/>
-    public abstract class PacketBase : IPacket
+    /// <remarks>A value of -1 indicates that the binary image of the packet is of variable length.</remarks>
+    public const int FixedLength = -1;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the packet.
+    /// </summary>
+    /// <param name="packetID">Numeric identifier for the packet type.</param>
+    protected PacketBase(short packetID)
     {
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of the packet.
-        /// </summary>
-        /// <remarks>A value of -1 indicates that the binary image of the packet is of variable length.</remarks>
-        public const int FixedLength = -1;
-
-        // Fields
-        private IArchive m_archive;
-        private Func<IEnumerable<byte[]>> m_processHandler;
-        private Func<IEnumerable<byte[]>> m_preProcessHandler;
-        private ICommonHeader<short> m_commonHeader;
-        private readonly short m_typeID;
-        private Guid m_source;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the packet.
-        /// </summary>
-        /// <param name="packetID">Numeric identifier for the packet type.</param>
-        protected PacketBase(short packetID)
-        {
-            m_typeID = packetID;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets the length of the packet's binary representation.
-        /// </summary>
-        public abstract int BinaryLength
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Gets or sets the current <see cref="IArchive"/>.
-        /// </summary>
-        public IArchive Archive
-        {
-            get
-            {
-                return m_archive;
-            }
-            set
-            {
-                m_archive = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Delegate"/> that processes the packet.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
-        /// </remarks>
-        public Func<IEnumerable<byte[]>> ProcessHandler
-        {
-            get
-            {
-                return m_processHandler;
-            }
-            set
-            {
-                m_processHandler = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Delegate"/> that pre-processes the packet.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
-        /// </remarks>
-        public Func<IEnumerable<byte[]>> PreProcessHandler
-        {
-            get
-            {
-                return m_preProcessHandler;
-            }
-            set
-            {
-                m_preProcessHandler = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="PacketCommonHeader"/> for the packet.
-        /// </summary>
-        public ICommonHeader<short> CommonHeader
-        {
-            get
-            {
-                return m_commonHeader;
-            }
-            set
-            {
-                m_commonHeader = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the numeric identifier for the packet type.
-        /// </summary>
-        public short TypeID
-        {
-            get
-            {
-                return m_typeID;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the data source identifier of the frame image.
-        /// </summary>
-        public Guid Source
-        {
-            get
-            {
-                return m_source;
-            }
-            set
-            {
-                m_source = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets flag that determines if frame image can queued for publication or should be processed immediately.
-        /// </summary>
-        /// <remarks>
-        /// Some frames, e.g., a configuration or key frame, may be critical to processing of other frames. In this
-        /// case, these types of frames should be published immediately so that subsequent frame parsing can have
-        /// access to needed critical information.
-        /// </remarks>
-        public bool AllowQueuedPublication
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes packet by parsing the specified <paramref name="buffer"/> containing a binary image.
-        /// </summary>
-        /// <param name="buffer">Buffer containing binary image to parse.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start parsing.</param>
-        /// <param name="length">Valid number of bytes within <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>The number of bytes used for initialization in the <paramref name="buffer"/> (i.e., the number of bytes parsed).</returns>
-        /// <remarks>
-        /// Implementers should validate <paramref name="startIndex"/> and <paramref name="length"/> against <paramref name="buffer"/> length.
-        /// The <see cref="GSF.ArrayExtensions.ValidateParameters"/> method can be used to perform this validation.
-        /// </remarks>
-        public abstract int ParseBinaryImage(byte[] buffer, int startIndex, int length);
-
-        /// <summary>
-        /// Generates binary image of the packet and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <remarks>
-        /// Implementers should validate <paramref name="startIndex"/> and <see cref="BinaryLength"/> against <paramref name="buffer"/> length.
-        /// The <see cref="GSF.ArrayExtensions.ValidateParameters"/> method can be used to perform this validation.
-        /// </remarks>
-        public abstract int GenerateBinaryImage(byte[] buffer, int startIndex);
-
-        /// <summary>
-        /// Extracts time-series data from the packet.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IDataPoint"/>s if the packet contains time-series data; otherwise null.</returns>
-        public abstract IEnumerable<IDataPoint> ExtractTimeSeriesData();
-
-        #endregion
+        TypeID = packetID;
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets the length of the packet's binary representation.
+    /// </summary>
+    public abstract int BinaryLength { get; }
+
+    /// <summary>
+    /// Gets or sets the current <see cref="IArchive"/>.
+    /// </summary>
+    public IArchive Archive { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Delegate"/> that processes the packet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
+    /// </remarks>
+    public Func<IEnumerable<byte[]>> ProcessHandler { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Delegate"/> that pre-processes the packet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Func{TResult}"/> returns an <see cref="IEnumerable{T}"/> object containing the binary data to be sent back to the packet sender.
+    /// </remarks>
+    public Func<IEnumerable<byte[]>> PreProcessHandler { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="PacketCommonHeader"/> for the packet.
+    /// </summary>
+    public ICommonHeader<short> CommonHeader { get; set; }
+
+    /// <summary>
+    /// Gets or sets the numeric identifier for the packet type.
+    /// </summary>
+    public short TypeID { get; }
+
+    /// <summary>
+    /// Gets or sets the data source identifier of the frame image.
+    /// </summary>
+    public Guid Source { get; set; }
+
+    /// <summary>
+    /// Gets flag that determines if frame image can be queued for publication or should be processed immediately.
+    /// </summary>
+    /// <remarks>
+    /// Some frames, e.g., a configuration or key frame, may be critical to processing of other frames. In this
+    /// case, these types of frames should be published immediately so that subsequent frame parsing can have
+    /// access to needed critical information.
+    /// </remarks>
+    public bool AllowQueuedPublication => true;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes packet by parsing the specified <paramref name="buffer"/> containing a binary image.
+    /// </summary>
+    /// <param name="buffer">Buffer containing binary image to parse.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start parsing.</param>
+    /// <param name="length">Valid number of bytes within <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>The number of bytes used for initialization in the <paramref name="buffer"/> (i.e., the number of bytes parsed).</returns>
+    /// <remarks>
+    /// Implementers should validate <paramref name="startIndex"/> and <paramref name="length"/> against <paramref name="buffer"/> length.
+    /// The <see cref="GSF.ArrayExtensions.ValidateParameters{T}"/> method can be used to perform this validation.
+    /// </remarks>
+    public abstract int ParseBinaryImage(byte[] buffer, int startIndex, int length);
+
+    /// <summary>
+    /// Generates binary image of the packet and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <remarks>
+    /// Implementers should validate <paramref name="startIndex"/> and <see cref="BinaryLength"/> against <paramref name="buffer"/> length.
+    /// The <see cref="GSF.ArrayExtensions.ValidateParameters{T}"/> method can be used to perform this validation.
+    /// </remarks>
+    public abstract int GenerateBinaryImage(byte[] buffer, int startIndex);
+
+    /// <summary>
+    /// Extracts time-series data from the packet.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IDataPoint"/>s if the packet contains time-series data; otherwise null.</returns>
+    public abstract IEnumerable<IDataPoint> ExtractTimeSeriesData();
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketCommonHeader.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketCommonHeader.cs
@@ -32,26 +32,25 @@
 using System;
 using GSF.Parsing;
 
-namespace GSF.Historian.Packets
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents the common header information that is present in the binary image of all <see cref="Type"/>s that implement the <see cref="IPacket"/> interface.
+/// </summary>
+public sealed class PacketCommonHeader : CommonHeaderBase<short>
 {
     /// <summary>
-    /// Represents the common header information that is present in the binary image of all <see cref="Type"/>s that implement the <see cref="IPacket"/> interface.
+    /// Initializes a new instance of the <see cref="PacketCommonHeader"/> class.
     /// </summary>
-    public class PacketCommonHeader : CommonHeaderBase<short>
+    /// <param name="buffer">Buffer containing binary image to be used for initializing <see cref="PacketCommonHeader"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <exception cref="InvalidOperationException">Not enough <paramref name="length"/> available to parse <see cref="PacketCommonHeader"/>.</exception>
+    public PacketCommonHeader(byte[] buffer, int startIndex, int length)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketCommonHeader"/> class.
-        /// </summary>
-        /// <param name="buffer">Buffer containing binary image to be used for initializing <see cref="PacketCommonHeader"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <exception cref="InvalidOperationException">Not enough <paramref name="length"/> available to parse <see cref="PacketCommonHeader"/>.</exception>
-        public PacketCommonHeader(byte[] buffer, int startIndex, int length)
-        {
-            if (length > 1)
-                TypeID = LittleEndian.ToInt16(buffer, startIndex);
-            else
-                throw new InvalidOperationException("Not enough length available to parse common header");
-        }
+        if (length > 1)
+            TypeID = LittleEndian.ToInt16(buffer, startIndex);
+        else
+            throw new InvalidOperationException("Not enough length available to parse common header");
     }
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketParser.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketParser.cs
@@ -34,46 +34,36 @@
 using System;
 using GSF.Parsing;
 
-namespace GSF.Historian.Packets
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a data parser that can parse binary data in to <see cref="IPacket"/>s.
+/// </summary>
+public class PacketParser : MultiSourceFrameImageParserBase<Guid, short, IPacket>
 {
+    #region [ Properties ]
+
     /// <summary>
-    /// Represents a data parser that can parse binary data in to <see cref="IPacket"/>s.
+    /// Returns false since the protocol implementation of <see cref="IPacket"/> does not use synchronization.
     /// </summary>
-    public class PacketParser : MultiSourceFrameImageParserBase<Guid, short, IPacket>
+    public override bool ProtocolUsesSyncBytes => false;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Returns an <see cref="PacketCommonHeader"/> object.
+    /// </summary>
+    /// <param name="buffer">Buffer containing data to parse.</param>
+    /// <param name="offset">Offset index into <paramref name="buffer"/> that represents where to start parsing.</param>
+    /// <param name="length">Maximum length of valid data from <paramref name="offset"/>.</param>
+    /// <returns>A <see cref="PacketCommonHeader"/> object parsed from the <paramref name="buffer"/>, or <c>null</c> if not enough buffer is available..</returns>
+    protected override ICommonHeader<short> ParseCommonHeader(byte[] buffer, int offset, int length)
     {
-        #region [ Properties ]
-
-        /// <summary>
-        /// Returns false since the protocol implementation of <see cref="IPacket"/> does not use synchronization.
-        /// </summary>
-        public override bool ProtocolUsesSyncBytes
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Returns an <see cref="PacketCommonHeader"/> object.
-        /// </summary>
-        /// <param name="buffer">Buffer containing data to parse.</param>
-        /// <param name="offset">Offset index into <paramref name="buffer"/> that represents where to start parsing.</param>
-        /// <param name="length">Maximum length of valid data from <paramref name="offset"/>.</param>
-        /// <returns>A <see cref="PacketCommonHeader"/> object parsed from the <paramref name="buffer"/>, or <c>null</c> if not enough buffer is available..</returns>
-        protected override ICommonHeader<short> ParseCommonHeader(byte[] buffer, int offset, int length)
-        {
-            if (length > 1)
-                return new PacketCommonHeader(buffer, offset, length);
-
-            // Return null if there is not enough buffer to parse common header
-            return null;
-        }
-
-        #endregion
+        // Return null if there is not enough buffer to parse common header
+        return length > 1 ? new PacketCommonHeader(buffer, offset, length) : null;
     }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType1.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType1.cs
@@ -39,285 +39,247 @@ using System.Text;
 using GSF.Historian.Files;
 using GSF.TimeSeries;
 
-namespace GSF.Historian.Packets
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a packet to be used for sending single time-series data point to a historian for archival.
+/// </summary>
+public class PacketType1 : PacketBase
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 2          0-1        Int16      TypeID (packet identifier)                                    *
+    // * 4          2-5        Int32      HistorianID                                                   *
+    // * 8          6-13       Double     Time                                                          *
+    // * 4          14-17      Int32      Quality                                                       *
+    // * 4          18-21      Single     Value                                                         *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a packet to be used for sending single time-series data point to a historian for archival.
+    /// Specifies the number of bytes in the binary image of <see cref="PacketType1"/>.
     /// </summary>
-    public class PacketType1 : PacketBase
+    public new const int FixedLength = 22;
+
+    // Fields
+    private int m_historianID;
+    private TimeTag m_time;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType1"/> class.
+    /// </summary>
+    public PacketType1()
+        : base(1)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 2          0-1        Int16      TypeID (packet identifier)                                    *
-        // * 4          2-5        Int32      HistorianID                                                   *
-        // * 8          6-13       Double     Time                                                          *
-        // * 4          14-17      Int32      Quality                                                       *
-        // * 4          18-21      Single     Value                                                         *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="PacketType1"/>.
-        /// </summary>
-        public new const int FixedLength = 22;
-
-        // Fields
-        private int m_historianID;
-        private TimeTag m_time;
-        private Quality m_quality;
-        private float m_value;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType1"/> class.
-        /// </summary>
-        public PacketType1()
-            : base(1)
-        {
-            Time = TimeTag.MinValue;
-            ProcessHandler = Process;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType1"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier.</param>
-        public PacketType1(int historianID)
-            : this()
-        {
-            HistorianID = historianID;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType1"/> class.
-        /// </summary>
-        /// <param name="dataPoint">Object that implements the <see cref="IDataPoint"/> interface.</param>
-        public PacketType1(IDataPoint dataPoint)
-            : this()
-        {
-            HistorianID = dataPoint.HistorianID;
-            Time = dataPoint.Time;
-            Value = dataPoint.Value;
-            Quality = dataPoint.Quality;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType1"/> class.
-        /// </summary>
-        /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
-        public PacketType1(IMeasurement measurement)
-            : this()
-        {
-            HistorianID = (int)measurement.Key.ID;
-            Time = new TimeTag((DateTime)measurement.Timestamp);
-            Value = (float)measurement.AdjustedValue;
-            Quality = measurement.HistorianQuality();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType1"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType1"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType1(byte[] buffer, int startIndex, int length)
-            : this()
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the historian identifier of the time-series data.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
-        public int HistorianID
-        {
-            get
-            {
-                return m_historianID;
-            }
-            set
-            {
-                if (value < 1)
-                    throw new ArgumentException("Value must be positive");
-
-                m_historianID = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="TimeTag"/> of the time-series data.
-        /// </summary>
-        /// /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
-        public TimeTag Time
-        {
-            get
-            {
-                return m_time;
-            }
-            set
-            {
-                if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
-                    throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
-
-                m_time = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Quality"/> of the time-series data.
-        /// </summary>
-        public Quality Quality
-        {
-            get
-            {
-                return m_quality;
-            }
-            set
-            {
-                m_quality = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the time-series data.
-        /// </summary>
-        public float Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="PacketType1"/>.
-        /// </summary>
-        public override int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="PacketType1"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType1"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType1"/>.</returns>
-        public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                short packetID = LittleEndian.ToInt16(buffer, startIndex);
-                if (packetID != TypeID)
-                    throw new ArgumentException(string.Format("Unexpected packet id '{0}' (expected '{1}')", packetID, TypeID));
-
-                // We have a binary image with the correct packet id.
-                HistorianID = LittleEndian.ToInt32(buffer, startIndex + 2);
-                Time = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 6));
-                Quality = (Quality)(LittleEndian.ToInt32(buffer, startIndex + 14));
-                Value = LittleEndian.ToSingle(buffer, startIndex + 18);
-
-                // We'll send an "ACK" to the sender if this is the last packet in the transmission.
-                if (length == FixedLength)
-                    PreProcessHandler = PreProcess;
-
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="PacketType1"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public override int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex + 2, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes((double)m_time.Value), 0, buffer, startIndex + 6, 8);
-            Buffer.BlockCopy(LittleEndian.GetBytes((int)m_quality), 0, buffer, startIndex + 14, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_value), 0, buffer, startIndex + 18, 4);
-
-            return length;
-        }
-
-        /// <summary>
-        /// Extracts time-series data from <see cref="PacketType1"/>.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="ArchiveDataPoint"/>s.</returns>
-        public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
-        {
-            return new[] { new ArchiveDataPoint(m_historianID, m_time, m_value, m_quality) };
-        }
-
-        /// <summary>
-        /// Processes <see cref="PacketType1"/>.
-        /// </summary>
-        /// <returns>A null reference.</returns>
-        protected virtual IEnumerable<byte[]> Process()
-        {
-            if (Archive != null)
-            {
-                foreach (IDataPoint dataPoint in ExtractTimeSeriesData())
-                {
-                    Archive.WriteData(dataPoint);
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Pre-processes <see cref="PacketType1"/>.
-        /// </summary>
-        /// <returns>A <see cref="byte"/> array for "ACK".</returns>
-        protected virtual IEnumerable<byte[]> PreProcess()
-        {
-            return new[] { Encoding.ASCII.GetBytes("ACK") };
-        }
-
-        #endregion
+        Time = TimeTag.MinValue;
+        ProcessHandler = Process;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType1"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier.</param>
+    public PacketType1(int historianID)
+        : this()
+    {
+        HistorianID = historianID;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType1"/> class.
+    /// </summary>
+    /// <param name="dataPoint">Object that implements the <see cref="IDataPoint"/> interface.</param>
+    public PacketType1(IDataPoint dataPoint)
+        : this()
+    {
+        HistorianID = dataPoint.HistorianID;
+        Time = dataPoint.Time;
+        Value = dataPoint.Value;
+        Quality = dataPoint.Quality;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType1"/> class.
+    /// </summary>
+    /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
+    public PacketType1(IMeasurement measurement)
+        : this()
+    {
+        HistorianID = (int)measurement.Key.ID;
+        Time = new TimeTag((DateTime)measurement.Timestamp);
+        Value = (float)measurement.AdjustedValue;
+        Quality = measurement.HistorianQuality();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType1"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType1"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType1(byte[] buffer, int startIndex, int length)
+        : this()
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the historian identifier of the time-series data.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
+    public int HistorianID
+    {
+        get => m_historianID;
+        set
+        {
+            if (value < 1)
+                throw new ArgumentException("Value must be positive");
+
+            m_historianID = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="TimeTag"/> of the time-series data.
+    /// </summary>
+    /// /// <exception cref="ArgumentException">The value being assigned is not between 01/01/1995 and 01/19/2063.</exception>
+    public TimeTag Time
+    {
+        get => m_time;
+        set
+        {
+            if (value.CompareTo(TimeTag.MinValue) < 0 || value.CompareTo(TimeTag.MaxValue) > 0)
+                throw new ArgumentException("Value must between 01/01/1995 and 01/19/2063");
+
+            m_time = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Quality"/> of the time-series data.
+    /// </summary>
+    public Quality Quality { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of the time-series data.
+    /// </summary>
+    public float Value { get; set; }
+
+    /// <summary>
+    /// Gets the length of the <see cref="PacketType1"/>.
+    /// </summary>
+    public override int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="PacketType1"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType1"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType1"/>.</returns>
+    public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        short packetID = LittleEndian.ToInt16(buffer, startIndex);
+
+        if (packetID != TypeID)
+            throw new ArgumentException($"Unexpected packet id '{packetID}' (expected '{TypeID}')");
+
+        // We have a binary image with the correct packet id.
+        HistorianID = LittleEndian.ToInt32(buffer, startIndex + 2);
+        Time = new TimeTag((decimal)LittleEndian.ToDouble(buffer, startIndex + 6));
+        Quality = (Quality)LittleEndian.ToInt32(buffer, startIndex + 14);
+        Value = LittleEndian.ToSingle(buffer, startIndex + 18);
+
+        // We'll send an "ACK" to the sender if this is the last packet in the transmission.
+        if (length == FixedLength)
+            PreProcessHandler = PreProcess;
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="PacketType1"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public override int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex + 2, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes((double)m_time.Value), 0, buffer, startIndex + 6, 8);
+        Buffer.BlockCopy(LittleEndian.GetBytes((int)Quality), 0, buffer, startIndex + 14, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(Value), 0, buffer, startIndex + 18, 4);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Extracts time-series data from <see cref="PacketType1"/>.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="ArchiveDataPoint"/>s.</returns>
+    public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
+    {
+        return [new ArchiveDataPoint(m_historianID, m_time, Value, Quality)];
+    }
+
+    /// <summary>
+    /// Processes <see cref="PacketType1"/>.
+    /// </summary>
+    /// <returns>A null reference.</returns>
+    protected virtual IEnumerable<byte[]> Process()
+    {
+        if (Archive is null)
+            return null;
+        
+        foreach (IDataPoint dataPoint in ExtractTimeSeriesData())
+            Archive.WriteData(dataPoint);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Pre-processes <see cref="PacketType1"/>.
+    /// </summary>
+    /// <returns>A <see cref="byte"/> array for "ACK".</returns>
+    protected virtual IEnumerable<byte[]> PreProcess()
+    {
+        return [Encoding.ASCII.GetBytes("ACK")];
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType101.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType101.cs
@@ -33,233 +33,213 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using GSF.Historian.Files;
 using GSF.TimeSeries;
 
-namespace GSF.Historian.Packets
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a packet that can be used to send multiple time-series data points to a historian for archival.
+/// </summary>
+/// <seealso cref="PacketType101DataPoint"/>
+public class PacketType101 : PacketBase
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 2          0-1        Int16      TypeID (packet identifier)                                    *
+    // * 4          2-5        Int32      Data.Count                                                    *
+    // * 14         6-19       Byte[]     Data[0]                                                       *
+    // * 14         n1-n2      Byte[]     Data[Data.Count - 1]                                          *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Fields
+    private readonly List<IDataPoint> m_data;
+
+    #endregion
+
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a packet that can be used to send multiple time-series data points to a historian for archival.
+    /// Initializes a new instance of the <see cref="PacketType101"/> class.
     /// </summary>
-    /// <seealso cref="PacketType101DataPoint"/>
-    public class PacketType101 : PacketBase
+    public PacketType101()
+        : base(101)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 2          0-1        Int16      TypeID (packet identifier)                                    *
-        // * 4          2-5        Int32      Data.Count                                                    *
-        // * 14         6-19       Byte[]     Data[0]                                                       *
-        // * 14         n1-n2      Byte[]     Data[Data.Count - 1]                                          *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Fields
-        private readonly List<IDataPoint> m_data;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101"/> class.
-        /// </summary>
-        public PacketType101()
-            : base(101)
-        {
-            m_data = new List<IDataPoint>();
-            ProcessHandler = Process;
-            PreProcessHandler = PreProcess;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101"/> class.
-        /// </summary>
-        /// <param name="dataPoints">A collection of time-series data points.</param>
-        public PacketType101(IEnumerable<IDataPoint> dataPoints)
-            : this()
-        {
-            if (dataPoints == null)
-                throw new ArgumentNullException("value");
-
-            foreach (IDataPoint dataPoint in dataPoints)
-            {
-                m_data.Add(new PacketType101DataPoint(dataPoint));
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101"/> class.
-        /// </summary>
-        /// <param name="measurements">A collection of mesurements.</param>
-        public PacketType101(IEnumerable<IMeasurement> measurements)
-            : this()
-        {
-            if (measurements == null)
-                throw new ArgumentNullException("value");
-
-            foreach (IMeasurement measurement in measurements)
-            {
-                m_data.Add(new PacketType101DataPoint(
-                    (int)measurement.Key.ID,
-                    new TimeTag((DateTime)measurement.Timestamp),
-                    (float)measurement.AdjustedValue,
-                    measurement.HistorianQuality()));
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType101(byte[] buffer, int startIndex, int length)
-            : this()
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets the time-series data in <see cref="PacketType101"/>.
-        /// </summary>
-        public IList<IDataPoint> Data
-        {
-            get
-            {
-                return m_data;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="PacketType101"/>.
-        /// </summary>
-        public override int BinaryLength
-        {
-            get
-            {
-                return (2 + 4 + (m_data.Count * PacketType101DataPoint.FixedLength));
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="PacketType101"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType101"/>.</returns>
-        public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= 6)
-            {
-                // Binary image has sufficient data.
-                short packetID = LittleEndian.ToInt16(buffer, startIndex);
-                if (packetID != TypeID)
-                    throw new ArgumentException(string.Format("Unexpected packet id '{0}' (expected '{1}')", packetID, TypeID));
-
-                // Ensure that the binary image is complete
-                int dataCount = LittleEndian.ToInt32(buffer, startIndex + 2);
-                if (length < 6 + dataCount * PacketType101DataPoint.FixedLength)
-                    return 0;
-
-                // We have a binary image with the correct packet id.
-                int offset;
-                m_data.Clear();
-                for (int i = 0; i < dataCount; i++)
-                {
-                    offset = startIndex + 6 + (i * PacketType101DataPoint.FixedLength);
-                    m_data.Add(new PacketType101DataPoint(buffer, offset, length - offset));
-                }
-
-                return BinaryLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="PacketType101"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public override int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_data.Count), 0, buffer, startIndex + 2, 4);
-            for (int i = 0; i < m_data.Count; i++)
-            {
-                m_data[i].GenerateBinaryImage(buffer, startIndex + 6 + (i * PacketType101DataPoint.FixedLength));
-            }
-
-            return length;
-        }
-
-        /// <summary>
-        /// Extracts time-series data from <see cref="PacketType101"/>.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="ArchiveDataPoint"/>s.</returns>
-        public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
-        {
-            List<IDataPoint> data = new List<IDataPoint>();
-            foreach (IDataPoint dataPoint in m_data)
-            {
-                data.Add(new ArchiveDataPoint(dataPoint));
-            }
-            return data;
-        }
-
-        /// <summary>
-        /// Processes <see cref="PacketType101"/>.
-        /// </summary>
-        /// <returns>A null reference.</returns>
-        protected virtual IEnumerable<byte[]> Process()
-        {
-            if (Archive != null)
-            {
-                foreach (IDataPoint dataPoint in ExtractTimeSeriesData())
-                {
-                    Archive.WriteData(dataPoint);
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Pre-processes <see cref="PacketType101"/>.
-        /// </summary>
-        /// <returns>A <see cref="byte"/> array for "ACK".</returns>
-        protected virtual IEnumerable<byte[]> PreProcess()
-        {
-            return new[] { Encoding.ASCII.GetBytes("ACK") };
-        }
-
-        #endregion
+        m_data = [];
+        ProcessHandler = Process;
+        PreProcessHandler = PreProcess;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType101"/> class.
+    /// </summary>
+    /// <param name="dataPoints">A collection of time-series data points.</param>
+    public PacketType101(IEnumerable<IDataPoint> dataPoints)
+        : this()
+    {
+        if (dataPoints is null)
+            throw new ArgumentNullException(nameof(dataPoints));
+
+        foreach (IDataPoint dataPoint in dataPoints)
+            m_data.Add(new PacketType101DataPoint(dataPoint));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType101"/> class.
+    /// </summary>
+    /// <param name="measurements">A collection of measurements.</param>
+    public PacketType101(IEnumerable<IMeasurement> measurements)
+        : this()
+    {
+        if (measurements is null)
+            throw new ArgumentNullException(nameof(measurements));
+
+        foreach (IMeasurement measurement in measurements)
+        {
+            m_data.Add(new PacketType101DataPoint(
+                (int)measurement.Key.ID,
+                new TimeTag((DateTime)measurement.Timestamp),
+                (float)measurement.AdjustedValue,
+                measurement.HistorianQuality()));
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType101"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType101(byte[] buffer, int startIndex, int length)
+        : this()
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets the time-series data in <see cref="PacketType101"/>.
+    /// </summary>
+    public IList<IDataPoint> Data => m_data;
+
+    /// <summary>
+    /// Gets the length of the <see cref="PacketType101"/>.
+    /// </summary>
+    public override int BinaryLength => 2 + 4 + m_data.Count * PacketType101DataPoint.FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="PacketType101"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType101"/>.</returns>
+    public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < 6)
+            return 0;
+        
+        // Binary image has sufficient data.
+        short packetID = LittleEndian.ToInt16(buffer, startIndex);
+        
+        if (packetID != TypeID)
+            throw new ArgumentException($"Unexpected packet id '{packetID}' (expected '{TypeID}')");
+
+        // Ensure that the binary image is complete
+        int dataCount = LittleEndian.ToInt32(buffer, startIndex + 2);
+        
+        if (length < 6 + dataCount * PacketType101DataPoint.FixedLength)
+            return 0;
+
+        // We have a binary image with the correct packet id.
+        int offset;
+        
+        m_data.Clear();
+        
+        for (int i = 0; i < dataCount; i++)
+        {
+            offset = startIndex + 6 + i * PacketType101DataPoint.FixedLength;
+            m_data.Add(new PacketType101DataPoint(buffer, offset, length - offset));
+        }
+
+        return BinaryLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="PacketType101"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public override int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_data.Count), 0, buffer, startIndex + 2, 4);
+
+        for (int i = 0; i < m_data.Count; i++)
+            m_data[i].GenerateBinaryImage(buffer, startIndex + 6 + i * PacketType101DataPoint.FixedLength);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Extracts time-series data from <see cref="PacketType101"/>.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="ArchiveDataPoint"/>s.</returns>
+    public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
+    {
+        return m_data.Select(dataPoint => new ArchiveDataPoint(dataPoint));
+    }
+
+    /// <summary>
+    /// Processes <see cref="PacketType101"/>.
+    /// </summary>
+    /// <returns>A null reference.</returns>
+    protected virtual IEnumerable<byte[]> Process()
+    {
+        if (Archive is null)
+            return null;
+        
+        foreach (IDataPoint dataPoint in ExtractTimeSeriesData())
+            Archive.WriteData(dataPoint);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Pre-processes <see cref="PacketType101"/>.
+    /// </summary>
+    /// <returns>A <see cref="byte"/> array for "ACK".</returns>
+    protected virtual IEnumerable<byte[]> PreProcess()
+    {
+        return [Encoding.ASCII.GetBytes("ACK")];
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType101DataPoint.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType101DataPoint.cs
@@ -35,146 +35,135 @@ using System;
 using GSF.Historian.Files;
 using GSF.TimeSeries;
 
-namespace GSF.Historian.Packets
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents time-series data transmitted in <see cref="PacketType101"/>.
+/// </summary>
+/// <seealso cref="PacketType101"/>
+public class PacketType101DataPoint : ArchiveDataPoint
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 4          0-3        Int32      HistorianID                                                   *
+    // * 4          4-7        Int32      Time                                                          *
+    // * 2          8-9        Int16      Flags (Quality & Milliseconds)                                *
+    // * 4          10-13      Single     Value                                                         *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents time-series data transmitted in <see cref="PacketType101"/>.
+    /// Specifies the number of bytes in the binary image of <see cref="PacketType101DataPoint"/>.
     /// </summary>
-    /// <seealso cref="PacketType101"/>
-    public class PacketType101DataPoint : ArchiveDataPoint
+    public new const int FixedLength = 14;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
+    /// </summary>
+    /// <param name="dataPoint">A time-series data point.</param>
+    public PacketType101DataPoint(IDataPoint dataPoint)
+        : base(dataPoint)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 4          0-3        Int32      HistorianID                                                   *
-        // * 4          4-7        Int32      Time                                                          *
-        // * 2          8-9        Int16      Flags (Quality & Milliseconds)                                *
-        // * 4          10-13      Single     Value                                                         *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="PacketType101DataPoint"/>.
-        /// </summary>
-        public new const int FixedLength = 14;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
-        /// </summary>
-        /// <param name="dataPoint">A time-series data point.</param>
-        public PacketType101DataPoint(IDataPoint dataPoint)
-            : base(dataPoint)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
-        /// </summary>
-        /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
-        public PacketType101DataPoint(IMeasurement measurement)
-            : base(measurement)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
-        /// </summary>
-        /// <param name="historianID">Historian identifier of <see cref="PacketType101DataPoint"/>.</param>
-        /// <param name="time"><see cref="TimeTag"/> of <see cref="PacketType101DataPoint"/>.</param>
-        /// <param name="value">Floating-point value of <see cref="PacketType101DataPoint"/>.</param>
-        /// <param name="quality"><see cref="Quality"/> of <see cref="PacketType101DataPoint"/>.</param>
-        public PacketType101DataPoint(int historianID, TimeTag time, float value, Quality quality)
-            : base(historianID, time, value, quality)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101DataPoint"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType101DataPoint(byte[] buffer, int startIndex, int length)
-            : base(1, buffer, startIndex, length)
-        {
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Gets the length of the <see cref="PacketType101DataPoint"/>.
-        /// </summary>
-        public override int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        /// <summary>
-        /// Initializes <see cref="PacketType101DataPoint"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101DataPoint"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType101DataPoint"/>.</returns>
-        public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                HistorianID = LittleEndian.ToInt32(buffer, startIndex);
-                Flags = LittleEndian.ToInt16(buffer, startIndex + 8);
-                Value = LittleEndian.ToSingle(buffer, startIndex + 10);
-                Time = new TimeTag(LittleEndian.ToInt32(buffer, startIndex + 4) +   // Seconds
-                        ((decimal)(Flags.GetMaskedValue(MillisecondMask) >> 5) / 1000));         // Milliseconds
-
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="PacketType101DataPoint"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public override int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(HistorianID), 0, buffer, startIndex, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes((int)Time.Value), 0, buffer, startIndex + 4, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes((short)Flags), 0, buffer, startIndex + 8, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(Value), 0, buffer, startIndex + 10, 4);
-
-            return length;
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
+    /// </summary>
+    /// <param name="measurement">Object that implements the <see cref="IMeasurement"/> interface.</param>
+    public PacketType101DataPoint(IMeasurement measurement)
+        : base(measurement)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
+    /// </summary>
+    /// <param name="historianID">Historian identifier of <see cref="PacketType101DataPoint"/>.</param>
+    /// <param name="time"><see cref="TimeTag"/> of <see cref="PacketType101DataPoint"/>.</param>
+    /// <param name="value">Floating-point value of <see cref="PacketType101DataPoint"/>.</param>
+    /// <param name="quality"><see cref="Quality"/> of <see cref="PacketType101DataPoint"/>.</param>
+    public PacketType101DataPoint(int historianID, TimeTag time, float value, Quality quality)
+        : base(historianID, time, value, quality)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType101DataPoint"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101DataPoint"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType101DataPoint(byte[] buffer, int startIndex, int length)
+        : base(1, buffer, startIndex, length)
+    {
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Gets the length of the <see cref="PacketType101DataPoint"/>.
+    /// </summary>
+    public override int BinaryLength => FixedLength;
+
+    /// <summary>
+    /// Initializes <see cref="PacketType101DataPoint"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType101DataPoint"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType101DataPoint"/>.</returns>
+    public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        HistorianID = LittleEndian.ToInt32(buffer, startIndex);
+        Flags = LittleEndian.ToInt16(buffer, startIndex + 8);
+        Value = LittleEndian.ToSingle(buffer, startIndex + 10);
+        Time = new TimeTag(LittleEndian.ToInt32(buffer, startIndex + 4) +   // Seconds
+                           (decimal)(Flags.GetMaskedValue(MillisecondMask) >> 5) / 1000);         // Milliseconds
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="PacketType101DataPoint"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public override int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(HistorianID), 0, buffer, startIndex, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes((int)Time.Value), 0, buffer, startIndex + 4, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes((short)Flags), 0, buffer, startIndex + 8, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(Value), 0, buffer, startIndex + 10, 4);
+
+        return length;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType11.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType11.cs
@@ -37,82 +37,86 @@ using System.Collections.Generic;
 using GSF.Historian.Files;
 using GSF.Parsing;
 
-namespace GSF.Historian.Packets
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a packet to be used for requesting <see cref="StateRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.
+/// </summary>
+public class PacketType11 : QueryPacketBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a packet to be used for requesting <see cref="StateRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.
+    /// Initializes a new instance of the <see cref="PacketType11"/> class.
     /// </summary>
-    public class PacketType11 : QueryPacketBase
+    public PacketType11()
+        : base(11)
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType11"/> class.
-        /// </summary>
-        public PacketType11()
-            : base(11)
-        {
-            ProcessHandler = Process;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType11"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType11"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType11(byte[] buffer, int startIndex, int length)
-            : this()
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes <see cref="PacketType11"/>.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> object containing the binary images of <see cref="StateRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.</returns>
-        protected virtual IEnumerable<byte[]> Process()
-        {
-            if (Archive == null)
-                yield break;
-
-            byte[] data;
-            if (RequestIDs.Count == 0 || (RequestIDs.Count == 1 && RequestIDs[0] == -1))
-            {
-                // Information for all defined records is requested.
-                int id = 0;
-                while (true)
-                {
-                    data = Archive.ReadStateDataSummary(++id);
-                    if (data == null)
-                        // No more records.
-                        break;
-                    else
-                        // Yield retrieved data.
-                        yield return data;
-                }
-            }
-            else
-            {
-                // Information for specific records is requested.
-                foreach (int id in RequestIDs)
-                {
-                    data = Archive.ReadStateDataSummary(id);
-                    if (data == null)
-                        // ID is invalid.
-                        continue;
-                    else
-                        // Yield retrieved data.
-                        yield return data;
-                }
-            }
-            yield return new StateRecord(-1).Summary.BinaryImage();   // To indicate EOT.
-        }
-
-        #endregion
+        ProcessHandler = Process;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType11"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType11"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType11(byte[] buffer, int startIndex, int length)
+        : this()
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes <see cref="PacketType11"/>.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> object containing the binary images of <see cref="StateRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.</returns>
+    protected virtual IEnumerable<byte[]> Process()
+    {
+        if (Archive is null)
+            yield break;
+
+        byte[] data;
+        
+        if (RequestIDs.Count == 0 || (RequestIDs.Count == 1 && RequestIDs[0] == -1))
+        {
+            // Information for all defined records is requested.
+            int id = 0;
+            
+            while (true)
+            {
+                data = Archive.ReadStateDataSummary(++id);
+                
+                if (data is null)
+                    break; // No more records.
+
+                // Yield retrieved data.
+                yield return data;
+            }
+        }
+        else
+        {
+            // Information for specific records is requested.
+            foreach (int id in RequestIDs)
+            {
+                data = Archive.ReadStateDataSummary(id);
+                
+                if (data is null)
+                    continue; // ID is invalid.
+                
+                // Yield retrieved data.
+                yield return data;
+            }
+        }
+
+        yield return new StateRecord(-1).Summary.BinaryImage();   // To indicate EOT.
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType2.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType2.cs
@@ -38,407 +38,340 @@ using System.Collections.Generic;
 using System.Text;
 using GSF.Historian.Files;
 
-namespace GSF.Historian.Packets
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a packet to be used for sending single time (expanded format) series data point to a historian for archival.
+/// </summary>
+public class PacketType2 : PacketBase
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 2          0-1        Int16      TypeID (packet identifier)                                    *
+    // * 4          2-5        Int32      HistorianID                                                   *
+    // * 2          6-7        Int16      Year                                                          *
+    // * 1          8          Byte       Month                                                         *
+    // * 1          9          Byte       Day                                                           *
+    // * 1          10         Byte       Hour                                                          *
+    // * 1          11         Byte       Minute                                                        *
+    // * 1          12         Byte       Second                                                        *
+    // * 1          13         Byte       Quality                                                       *
+    // * 2          14-15      Int16      Milliseconds                                                  *
+    // * 2          16-17      Int16      GmtOffset                                                     *
+    // * 4          18-21      Single     Value                                                         *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a packet to be used for sending single time (expanded format) series data point to a historian for archival.
+    /// Specifies the number of bytes in the binary image of <see cref="PacketType2"/>.
     /// </summary>
-    public class PacketType2 : PacketBase
+    public new const int FixedLength = 22;
+
+    // Fields
+    private int m_historianID;
+    private short m_year;
+    private short m_month;
+    private short m_day;
+    private short m_hour;
+    private short m_minute;
+    private short m_second;
+    private short m_millisecond;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType2"/> class.
+    /// </summary>
+    public PacketType2()
+        : base(2)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 2          0-1        Int16      TypeID (packet identifier)                                    *
-        // * 4          2-5        Int32      HistorianID                                                   *
-        // * 2          6-7        Int16      Year                                                          *
-        // * 1          8          Byte       Month                                                         *
-        // * 1          9          Byte       Day                                                           *
-        // * 1          10         Byte       Hour                                                          *
-        // * 1          11         Byte       Minute                                                        *
-        // * 1          12         Byte       Second                                                        *
-        // * 1          13         Byte       Quality                                                       *
-        // * 2          14-15      Int16      Milliseconds                                                  *
-        // * 2          16-17      Int16      GmtOffset                                                     *
-        // * 4          18-21      Single     Value                                                         *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="PacketType2"/>.
-        /// </summary>
-        public new const int FixedLength = 22;
-
-        // Fields
-        private int m_historianID;
-        private short m_year;
-        private short m_month;
-        private short m_day;
-        private short m_hour;
-        private short m_minute;
-        private short m_second;
-        private Quality m_quality;
-        private short m_millisecond;
-        private short m_gmtOffset;
-        private float m_value;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType2"/> class.
-        /// </summary>
-        public PacketType2()
-            : base(2)
-        {
-            ProcessHandler = Process;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType2"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType2"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType2(byte[] buffer, int startIndex, int length)
-            : this()
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the historian identifier of the time-series data.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
-        public int HistorianID
-        {
-            get
-            {
-                return m_historianID;
-            }
-            set
-            {
-                if (value < 1)
-                    throw new ArgumentException("Value must be positive.");
-
-                m_historianID = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the year-part of the time.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 1995 and 2063.</exception>
-        public short Year
-        {
-            get
-            {
-                return m_year;
-            }
-            set
-            {
-                if (value < TimeTag.MinValue.ToDateTime().Year || value > TimeTag.MaxValue.ToDateTime().Year)
-                    throw new ArgumentException("Value must 1995 and 2063.");
-
-                m_year = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the month-part of the time.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 1 and 12.</exception>
-        public short Month
-        {
-            get
-            {
-                return m_month;
-            }
-            set
-            {
-                if (value < 1 || value > 12)
-                    throw new ArgumentException("Value must be between 1 and 12.");
-
-                m_month = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the day-part of the time.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 1 and 31.</exception>
-        public short Day
-        {
-            get
-            {
-                return m_day;
-            }
-            set
-            {
-                if (value < 1 || value > 31)
-                    throw new ArgumentException("Value must be between 1 and 31.");
-
-                m_day = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the hour-part of the time.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 0 and 23.</exception>
-        public short Hour
-        {
-            get
-            {
-                return m_hour;
-            }
-            set
-            {
-                if (value < 0 || value > 23)
-                    throw new ArgumentException("Value must be between 0 and 23.");
-
-                m_hour = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the minute-part of the time.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 0 and 59.</exception>
-        public short Minute
-        {
-            get
-            {
-                return m_minute;
-            }
-            set
-            {
-                if (value < 0 || value > 59)
-                    throw new ArgumentException("Value must be between 0 and 59.");
-
-                m_minute = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the second-part of the time.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 0 and 59.</exception>
-        public short Second
-        {
-            get
-            {
-                return m_second;
-            }
-            set
-            {
-                if (value < 0 || value > 59)
-                    throw new ArgumentException("Value must be between 0 and 59.");
-
-                m_second = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="Quality"/> of the time-series data.
-        /// </summary>
-        public Quality Quality
-        {
-            get
-            {
-                return m_quality;
-            }
-            set
-            {
-                m_quality = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the millisecond-part of the time.
-        /// </summary>
-        /// <exception cref="ArgumentException">The value being assigned is not between 0 and 999.</exception>
-        public short Millisecond
-        {
-            get
-            {
-                return m_millisecond;
-            }
-            set
-            {
-                if (value < 0 || value > 999)
-                    throw new ArgumentException("Value must be between 0 and 999.");
-
-                m_millisecond = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the difference, in hours, between the local time and Greenwich Mean Time (Universal Coordinated Time).
-        /// </summary>
-        public short GmtOffset
-        {
-            get
-            {
-                return m_gmtOffset;
-            }
-            set
-            {
-                m_gmtOffset = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the time-series data.
-        /// </summary>
-        public float Value
-        {
-            get
-            {
-                return m_value;
-            }
-            set
-            {
-                m_value = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="PacketType2"/>.
-        /// </summary>
-        public override int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="PacketType2"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType2"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType2"/>.</returns>
-        public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                short packetID = LittleEndian.ToInt16(buffer, startIndex);
-                if (packetID != TypeID)
-                    throw new ArgumentException(string.Format("Unexpected packet id '{0}' (expected '{1}')", packetID, TypeID));
-
-                // We have a binary image with the correct packet id.
-                HistorianID = LittleEndian.ToInt32(buffer, startIndex + 2);
-                Year = LittleEndian.ToInt16(buffer, startIndex + 6);
-                Month = Convert.ToInt16(buffer[startIndex + 8]);
-                Day = Convert.ToInt16(buffer[startIndex + 9]);
-                Hour = Convert.ToInt16(buffer[startIndex + 10]);
-                Minute = Convert.ToInt16(buffer[startIndex + 11]);
-                Second = Convert.ToInt16(buffer[startIndex + 12]);
-                Quality = (Quality)(buffer[startIndex + 13]);
-                Millisecond = LittleEndian.ToInt16(buffer, startIndex + 14);
-                GmtOffset = LittleEndian.ToInt16(buffer, startIndex + 16);
-                Value = LittleEndian.ToSingle(buffer, startIndex + 18);
-
-                // We'll send an "ACK" to the sender if this is the last packet in the transmission.
-                if (length == FixedLength)
-                    PreProcessHandler = PreProcess;
-
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="PacketType2"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public override int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex + 2, 4);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_year), 0, buffer, startIndex + 6, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_month), 0, buffer, startIndex + 8, 1);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_day), 0, buffer, startIndex + 9, 1);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_hour), 0, buffer, startIndex + 10, 1);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_minute), 0, buffer, startIndex + 11, 1);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_second), 0, buffer, startIndex + 12, 1);
-            Buffer.BlockCopy(LittleEndian.GetBytes((int)m_quality), 0, buffer, startIndex + 13, 1);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_millisecond), 0, buffer, startIndex + 14, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_gmtOffset), 0, buffer, startIndex + 16, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_value), 0, buffer, startIndex + 18, 4);
-
-            return length;
-        }
-
-        /// <summary>
-        /// Extracts time-series data from <see cref="PacketType2"/>.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="ArchiveDataPoint"/>s.</returns>
-        public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
-        {
-            DateTime timestamp = new DateTime(m_year, m_month, m_day, m_hour + m_gmtOffset, m_minute, m_second, m_millisecond, DateTimeKind.Utc);
-
-            return new[] { new ArchiveDataPoint(m_historianID, new TimeTag(timestamp), m_value, m_quality) };
-        }
-
-        /// <summary>
-        /// Processes <see cref="PacketType2"/>.
-        /// </summary>
-        /// <returns>A null reference.</returns>
-        protected virtual IEnumerable<byte[]> Process()
-        {
-            if (Archive != null)
-            {
-                foreach (IDataPoint dataPoint in ExtractTimeSeriesData())
-                {
-                    Archive.WriteData(dataPoint);
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Pre-processes <see cref="PacketType2"/>.
-        /// </summary>
-        /// <returns>A <see cref="byte"/> array for "ACK".</returns>
-        protected virtual IEnumerable<byte[]> PreProcess()
-        {
-            return new[] { Encoding.ASCII.GetBytes("ACK") };
-        }
-
-        #endregion
+        ProcessHandler = Process;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType2"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType2"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType2(byte[] buffer, int startIndex, int length)
+        : this()
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the historian identifier of the time-series data.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not positive.</exception>
+    public int HistorianID
+    {
+        get => m_historianID;
+        set
+        {
+            if (value < 1)
+                throw new ArgumentException("Value must be positive.");
+
+            m_historianID = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the year-part of the time.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 1995 and 2063.</exception>
+    public short Year
+    {
+        get => m_year;
+        set
+        {
+            if (value < TimeTag.MinValue.ToDateTime().Year || value > TimeTag.MaxValue.ToDateTime().Year)
+                throw new ArgumentException("Value must 1995 and 2063.");
+
+            m_year = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the month-part of the time.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 1 and 12.</exception>
+    public short Month
+    {
+        get => m_month;
+        set
+        {
+            if (value is < 1 or > 12)
+                throw new ArgumentException("Value must be between 1 and 12.");
+
+            m_month = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the day-part of the time.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 1 and 31.</exception>
+    public short Day
+    {
+        get => m_day;
+        set
+        {
+            if (value is < 1 or > 31)
+                throw new ArgumentException("Value must be between 1 and 31.");
+
+            m_day = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the hour-part of the time.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 0 and 23.</exception>
+    public short Hour
+    {
+        get => m_hour;
+        set
+        {
+            if (value is < 0 or > 23)
+                throw new ArgumentException("Value must be between 0 and 23.");
+
+            m_hour = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the minute-part of the time.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 0 and 59.</exception>
+    public short Minute
+    {
+        get => m_minute;
+        set
+        {
+            if (value is < 0 or > 59)
+                throw new ArgumentException("Value must be between 0 and 59.");
+
+            m_minute = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the second-part of the time.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 0 and 59.</exception>
+    public short Second
+    {
+        get => m_second;
+        set
+        {
+            if (value is < 0 or > 59)
+                throw new ArgumentException("Value must be between 0 and 59.");
+
+            m_second = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Quality"/> of the time-series data.
+    /// </summary>
+    public Quality Quality { get; set; }
+
+    /// <summary>
+    /// Gets or sets the millisecond-part of the time.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value being assigned is not between 0 and 999.</exception>
+    public short Millisecond
+    {
+        get => m_millisecond;
+        set
+        {
+            if (value is < 0 or > 999)
+                throw new ArgumentException("Value must be between 0 and 999.");
+
+            m_millisecond = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the difference, in hours, between the local time and Greenwich Mean Time (Universal Coordinated Time).
+    /// </summary>
+    public short GmtOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of the time-series data.
+    /// </summary>
+    public float Value { get; set; }
+
+    /// <summary>
+    /// Gets the length of the <see cref="PacketType2"/>.
+    /// </summary>
+    public override int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="PacketType2"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType2"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType2"/>.</returns>
+    public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        short packetID = LittleEndian.ToInt16(buffer, startIndex);
+
+        if (packetID != TypeID)
+            throw new ArgumentException($"Unexpected packet id '{packetID}' (expected '{TypeID}')");
+
+        // We have a binary image with the correct packet id.
+        HistorianID = LittleEndian.ToInt32(buffer, startIndex + 2);
+        Year = LittleEndian.ToInt16(buffer, startIndex + 6);
+        Month = Convert.ToInt16(buffer[startIndex + 8]);
+        Day = Convert.ToInt16(buffer[startIndex + 9]);
+        Hour = Convert.ToInt16(buffer[startIndex + 10]);
+        Minute = Convert.ToInt16(buffer[startIndex + 11]);
+        Second = Convert.ToInt16(buffer[startIndex + 12]);
+        Quality = (Quality)buffer[startIndex + 13];
+        Millisecond = LittleEndian.ToInt16(buffer, startIndex + 14);
+        GmtOffset = LittleEndian.ToInt16(buffer, startIndex + 16);
+        Value = LittleEndian.ToSingle(buffer, startIndex + 18);
+
+        // We'll send an "ACK" to the sender if this is the last packet in the transmission.
+        if (length == FixedLength)
+            PreProcessHandler = PreProcess;
+
+        return FixedLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="PacketType2"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public override int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_historianID), 0, buffer, startIndex + 2, 4);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_year), 0, buffer, startIndex + 6, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_month), 0, buffer, startIndex + 8, 1);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_day), 0, buffer, startIndex + 9, 1);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_hour), 0, buffer, startIndex + 10, 1);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_minute), 0, buffer, startIndex + 11, 1);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_second), 0, buffer, startIndex + 12, 1);
+        Buffer.BlockCopy(LittleEndian.GetBytes((int)Quality), 0, buffer, startIndex + 13, 1);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_millisecond), 0, buffer, startIndex + 14, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(GmtOffset), 0, buffer, startIndex + 16, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(Value), 0, buffer, startIndex + 18, 4);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Extracts time-series data from <see cref="PacketType2"/>.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> object of <see cref="ArchiveDataPoint"/>s.</returns>
+    public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
+    {
+        DateTime timestamp = new(m_year, m_month, m_day, m_hour + GmtOffset, m_minute, m_second, m_millisecond, DateTimeKind.Utc);
+
+        return [new ArchiveDataPoint(m_historianID, new TimeTag(timestamp), Value, Quality)];
+    }
+
+    /// <summary>
+    /// Processes <see cref="PacketType2"/>.
+    /// </summary>
+    /// <returns>A null reference.</returns>
+    protected virtual IEnumerable<byte[]> Process()
+    {
+        if (Archive is null)
+            return null;
+        
+        foreach (IDataPoint dataPoint in ExtractTimeSeriesData())
+            Archive.WriteData(dataPoint);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Pre-processes <see cref="PacketType2"/>.
+    /// </summary>
+    /// <returns>A <see cref="byte"/> array for "ACK".</returns>
+    protected virtual IEnumerable<byte[]> PreProcess()
+    {
+        return [Encoding.ASCII.GetBytes("ACK")];
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType3.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType3.cs
@@ -37,80 +37,84 @@ using System.Collections.Generic;
 using GSF.Historian.Files;
 using GSF.Parsing;
 
-namespace GSF.Historian.Packets
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a packet to be used for requesting <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.
+/// </summary>
+public class PacketType3 : QueryPacketBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a packet to be used for requesting <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.
+    /// Initializes a new instance of the <see cref="PacketType3"/> class.
     /// </summary>
-    public class PacketType3 : QueryPacketBase
+    public PacketType3()
+        : base(3)
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType3"/> class.
-        /// </summary>
-        public PacketType3()
-            : base(3)
-        {
-            ProcessHandler = Process;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType3"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType3"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType3(byte[] buffer, int startIndex, int length)
-            : this()
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes <see cref="PacketType3"/>.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> object containing the binary images of <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.</returns>
-        protected virtual IEnumerable<byte[]> Process()
-        {
-            if (Archive == null)
-                yield break;
-
-            byte[] data;
-            if (RequestIDs.Count == 0 || (RequestIDs.Count == 1 && RequestIDs[0] == -1))
-            {
-                // Information for all defined records is requested.
-                int id = 0;
-                while (true)
-                {
-                    data = Archive.ReadMetaDataSummary(++id);
-                    if (data == null)
-                        // No more records.
-                        break;
-
-                    yield return data;
-                }
-            }
-            else
-            {
-                // Information for specific records is requested.
-                foreach (int id in RequestIDs)
-                {
-                    data = Archive.ReadMetaDataSummary(id);
-                    if (data == null)
-                        // ID is invalid.
-                        continue;
-
-                    yield return data;
-                }
-            }
-            yield return new MetadataRecord(-1, MetadataFileLegacyMode.Enabled).Summary.BinaryImage();    // To indicate EOT.
-        }
-
-        #endregion
+        ProcessHandler = Process;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType3"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType3"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType3(byte[] buffer, int startIndex, int length)
+        : this()
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes <see cref="PacketType3"/>.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> object containing the binary images of <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.</returns>
+    protected virtual IEnumerable<byte[]> Process()
+    {
+        if (Archive is null)
+            yield break;
+
+        byte[] data;
+
+        if (RequestIDs.Count == 0 || (RequestIDs.Count == 1 && RequestIDs[0] == -1))
+        {
+            // Information for all defined records is requested.
+            int id = 0;
+
+            while (true)
+            {
+                data = Archive.ReadMetaDataSummary(++id);
+                
+                if (data is null)
+                    break; // No more records.
+
+                yield return data;
+            }
+        }
+        else
+        {
+            // Information for specific records is requested.
+            foreach (int id in RequestIDs)
+            {
+                data = Archive.ReadMetaDataSummary(id);
+                
+                if (data is null) // ID is invalid.
+                    continue;
+
+                yield return data;
+            }
+        }
+
+        yield return new MetadataRecord(-1, MetadataFileLegacyMode.Enabled).Summary.BinaryImage();    // To indicate EOT.
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType4.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType4.cs
@@ -37,104 +37,105 @@ using System.Collections.Generic;
 using GSF.Historian.Files;
 using GSF.Parsing;
 
-namespace GSF.Historian.Packets
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a packet to be used for requesting <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/> only if the <see cref="MetadataRecord"/> has changed.
+/// </summary>
+public class PacketType4 : QueryPacketBase
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a packet to be used for requesting <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/> only if the <see cref="MetadataRecord"/> has changed.
+    /// Initializes a new instance of the <see cref="PacketType4"/> class.
     /// </summary>
-    public class PacketType4 : QueryPacketBase
+    public PacketType4()
+        : base(4)
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType4"/> class.
-        /// </summary>
-        public PacketType4()
-            : base(4)
-        {
-            ProcessHandler = Process;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType4"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType4"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType4(byte[] buffer, int startIndex, int length)
-            : this()
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Processes <see cref="PacketType4"/>.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> object containing the binary images of <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.</returns>
-        protected virtual IEnumerable<byte[]> Process()
-        {
-            if (Archive == null)
-                yield break;
-
-            byte[] data;
-            MetadataRecord record;
-            if (RequestIDs.Count == 0 || (RequestIDs.Count == 1 && RequestIDs[0] == -1))
-            {
-                // Information for all defined records is requested.
-                int id = 0;
-                while (true)
-                {
-                    data = Archive.ReadMetaData(++id);
-                    if (data == null)
-                    {
-                        // No more records.
-                        break;
-                    }
-
-                    record = new MetadataRecord(id, MetadataFileLegacyMode.Enabled, data, 0, data.Length);
-
-                    // Only send information that has changed.
-                    if (record.GeneralFlags.Changed)
-                    {
-                        // Reset the "changed" field.
-                        record.GeneralFlags.Changed = false;
-                        Archive.WriteMetaData(id, record.BinaryImage());
-
-                        yield return record.Summary.BinaryImage();
-                    }
-                }
-            }
-            else
-            {
-                // Information for specific records is requested.
-                foreach (int id in RequestIDs)
-                {
-                    data = Archive.ReadMetaData(id);
-                    if (data == null)
-                    {
-                        // ID is invalid.
-                        continue;
-                    }
-
-                    record = new MetadataRecord(id, MetadataFileLegacyMode.Enabled, data, 0, data.Length);
-
-                    // Only send information that has changed.
-                    if (record.GeneralFlags.Changed)
-                    {
-                        // Reset the "changed" field.
-                        record.GeneralFlags.Changed = false;
-                        Archive.WriteMetaData(id, record.BinaryImage());
-
-                        yield return record.Summary.BinaryImage();
-                    }
-                }
-            }
-            yield return new MetadataRecord(-1, MetadataFileLegacyMode.Enabled).Summary.BinaryImage();    // To indicate EOT.
-        }
-        #endregion
+        ProcessHandler = Process;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType4"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType4"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType4(byte[] buffer, int startIndex, int length)
+        : this()
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Processes <see cref="PacketType4"/>.
+    /// </summary>
+    /// <returns>An <see cref="IEnumerable{T}"/> object containing the binary images of <see cref="MetadataRecord.Summary"/> for the <see cref="QueryPacketBase.RequestIDs"/>.</returns>
+    protected virtual IEnumerable<byte[]> Process()
+    {
+        if (Archive is null)
+            yield break;
+
+        byte[] data;
+        MetadataRecord record;
+
+        if (RequestIDs.Count == 0 || (RequestIDs.Count == 1 && RequestIDs[0] == -1))
+        {
+            // Information for all defined records is requested.
+            int id = 0;
+            
+            while (true)
+            {
+                data = Archive.ReadMetaData(++id);
+                
+                if (data is null)
+                    break; // No more records.
+
+                record = new MetadataRecord(id, MetadataFileLegacyMode.Enabled, data, 0, data.Length);
+
+                // Only send information that has changed.
+                if (!record.GeneralFlags.Changed)
+                    continue;
+                
+                // Reset the "changed" field.
+                record.GeneralFlags.Changed = false;
+                Archive.WriteMetaData(id, record.BinaryImage());
+
+                yield return record.Summary.BinaryImage();
+            }
+        }
+        else
+        {
+            // Information for specific records is requested.
+            foreach (int id in RequestIDs)
+            {
+                data = Archive.ReadMetaData(id);
+                
+                if (data is null)
+                    continue; // ID is invalid.
+
+                record = new MetadataRecord(id, MetadataFileLegacyMode.Enabled, data, 0, data.Length);
+
+                // Only send information that has changed.
+                if (!record.GeneralFlags.Changed)
+                    continue;
+                
+                // Reset the "changed" field.
+                record.GeneralFlags.Changed = false;
+                Archive.WriteMetaData(id, record.BinaryImage());
+
+                yield return record.Summary.BinaryImage();
+            }
+        }
+        
+        yield return new MetadataRecord(-1, MetadataFileLegacyMode.Enabled).Summary.BinaryImage();    // To indicate EOT.
+    }
+    
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/PacketType5.cs
+++ b/Source/Libraries/GSF.Historian/Packets/PacketType5.cs
@@ -34,129 +34,120 @@
 using System;
 using System.Collections.Generic;
 
-namespace GSF.Historian.Packets
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Represents a packet that can be used to query the status of a historian.
+/// </summary>
+public class PacketType5 : PacketBase
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 2          0-1        Int16      TypeID (packet identifier)                                    *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Constants
+
     /// <summary>
-    /// Represents a packet that can be used to query the status of a historian.
+    /// Specifies the number of bytes in the binary image of <see cref="PacketType5"/>.
     /// </summary>
-    public class PacketType5 : PacketBase
+    public new const int FixedLength = 2;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType5"/> class.
+    /// </summary>
+    public PacketType5()
+        : base(5)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 2          0-1        Int16      TypeID (packet identifier)                                    *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Constants
-
-        /// <summary>
-        /// Specifies the number of bytes in the binary image of <see cref="PacketType5"/>.
-        /// </summary>
-        public new const int FixedLength = 2;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType5"/> class.
-        /// </summary>
-        public PacketType5()
-            : base(5)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PacketType5"/> class.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType5"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        public PacketType5(byte[] buffer, int startIndex, int length)
-            : this()
-        {
-            ParseBinaryImage(buffer, startIndex, length);
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets the length of the <see cref="PacketType5"/>.
-        /// </summary>
-        public override int BinaryLength
-        {
-            get
-            {
-                return FixedLength;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes <see cref="PacketType5"/> from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType5"/>.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType5"/>.</returns>
-        public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= FixedLength)
-            {
-                // Binary image has sufficient data.
-                short packetID = LittleEndian.ToInt16(buffer, startIndex);
-                if (packetID != TypeID)
-                    throw new ArgumentException(string.Format("Unexpected packet id '{0}' (expected '{1}')", packetID, TypeID));
-
-                // We have a binary image with the correct packet id and that all this packet type will contain.
-                return FixedLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-        /// <summary>
-        /// Generates binary image of the <see cref="PacketType5"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public override int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
-
-            return length;
-        }
-
-        /// <summary>
-        /// Extracts time-series data from <see cref="PacketType5"/>.
-        /// </summary>
-        /// <returns>A null reference.</returns>
-        public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
-        {
-            return null;
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketType5"/> class.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType5"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    public PacketType5(byte[] buffer, int startIndex, int length)
+        : this()
+    {
+        ParseBinaryImage(buffer, startIndex, length);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets the length of the <see cref="PacketType5"/>.
+    /// </summary>
+    public override int BinaryLength => FixedLength;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes <see cref="PacketType5"/> from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing <see cref="PacketType5"/>.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing <see cref="PacketType5"/>.</returns>
+    public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < FixedLength)
+            return 0;
+        
+        // Binary image has sufficient data.
+        short packetID = LittleEndian.ToInt16(buffer, startIndex);
+
+        if (packetID != TypeID)
+            throw new ArgumentException($"Unexpected packet id '{packetID}' (expected '{TypeID}')");
+
+        // We have a binary image with the correct packet id and that all this packet type will contain.
+        return FixedLength;
+    }
+    /// <summary>
+    /// Generates binary image of the <see cref="PacketType5"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public override int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+        Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Extracts time-series data from <see cref="PacketType5"/>.
+    /// </summary>
+    /// <returns>A null reference.</returns>
+    public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
+    {
+        return null;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Packets/QueryPacketBase.cs
+++ b/Source/Libraries/GSF.Historian/Packets/QueryPacketBase.cs
@@ -34,147 +34,130 @@
 using System;
 using System.Collections.Generic;
 
-namespace GSF.Historian.Packets
+namespace GSF.Historian.Packets;
+
+/// <summary>
+/// Base class for a packet to be used for requesting information from a historian.
+/// </summary>
+public abstract class QueryPacketBase : PacketBase
 {
+    // **************************************************************************************************
+    // *                                        Binary Structure                                        *
+    // **************************************************************************************************
+    // * # Of Bytes Byte Index Data Type  Property Name                                                 *
+    // * ---------- ---------- ---------- --------------------------------------------------------------*
+    // * 2          0-1        Int16      TypeID (packet identifier)                                    *
+    // * 4          2-5        Int32      RequestIDs.Count                                              *
+    // * 4          6-9        Int32      RequestIDs[0]                                                 *
+    // * 4          n1-n2      Int32      RequestIDs[RequestIDs.Count -1 ]                              *
+    // **************************************************************************************************
+
+    #region [ Members ]
+
+    // Fields
+    private readonly List<int> m_requestIDs;
+
+    #endregion
+
+    #region [ Constructors ]
+
     /// <summary>
-    /// Base class for a packet to be used for requesting information from a historian.
+    /// Initializes a new instance of the query packet.
     /// </summary>
-    public abstract class QueryPacketBase : PacketBase
+    /// <param name="packetID">Numeric identifier for the packet type.</param>
+    protected QueryPacketBase(short packetID)
+        : base(packetID)
     {
-        // **************************************************************************************************
-        // *                                        Binary Structure                                        *
-        // **************************************************************************************************
-        // * # Of Bytes Byte Index Data Type  Property Name                                                 *
-        // * ---------- ---------- ---------- --------------------------------------------------------------*
-        // * 2          0-1        Int16      TypeID (packet identifier)                                    *
-        // * 4          2-5        Int32      RequestIDs.Count                                              *
-        // * 4          6-9        Int32      RequestIDs[0]                                                 *
-        // * 4          n1-n2      Int32      RequestIDs[RequestIDs.Count -1 ]                              *
-        // **************************************************************************************************
-
-        #region [ Members ]
-
-        // Fields
-        private readonly List<int> m_requestIDs;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the query packet.
-        /// </summary>
-        /// <param name="packetID">Numeric identifier for the packet type.</param>
-        protected QueryPacketBase(short packetID)
-            : base(packetID)
-        {
-            m_requestIDs = new List<int>();
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets a list of historian identifiers whose information is being requested.
-        /// </summary>
-        /// <remarks>A singe entry with ID of -1 can be used to request information for all defined historian identifiers.</remarks>
-        public IList<int> RequestIDs
-        {
-            get
-            {
-                return m_requestIDs;
-            }
-        }
-
-        /// <summary>
-        /// Gets the length of the <see cref="QueryPacketBase"/>.
-        /// </summary>
-        public override int BinaryLength
-        {
-            get
-            {
-                return (2 + 4 + (m_requestIDs.Count * 4));
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Initializes the query packet from the specified <paramref name="buffer"/>.
-        /// </summary>
-        /// <param name="buffer">Binary image to be used for initializing the query packet.</param>
-        /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
-        /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
-        /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing the query packet.</returns>
-        public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
-        {
-            if (length >= 6)
-            {
-                // Binary image has sufficient data.
-                short packetID = LittleEndian.ToInt16(buffer, startIndex);
-                if (packetID != TypeID)
-                    throw new ArgumentException(string.Format("Unexpected packet id '{0}' (expected '{1}')", packetID, TypeID));
-
-                // Ensure that the binary image is complete
-                int requestIDCount = LittleEndian.ToInt32(buffer, startIndex + 2);
-                if (length < 6 + requestIDCount * 4)
-                    return 0;
-
-                // We have a binary image with the correct packet id.
-                m_requestIDs.Clear();
-                for (int i = 0; i < requestIDCount; i++)
-                {
-                    m_requestIDs.Add(LittleEndian.ToInt32(buffer, startIndex + 6 + (i * 4)));
-                }
-
-                return BinaryLength;
-            }
-            else
-            {
-                // Binary image does not have sufficient data.
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Generates binary image of the <see cref="QueryPacketBase"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
-        /// </summary>
-        /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
-        /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
-        /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
-        /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
-        /// </exception>
-        public override int GenerateBinaryImage(byte[] buffer, int startIndex)
-        {
-            int length = BinaryLength;
-
-            buffer.ValidateParameters(startIndex, length);
-
-            Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
-            Buffer.BlockCopy(LittleEndian.GetBytes(m_requestIDs.Count), 0, buffer, startIndex + 2, 4);
-            for (int i = 0; i < m_requestIDs.Count; i++)
-            {
-                Buffer.BlockCopy(LittleEndian.GetBytes(m_requestIDs[i]), 0, buffer, startIndex + 6 + (i * 4), 4);
-            }
-
-            return length;
-        }
-
-        /// <summary>
-        /// Extracts time-series data from the query packet type.
-        /// </summary>
-        /// <returns>A null reference.</returns>
-        public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
-        {
-            return null;
-        }
-
-        #endregion
+        m_requestIDs = [];
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets a list of historian identifiers whose information is being requested.
+    /// </summary>
+    /// <remarks>A singe entry with ID of -1 can be used to request information for all defined historian identifiers.</remarks>
+    public IList<int> RequestIDs => m_requestIDs;
+
+    /// <summary>
+    /// Gets the length of the <see cref="QueryPacketBase"/>.
+    /// </summary>
+    public override int BinaryLength => 2 + 4 + m_requestIDs.Count * 4;
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Initializes the query packet from the specified <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Binary image to be used for initializing the query packet.</param>
+    /// <param name="startIndex">0-based starting index of initialization data in the <paramref name="buffer"/>.</param>
+    /// <param name="length">Valid number of bytes in <paramref name="buffer"/> from <paramref name="startIndex"/>.</param>
+    /// <returns>Number of bytes used from the <paramref name="buffer"/> for initializing the query packet.</returns>
+    public override int ParseBinaryImage(byte[] buffer, int startIndex, int length)
+    {
+        // Binary image does not have sufficient data.
+        if (length < 6)
+            return 0;
+        
+        // Binary image has sufficient data.
+        short packetID = LittleEndian.ToInt16(buffer, startIndex);
+        
+        if (packetID != TypeID)
+            throw new ArgumentException($"Unexpected packet id '{packetID}' (expected '{TypeID}')");
+
+        // Ensure that the binary image is complete
+        int requestIDCount = LittleEndian.ToInt32(buffer, startIndex + 2);
+        
+        if (length < 6 + requestIDCount * 4)
+            return 0;
+
+        // We have a binary image with the correct packet id.
+        m_requestIDs.Clear();
+        
+        for (int i = 0; i < requestIDCount; i++)
+            m_requestIDs.Add(LittleEndian.ToInt32(buffer, startIndex + 6 + i * 4));
+
+        return BinaryLength;
+    }
+
+    /// <summary>
+    /// Generates binary image of the <see cref="QueryPacketBase"/> and copies it into the given buffer, for <see cref="BinaryLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">Buffer used to hold generated binary image of the source object.</param>
+    /// <param name="startIndex">0-based starting index in the <paramref name="buffer"/> to start writing.</param>
+    /// <returns>The number of bytes written to the <paramref name="buffer"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex"/> or <see cref="BinaryLength"/> is less than 0 -or- 
+    /// <paramref name="startIndex"/> and <see cref="BinaryLength"/> will exceed <paramref name="buffer"/> length.
+    /// </exception>
+    public override int GenerateBinaryImage(byte[] buffer, int startIndex)
+    {
+        int length = BinaryLength;
+
+        buffer.ValidateParameters(startIndex, length);
+
+        Buffer.BlockCopy(LittleEndian.GetBytes(TypeID), 0, buffer, startIndex, 2);
+        Buffer.BlockCopy(LittleEndian.GetBytes(m_requestIDs.Count), 0, buffer, startIndex + 2, 4);
+        
+        for (int i = 0; i < m_requestIDs.Count; i++)
+            Buffer.BlockCopy(LittleEndian.GetBytes(m_requestIDs[i]), 0, buffer, startIndex + 6 + i * 4, 4);
+
+        return length;
+    }
+
+    /// <summary>
+    /// Extracts time-series data from the query packet type.
+    /// </summary>
+    /// <returns>A null reference.</returns>
+    public override IEnumerable<IDataPoint> ExtractTimeSeriesData()
+    {
+        return null;
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Replication/IReplicationProvider.cs
+++ b/Source/Libraries/GSF.Historian/Replication/IReplicationProvider.cs
@@ -28,66 +28,65 @@
 using System;
 using GSF.Adapters;
 
-namespace GSF.Historian.Replication
+namespace GSF.Historian.Replication;
+
+/// <summary>
+/// Defines a provider of replication mechanism for the <see cref="IArchive"/>.
+/// </summary>
+public interface IReplicationProvider : IAdapter
 {
+    #region [ Members ]
+
+    // Events
+
     /// <summary>
-    /// Defines a provider of replication mechanism for the <see cref="IArchive"/>.
+    /// Occurs when the process of replicating the <see cref="IArchive"/> is started.
     /// </summary>
-    public interface IReplicationProvider : IAdapter
-    {
-        #region [ Members ]
+    event EventHandler ReplicationStart;
 
-        // Events
+    /// <summary>
+    /// Occurs when the process of replicating the <see cref="IArchive"/> is complete.
+    /// </summary>
+    event EventHandler ReplicationComplete;
 
-        /// <summary>
-        /// Occurs when the process of replicating the <see cref="IArchive"/> is started.
-        /// </summary>
-        event EventHandler ReplicationStart;
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered during the replication process of <see cref="IArchive"/>.
+    /// </summary>
+    event EventHandler<EventArgs<Exception>> ReplicationException;
 
-        /// <summary>
-        /// Occurs when the process of replicating the <see cref="IArchive"/> is complete.
-        /// </summary>
-        event EventHandler ReplicationComplete;
+    /// <summary>
+    /// Occurs when the <see cref="IArchive"/> is being replicated.
+    /// </summary>
+    event EventHandler<EventArgs<ProcessProgress<int>>> ReplicationProgress;
 
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered during the replication process of <see cref="IArchive"/>.
-        /// </summary>
-        event EventHandler<EventArgs<Exception>> ReplicationException;
+    #endregion
 
-        /// <summary>
-        /// Occurs when the <see cref="IArchive"/> is being replicated.
-        /// </summary>
-        event EventHandler<EventArgs<ProcessProgress<int>>> ReplicationProgress;
+    #region [ Properties ]
 
-        #endregion
+    /// <summary>
+    /// Gets or sets the primary location of the <see cref="IArchive"/>.
+    /// </summary>
+    string ArchiveLocation { get; set; }
 
-        #region [ Properties ]
+    /// <summary>
+    /// Gets or sets the mirrored location of the <see cref="IArchive"/>.
+    /// </summary>
+    string ReplicaLocation { get; set; }
 
-        /// <summary>
-        /// Gets or sets the primary location of the <see cref="IArchive"/>.
-        /// </summary>
-        string ArchiveLocation { get; set; }
+    /// <summary>
+    /// Gets or sets the interval in milliseconds at which the <see cref="IArchive"/> is to be replicated.
+    /// </summary>
+    int ReplicationInterval { get; set; }
 
-        /// <summary>
-        /// Gets or sets the mirrored location of the <see cref="IArchive"/>.
-        /// </summary>
-        string ReplicaLocation { get; set; }
+    #endregion
 
-        /// <summary>
-        /// Gets or sets the interval in milliseconds at which the <see cref="IArchive"/> is to be replicated.
-        /// </summary>
-        int ReplicationInterval { get; set; }
+    #region [ Methods ]
 
-        #endregion
+    /// <summary>
+    /// Replicates the <see cref="IArchive"/>.
+    /// </summary>
+    /// <returns>true if the replication is successful; otherwise false.</returns>
+    bool Replicate();
 
-        #region [ Methods ]
-
-        /// <summary>
-        /// Replicates the <see cref="IArchive"/>.
-        /// </summary>
-        /// <returns>true if the replication is successful; otherwise false.</returns>
-        bool Replicate();
-
-        #endregion
-    }
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Replication/NamespaceDoc.cs
+++ b/Source/Libraries/GSF.Historian/Replication/NamespaceDoc.cs
@@ -27,13 +27,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace GSF.Historian.Replication
+namespace GSF.Historian.Replication;
+
+/// <summary>
+/// Contains classes and interfaces that allow for the replication of the time-series data archive.
+/// </summary>
+[CompilerGenerated]
+class NamespaceDoc
 {
-    /// <summary>
-    /// Contains classes and interfaces that allow for the replication of the time-series data archive.
-    /// </summary>
-    [CompilerGenerated]
-    class NamespaceDoc
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/Replication/ReplicationProviderBase.cs
+++ b/Source/Libraries/GSF.Historian/Replication/ReplicationProviderBase.cs
@@ -37,298 +37,267 @@ using GSF.Adapters;
 using GSF.Configuration;
 using Timer = System.Timers.Timer;
 
-namespace GSF.Historian.Replication
+// ReSharper disable VirtualMemberCallInConstructor
+
+namespace GSF.Historian.Replication;
+
+/// <summary>
+/// Base class for a provider of replication mechanism for the <see cref="IArchive"/>.
+/// </summary>
+public abstract class ReplicationProviderBase : Adapter, IReplicationProvider
 {
+    #region [ Members ]
+
+    // Events
+
     /// <summary>
-    /// Base class for a provider of replication mechanism for the <see cref="IArchive"/>.
+    /// Occurs when the process of replicating the <see cref="IArchive"/> is started.
     /// </summary>
-    public abstract class ReplicationProviderBase : Adapter, IReplicationProvider
+    public event EventHandler ReplicationStart;
+
+    /// <summary>
+    /// Occurs when the process of replicating the <see cref="IArchive"/> is complete.
+    /// </summary>
+    public event EventHandler ReplicationComplete;
+
+    /// <summary>
+    /// Occurs when an <see cref="Exception"/> is encountered during the replication process of <see cref="IArchive"/>.
+    /// </summary>
+    public event EventHandler<EventArgs<Exception>> ReplicationException;
+
+    /// <summary>
+    /// Occurs when the <see cref="IArchive"/> is being replicated.
+    /// </summary>
+    public event EventHandler<EventArgs<ProcessProgress<int>>> ReplicationProgress;
+
+    // Fields
+    private int m_replicationInterval;
+    private Thread m_replicationThread;
+    private Timer m_replicationTimer;
+    private bool m_initialized;
+    private bool m_disposed;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Initializes a new instance of the replication provider.
+    /// </summary>
+    protected ReplicationProviderBase()
     {
-        #region [ Members ]
-
-        // Events
-
-        /// <summary>
-        /// Occurs when the process of replicating the <see cref="IArchive"/> is started.
-        /// </summary>
-        public event EventHandler ReplicationStart;
-
-        /// <summary>
-        /// Occurs when the process of replicating the <see cref="IArchive"/> is complete.
-        /// </summary>
-        public event EventHandler ReplicationComplete;
-
-        /// <summary>
-        /// Occurs when an <see cref="Exception"/> is encountered during the replication process of <see cref="IArchive"/>.
-        /// </summary>
-        public event EventHandler<EventArgs<Exception>> ReplicationException;
-
-        /// <summary>
-        /// Occurs when the <see cref="IArchive"/> is being replicated.
-        /// </summary>
-        public event EventHandler<EventArgs<ProcessProgress<int>>> ReplicationProgress;
-
-        // Fields
-        private string m_archiveLocation;
-        private string m_replicaLocation;
-        private int m_replicationInterval;
-        private Thread m_replicationThread;
-        private Timer m_replicationTimer;
-        private bool m_initialized;
-        private bool m_disposed;
-
-        #endregion
-
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the replication provider.
-        /// </summary>
-        protected ReplicationProviderBase()
-        {
-            m_replicationInterval = -1;
-            PersistSettings = true;
-        }
-
-        #endregion
-
-        #region [ Properties ]
-
-        /// <summary>
-        /// Gets or sets the primary location of the <see cref="IArchive"/>.
-        /// </summary>
-        public string ArchiveLocation
-        {
-            get
-            {
-                return m_archiveLocation;
-            }
-            set
-            {
-                m_archiveLocation = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the mirrored location of the <see cref="IArchive"/>.
-        /// </summary>
-        public string ReplicaLocation
-        {
-            get
-            {
-                return m_replicaLocation;
-            }
-            set
-            {
-                m_replicaLocation = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the interval in minutes at which the <see cref="IArchive"/> is to be replicated.
-        /// </summary>
-        public int ReplicationInterval
-        {
-            get
-            {
-                return m_replicationInterval;
-            }
-            set
-            {
-                if (value < 0)
-                    m_replicationInterval = -1;
-                else
-                    m_replicationInterval = value;
-            }
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// When overridden in a derived class, replicates the <see cref="IArchive"/>.
-        /// </summary>
-        protected abstract void ReplicateArchive();
-
-        /// <summary>
-        /// Initializes the replication provider.
-        /// </summary>
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            if (!m_initialized)
-            {
-                // Start timer for periodic replication.
-                if (Enabled && m_replicationInterval > 0)
-                {
-                    m_replicationTimer = new Timer(m_replicationInterval * 60000);
-                    m_replicationTimer.Elapsed += ReplicationTimer_Elapsed;
-                    m_replicationTimer.Start();
-                }
-
-                // Initialize only once.
-                m_initialized = true;
-            }
-        }
-
-        /// <summary>
-        /// Saves replication provider settings to the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
-        public override void SaveSettings()
-        {
-            base.SaveSettings();
-
-            if (PersistSettings)
-            {
-                // Save settings under the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings["Enabled", true].Update(Enabled);
-                settings["ArchiveLocation", true].Update(m_archiveLocation);
-                settings["ReplicaLocation", true].Update(m_replicaLocation);
-                settings["ReplicationInterval", true].Update(m_replicationInterval);
-                config.Save();
-            }
-        }
-
-        /// <summary>
-        /// Loads saved replication provider settings from the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
-        /// </summary>
-        /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-
-            if (PersistSettings)
-            {
-                // Load settings from the specified category.
-                ConfigurationFile config = ConfigurationFile.Current;
-                CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
-                settings.Add("Enabled", Enabled, "True if this replication provider is enabled; otherwise False.");
-                settings.Add("ArchiveLocation", m_archiveLocation, "Path to the primary location of time-series data archive.");
-                settings.Add("ReplicaLocation", m_replicaLocation, "Path to the mirrored location of time-series data archive.");
-                settings.Add("ReplicationInterval", m_replicationInterval, "Interval in minutes at which the time-series data archive is to be replicated.");
-                Enabled = settings["Enabled"].ValueAs(Enabled);
-                ArchiveLocation = settings["ArchiveLocation"].ValueAs(m_archiveLocation);
-                ReplicaLocation = settings["ReplicaLocation"].ValueAs(m_replicaLocation);
-                ReplicationInterval = settings["ReplicationInterval"].ValueAs(m_replicationInterval);
-            }
-        }
-
-        /// <summary>
-        /// Replicates the <see cref="IArchive"/>.
-        /// </summary>
-        /// <returns>true if the replication is successful; otherwise false.</returns>
-        /// <exception cref="ArgumentNullException"><see cref="ArchiveLocation"/> or <see cref="ReplicaLocation"/> is null or empty string.</exception>
-        public bool Replicate()
-        {
-            if (!Enabled || (m_replicationThread != null && m_replicationThread.IsAlive))
-                return false;
-
-            if (string.IsNullOrEmpty(m_archiveLocation))
-                throw new ArgumentNullException("ArchiveLocation");
-
-            if (string.IsNullOrEmpty(m_replicaLocation))
-                throw new ArgumentNullException("ReplicaLocation");
-
-            m_replicationThread = new Thread(ReplicateInternal);
-            m_replicationThread.Start();
-            m_replicationThread.Join();
-
-            return true;
-        }
-
-        /// <summary>
-        /// Releases the unmanaged resources used by the replication provider and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (!m_disposed)
-            {
-                try
-                {
-                    // This will be done regardless of whether the object is finalized or disposed.				
-                    if (disposing)
-                    {
-                        if (m_replicationThread != null)
-                            m_replicationThread.Abort();
-
-                        if (m_replicationTimer != null)
-                        {
-                            m_replicationTimer.Elapsed -= ReplicationTimer_Elapsed;
-                            m_replicationTimer.Dispose();
-                        }
-                    }
-                }
-                finally
-                {
-                    m_disposed = true;  // Prevent duplicate dispose.
-                    base.Dispose(disposing);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ReplicationStart"/> event.
-        /// </summary>
-        protected virtual void OnReplicationStart()
-        {
-            if (ReplicationStart != null)
-                ReplicationStart(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ReplicationComplete"/> event.
-        /// </summary>
-        protected virtual void OnReplicationComplete()
-        {
-            if (ReplicationComplete != null)
-                ReplicationComplete(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ReplicationException"/> event.
-        /// </summary>
-        /// <param name="ex"><see cref="Exception"/> to send to <see cref="ReplicationException"/> event.</param>
-        protected virtual void OnReplicationException(Exception ex)
-        {
-            if (ReplicationException != null)
-                ReplicationException(this, new EventArgs<Exception>(ex));
-        }
-
-        /// <summary>
-        /// Raises the <see cref="ReplicationProgress"/> event.
-        /// </summary>
-        /// <param name="replicationProgress"><see cref="ProcessProgress{T}"/> to send to <see cref="ReplicationProgress"/> event.</param>
-        protected virtual void OnReplicationProgress(ProcessProgress<int> replicationProgress)
-        {
-            if (ReplicationProgress != null)
-                ReplicationProgress(this, new EventArgs<ProcessProgress<int>>(replicationProgress));
-        }
-
-        private void ReplicateInternal()
-        {
-            try
-            {
-                OnReplicationStart();
-                ReplicateArchive();
-                OnReplicationComplete();
-            }
-            catch (Exception ex)
-            {
-                OnReplicationException(ex);
-            }
-        }
-
-        private void ReplicationTimer_Elapsed(object sender, ElapsedEventArgs e)
-        {
-            Replicate();
-        }
-
-        #endregion
+        m_replicationInterval = -1;
+        PersistSettings = true;
     }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets or sets the primary location of the <see cref="IArchive"/>.
+    /// </summary>
+    public string ArchiveLocation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the mirrored location of the <see cref="IArchive"/>.
+    /// </summary>
+    public string ReplicaLocation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the interval in minutes at which the <see cref="IArchive"/> is to be replicated.
+    /// </summary>
+    public int ReplicationInterval
+    {
+        get => m_replicationInterval;
+        set => m_replicationInterval = value < 0 ? -1 : value;
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// When overridden in a derived class, replicates the <see cref="IArchive"/>.
+    /// </summary>
+    protected abstract void ReplicateArchive();
+
+    /// <summary>
+    /// Initializes the replication provider.
+    /// </summary>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        if (m_initialized)
+            return;
+        
+        // Start timer for periodic replication.
+        if (Enabled && m_replicationInterval > 0)
+        {
+            m_replicationTimer = new Timer(m_replicationInterval * 60000);
+            m_replicationTimer.Elapsed += ReplicationTimer_Elapsed;
+            m_replicationTimer.Start();
+        }
+
+        // Initialize only once.
+        m_initialized = true;
+    }
+
+    /// <summary>
+    /// Saves replication provider settings to the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
+    public override void SaveSettings()
+    {
+        base.SaveSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Save settings under the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings[nameof(Enabled), true].Update(Enabled);
+        settings[nameof(ArchiveLocation), true].Update(ArchiveLocation);
+        settings[nameof(ReplicaLocation), true].Update(ReplicaLocation);
+        settings[nameof(ReplicationInterval), true].Update(m_replicationInterval);
+        
+        config.Save();
+    }
+
+    /// <summary>
+    /// Loads saved replication provider settings from the config file if the <see cref="Adapter.PersistSettings"/> property is set to true.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"><see cref="Adapter.SettingsCategory"/> has a value of null or empty string.</exception>
+    public override void LoadSettings()
+    {
+        base.LoadSettings();
+
+        if (!PersistSettings)
+            return;
+        
+        // Load settings from the specified category.
+        ConfigurationFile config = ConfigurationFile.Current;
+        CategorizedSettingsElementCollection settings = config.Settings[SettingsCategory];
+        
+        settings.Add(nameof(Enabled), Enabled, "True if this replication provider is enabled; otherwise False.");
+        settings.Add(nameof(ArchiveLocation), ArchiveLocation, "Path to the primary location of time-series data archive.");
+        settings.Add(nameof(ReplicaLocation), ReplicaLocation, "Path to the mirrored location of time-series data archive.");
+        settings.Add(nameof(ReplicationInterval), m_replicationInterval, "Interval in minutes at which the time-series data archive is to be replicated.");
+        
+        Enabled = settings[nameof(Enabled)].ValueAs(Enabled);
+        ArchiveLocation = settings[nameof(ArchiveLocation)].ValueAs(ArchiveLocation);
+        ReplicaLocation = settings[nameof(ReplicaLocation)].ValueAs(ReplicaLocation);
+        ReplicationInterval = settings[nameof(ReplicationInterval)].ValueAs(m_replicationInterval);
+    }
+
+    /// <summary>
+    /// Replicates the <see cref="IArchive"/>.
+    /// </summary>
+    /// <returns>true if the replication is successful; otherwise false.</returns>
+    /// <exception cref="ArgumentNullException"><see cref="ArchiveLocation"/> or <see cref="ReplicaLocation"/> is null or empty string.</exception>
+    public bool Replicate()
+    {
+        if (!Enabled || (m_replicationThread is not null && m_replicationThread.IsAlive))
+            return false;
+
+        if (string.IsNullOrEmpty(ArchiveLocation))
+            throw new ArgumentNullException(nameof(ArchiveLocation));
+
+        if (string.IsNullOrEmpty(ReplicaLocation))
+            throw new ArgumentNullException(nameof(ReplicaLocation));
+
+        m_replicationThread = new Thread(ReplicateInternal);
+        m_replicationThread.Start();
+        m_replicationThread.Join();
+
+        return true;
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the replication provider and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (m_disposed)
+            return;
+        
+        try
+        {
+            // This will be done regardless of whether the object is finalized or disposed.				
+            if (!disposing)
+                return;
+            
+            m_replicationThread?.Abort();
+
+            if (m_replicationTimer is not null)
+            {
+                m_replicationTimer.Elapsed -= ReplicationTimer_Elapsed;
+                m_replicationTimer.Dispose();
+            }
+        }
+        finally
+        {
+            m_disposed = true;  // Prevent duplicate dispose.
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ReplicationStart"/> event.
+    /// </summary>
+    protected virtual void OnReplicationStart()
+    {
+        ReplicationStart?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ReplicationComplete"/> event.
+    /// </summary>
+    protected virtual void OnReplicationComplete()
+    {
+        ReplicationComplete?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ReplicationException"/> event.
+    /// </summary>
+    /// <param name="ex"><see cref="Exception"/> to send to <see cref="ReplicationException"/> event.</param>
+    protected virtual void OnReplicationException(Exception ex)
+    {
+        ReplicationException?.Invoke(this, new EventArgs<Exception>(ex));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ReplicationProgress"/> event.
+    /// </summary>
+    /// <param name="replicationProgress"><see cref="ProcessProgress{T}"/> to send to <see cref="ReplicationProgress"/> event.</param>
+    protected virtual void OnReplicationProgress(ProcessProgress<int> replicationProgress)
+    {
+        ReplicationProgress?.Invoke(this, new EventArgs<ProcessProgress<int>>(replicationProgress));
+    }
+
+    private void ReplicateInternal()
+    {
+        try
+        {
+            OnReplicationStart();
+            ReplicateArchive();
+            OnReplicationComplete();
+        }
+        catch (Exception ex)
+        {
+            OnReplicationException(ex);
+        }
+    }
+
+    private void ReplicationTimer_Elapsed(object sender, ElapsedEventArgs e)
+    {
+        Replicate();
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/Replication/ReplicationProviders.cs
+++ b/Source/Libraries/GSF.Historian/Replication/ReplicationProviders.cs
@@ -27,12 +27,11 @@
 
 using GSF.Adapters;
 
-namespace GSF.Historian.Replication
+namespace GSF.Historian.Replication;
+
+/// <summary>
+/// A class that loads all of the <see cref="IReplicationProvider">replication providers</see>.
+/// </summary>
+public class ReplicationProviders : AdapterLoader<IReplicationProvider>
 {
-    /// <summary>
-    /// A class that loads all of the <see cref="IReplicationProvider">replication providers</see>.
-    /// </summary>
-    public class ReplicationProviders : AdapterLoader<IReplicationProvider>
-    {
-    }
 }

--- a/Source/Libraries/GSF.Historian/TimeTag.cs
+++ b/Source/Libraries/GSF.Historian/TimeTag.cs
@@ -40,219 +40,202 @@ using System;
 using System.Globalization;
 using System.Runtime.Serialization;
 
-namespace GSF.Historian
+namespace GSF.Historian;
+
+/// <summary>
+/// Represents a historian time tag as number of seconds from the <see cref="BaseDate"/>.
+/// </summary>
+[Serializable]
+public class TimeTag : TimeTagBase, IComparable<TimeTag>
 {
+    #region [ Constructors ]
+
     /// <summary>
-    /// Represents a historian time tag as number of seconds from the <see cref="BaseDate"/>.
+    /// Initializes a new instance of the <see cref="TimeTag"/> class.
     /// </summary>
-    [Serializable]
-    public class TimeTag : TimeTagBase, IComparable<TimeTag>
+    /// <param name="ticks">Number of ticks since the <see cref="BaseDate"/>.</param>
+    public TimeTag(long ticks)
+        : base(BaseDate.Ticks, ticks)
     {
-        #region [ Constructors ]
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeTag"/> class.
-        /// </summary>
-        /// <param name="ticks">Number of ticks since the <see cref="BaseDate"/>.</param>
-        public TimeTag(long ticks)
-            : base(BaseDate.Ticks, ticks)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeTag"/> class.
-        /// </summary>
-        /// <param name="seconds">Number of seconds since the <see cref="BaseDate"/>.</param>
-        public TimeTag(decimal seconds)
-            : base(BaseDate.Ticks, seconds)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeTag"/> class.
-        /// </summary>
-        /// <param name="timestamp"><see cref="DateTime"/> value on or past the <see cref="BaseDate"/>.</param>
-        public TimeTag(DateTime timestamp)
-            : base(BaseDate.Ticks, timestamp)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="TimeTag"/> from serialization parameters.
-        /// </summary>
-        /// <param name="info">The <see cref="SerializationInfo"/> with populated with data.</param>
-        /// <param name="context">The source <see cref="StreamingContext"/> for this deserialization.</param>
-        protected TimeTag(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
-
-        #endregion
-
-        #region [ Methods ]
-
-        /// <summary>
-        /// Returns the default text representation of <see cref="TimeTag"/>.
-        /// </summary>
-        /// <returns><see cref="string"/> that represents <see cref="TimeTag"/>.</returns>
-        public override string ToString()
-        {
-            return ToString("dd-MMM-yyyy HH:mm:ss.fff");
-        }
-
-        /// <summary>
-        /// Compares this time tag instance to another time tag instance and returns an integer that indicates whether the value of this instance
-        /// is less than, equal to, or greater than the value of the other time tag.
-        /// </summary>
-        /// <param name="other">A <see cref="TimeTag"/> instance to compare.</param>
-        /// <returns>A signed number indicating the relative values of this instance and the other value.</returns>
-        /// <remarks>
-        /// Time tags are compared by their value.
-        /// </remarks>
-        public int CompareTo(TimeTag other)
-        {
-            decimal tVal = Value;
-            decimal oVal = other.Value;
-            return tVal < oVal ? -1 : tVal > oVal ? 1 : 0;
-        }
-
-        #endregion
-
-        #region [ Static ]
-
-        // Static Fields
-
-        /// <summary>
-        /// Represents the smallest possible value of <see cref="TimeTag"/>.
-        /// </summary>
-        public static readonly TimeTag MinValue;
-
-        /// <summary>
-        /// Represents the largest possible value of <see cref="TimeTag"/>.
-        /// </summary>
-        public static readonly TimeTag MaxValue;
-
-        /// <summary>
-        /// Represents the base <see cref="DateTime"/> (01/01/1995) for <see cref="TimeTag"/>.
-        /// </summary>
-        public static readonly DateTime BaseDate;
-
-        // Static Constructor
-
-        static TimeTag()
-        {
-            BaseDate = new DateTime(1995, 1, 1, 0, 0, 0);
-            MinValue = new TimeTag(0.0M);
-            MaxValue = new TimeTag(2147483647.999M);
-        }
-
-        // Static Properties
-
-        /// <summary>
-        /// Gets a <see cref="TimeTag"/> object that is set to the current date and time on this computer, expressed as the local time.
-        /// </summary>
-        public static TimeTag Now
-        {
-            get
-            {
-                return new TimeTag(DateTime.Now.Ticks - BaseDate.Ticks);
-            }
-        }
-
-        /// <summary>
-        /// Gets a <see cref="TimeTag"/> object that is set to the current date and time on this computer, expressed as the Coordinated Universal Time (UTC).
-        /// </summary>
-        public static TimeTag UtcNow
-        {
-            get
-            {
-                return new TimeTag(DateTime.UtcNow.Ticks - BaseDate.Ticks);
-            }
-        }
-
-        // Static Methods
-
-        /// <summary>
-        /// Converts the specified string representation of a date and time to its <see cref="TimeTag"/> equivalent.
-        /// </summary>
-        /// <param name="timetag">A string containing the date and time to convert.</param>
-        /// <returns>A <see cref="TimeTag"/> object.</returns>
-        /// <remarks>
-        /// <paramref name="timetag"/> can be specified in one of the following format:
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Time Format</term>
-        ///         <description>Format Description</description>
-        ///     </listheader>
-        ///     <item>
-        ///         <term>12-30-2000 23:59:59</term>
-        ///         <description>Absolute date and time.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>*</term>
-        ///         <description>Evaluates to <see cref="DateTime.UtcNow"/>.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>*-20s</term>
-        ///         <description>Evaluates to 20 seconds before <see cref="DateTime.UtcNow"/>.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>*-10m</term>
-        ///         <description>Evaluates to 10 minutes before <see cref="DateTime.UtcNow"/>.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>*-1h</term>
-        ///         <description>Evaluates to 1 hour before <see cref="DateTime.UtcNow"/>.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>*-1d</term>
-        ///         <description>Evaluates to 1 day before <see cref="DateTime.UtcNow"/>.</description>
-        ///     </item>
-        /// </list>
-        /// </remarks>
-        public static TimeTag Parse(string timetag)
-        {
-            DateTime dateTime;
-            timetag = timetag.ToLower();
-            if (timetag.Contains("*"))
-            {
-                // Relative time is specified.
-                // Examples:
-                // 1) * (Now)
-                // 2) *-20s (20 seconds ago)
-                // 3) *-10m (10 minutes ago)
-                // 4) *-1h (1 hour ago)
-                // 5) *-1d (1 day ago)
-                dateTime = DateTime.UtcNow;
-                if (timetag.Length > 1)
-                {
-                    string unit = timetag.Substring(timetag.Length - 1);
-                    int adjustment = int.Parse(timetag.Substring(1, timetag.Length - 2));
-                    switch (unit)
-                    {
-                        case "s":
-                            dateTime = dateTime.AddSeconds(adjustment);
-                            break;
-                        case "m":
-                            dateTime = dateTime.AddMinutes(adjustment);
-                            break;
-                        case "h":
-                            dateTime = dateTime.AddHours(adjustment);
-                            break;
-                        case "d":
-                            dateTime = dateTime.AddDays(adjustment);
-                            break;
-                    }
-                }
-            }
-            else
-            {
-                // Absolute time is specified.
-                dateTime = DateTime.Parse(timetag, CultureInfo.InvariantCulture);
-            }
-
-            return new TimeTag(dateTime);
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeTag"/> class.
+    /// </summary>
+    /// <param name="seconds">Number of seconds since the <see cref="BaseDate"/>.</param>
+    public TimeTag(decimal seconds)
+        : base(BaseDate.Ticks, seconds)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeTag"/> class.
+    /// </summary>
+    /// <param name="timestamp"><see cref="DateTime"/> value on or past the <see cref="BaseDate"/>.</param>
+    public TimeTag(DateTime timestamp)
+        : base(BaseDate.Ticks, timestamp)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="TimeTag"/> from serialization parameters.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> with populated with data.</param>
+    /// <param name="context">The source <see cref="StreamingContext"/> for this deserialization.</param>
+    protected TimeTag(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Returns the default text representation of <see cref="TimeTag"/>.
+    /// </summary>
+    /// <returns><see cref="string"/> that represents <see cref="TimeTag"/>.</returns>
+    public override string ToString()
+    {
+        return ToString("dd-MMM-yyyy HH:mm:ss.fff");
+    }
+
+    /// <summary>
+    /// Compares this time tag instance to another time tag instance and returns an integer that indicates whether the value of this instance
+    /// is less than, equal to, or greater than the value of the other time tag.
+    /// </summary>
+    /// <param name="other">A <see cref="TimeTag"/> instance to compare.</param>
+    /// <returns>A signed number indicating the relative values of this instance and the other value.</returns>
+    /// <remarks>
+    /// Time tags are compared by their value.
+    /// </remarks>
+    public int CompareTo(TimeTag other)
+    {
+        decimal tVal = Value;
+        decimal oVal = other.Value;
+        return tVal < oVal ? -1 : tVal > oVal ? 1 : 0;
+    }
+
+    #endregion
+
+    #region [ Static ]
+
+    // Static Fields
+
+    /// <summary>
+    /// Represents the smallest possible value of <see cref="TimeTag"/>.
+    /// </summary>
+    public static readonly TimeTag MinValue;
+
+    /// <summary>
+    /// Represents the largest possible value of <see cref="TimeTag"/>.
+    /// </summary>
+    public static readonly TimeTag MaxValue;
+
+    /// <summary>
+    /// Represents the base <see cref="DateTime"/> (01/01/1995) for <see cref="TimeTag"/>.
+    /// </summary>
+    public static readonly DateTime BaseDate;
+
+    // Static Constructor
+
+    static TimeTag()
+    {
+        BaseDate = new DateTime(1995, 1, 1, 0, 0, 0);
+        MinValue = new TimeTag(0.0M);
+        MaxValue = new TimeTag(2147483647.999M);
+    }
+
+    // Static Properties
+
+    /// <summary>
+    /// Gets a <see cref="TimeTag"/> object that is set to the current date and time on this computer, expressed as the local time.
+    /// </summary>
+    public static TimeTag Now => new(DateTime.Now.Ticks - BaseDate.Ticks);
+
+    /// <summary>
+    /// Gets a <see cref="TimeTag"/> object that is set to the current date and time on this computer, expressed as the Coordinated Universal Time (UTC).
+    /// </summary>
+    public static TimeTag UtcNow => new(DateTime.UtcNow.Ticks - BaseDate.Ticks);
+
+    // Static Methods
+
+    /// <summary>
+    /// Converts the specified string representation of a date and time to its <see cref="TimeTag"/> equivalent.
+    /// </summary>
+    /// <param name="timetag">A string containing the date and time to convert.</param>
+    /// <returns>A <see cref="TimeTag"/> object.</returns>
+    /// <remarks>
+    /// <paramref name="timetag"/> can be specified in one of the following format:
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Time Format</term>
+    ///         <description>Format Description</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>12-30-2000 23:59:59</term>
+    ///         <description>Absolute date and time.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>*</term>
+    ///         <description>Evaluates to <see cref="DateTime.UtcNow"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>*-20s</term>
+    ///         <description>Evaluates to 20 seconds before <see cref="DateTime.UtcNow"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>*-10m</term>
+    ///         <description>Evaluates to 10 minutes before <see cref="DateTime.UtcNow"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>*-1h</term>
+    ///         <description>Evaluates to 1 hour before <see cref="DateTime.UtcNow"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>*-1d</term>
+    ///         <description>Evaluates to 1 day before <see cref="DateTime.UtcNow"/>.</description>
+    ///     </item>
+    /// </list>
+    /// </remarks>
+    public static TimeTag Parse(string timetag)
+    {
+        DateTime dateTime;
+        timetag = timetag.ToLower();
+
+        if (timetag.Contains("*"))
+        {
+            // Relative time is specified.
+            // Examples:
+            // 1) * (Now)
+            // 2) *-20s (20 seconds ago)
+            // 3) *-10m (10 minutes ago)
+            // 4) *-1h (1 hour ago)
+            // 5) *-1d (1 day ago)
+            dateTime = DateTime.UtcNow;
+
+            if (timetag.Length <= 1)
+                return new TimeTag(dateTime);
+            
+            string unit = timetag.Substring(timetag.Length - 1);
+            int adjustment = int.Parse(timetag.Substring(1, timetag.Length - 2));
+
+            dateTime = unit switch
+            {
+                "s" => dateTime.AddSeconds(adjustment),
+                "m" => dateTime.AddMinutes(adjustment),
+                "h" => dateTime.AddHours(adjustment),
+                "d" => dateTime.AddDays(adjustment),
+                _ => dateTime
+            };
+        }
+        else
+        {
+            // Absolute time is specified.
+            dateTime = DateTime.Parse(timetag, CultureInfo.InvariantCulture);
+        }
+
+        return new TimeTag(dateTime);
+    }
+
+    #endregion
 }

--- a/Source/Libraries/GSF.Historian/TimeTagException.cs
+++ b/Source/Libraries/GSF.Historian/TimeTagException.cs
@@ -23,36 +23,35 @@
 
 using System;
 
-namespace GSF.Historian
+namespace GSF.Historian;
+
+/// <summary>
+/// Represents an exception related to <see cref="TimeTag"/> instances.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable")]
+public class TimeTagException : Exception
 {
     /// <summary>
-    /// Represents an exception related to <see cref="TimeTag"/> instances.
+    /// Initializes a new instance of the <see cref="TimeTagException" /> class.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable")]
-    public class TimeTagException : Exception
+    public TimeTagException()
+    {            
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeTagException" /> class with a specified error <paramref name="message"/> that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    public TimeTagException(string message) : base(message)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeTagException" /> class.
-        /// </summary>
-        public TimeTagException()
-        {            
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeTagException" /> class with a specified error <paramref name="message"/> that is the cause of this exception.
-        /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        public TimeTagException(string message) : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeTagException" /> class with a specified error <paramref name="message"/> and a reference to the <paramref name="innerException"/> that is the cause of this exception.
-        /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
-        public TimeTagException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeTagException" /> class with a specified error <paramref name="message"/> and a reference to the <paramref name="innerException"/> that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a <c>null</c> reference if no inner exception is specified.</param>
+    public TimeTagException(string message, Exception innerException) : base(message, innerException)
+    {
     }
 }


### PR DESCRIPTION
This adds the ability to query the GSF historian in reverse order any time requested time range has a start time greater than the end time.

Instead of throwing an exception, API will now read, and return data, in reverse time order.

This allows systems, e.g., Grafana, to quickly assess if last alarm state change, reading in reverse before target time range, was in a raised state. Since read operation can stop after first encountered point, operation is lightweight.

As part of this change, a full code refresh of this library was performed, bringing code up to the latest C# standards.

Some small optimizations were also added as part of the read operations with this update, ensuring yielding enumerators were used, where possible, instead of reading large sets of target data into buffers, then returning.