### PR TITLE
GSF.TimeSeries: Don't use UTC when validating timestamps during temporal measurement updates

### DIFF
--- a/Source/Libraries/GSF.TimeSeries/ImmediateMeasurements.cs
+++ b/Source/Libraries/GSF.TimeSeries/ImmediateMeasurements.cs
@@ -281,7 +281,7 @@ namespace GSF.TimeSeries
             TemporalMeasurement measurement = Measurement(newMeasurement);
 
             // Set new value updating state flags if value was updated...
-            if (!measurement.SetValue(newMeasurement.Timestamp, newMeasurement.Value, newMeasurement.StateFlags))
+            if (!measurement.SetValue(m_realTimeFunction(), newMeasurement.Timestamp, newMeasurement.Value, newMeasurement.StateFlags))
                 return;
 
             measurement.Metadata = newMeasurement.Metadata;

--- a/Source/Libraries/GSF.TimeSeries/TemporalMeasurement.cs
+++ b/Source/Libraries/GSF.TimeSeries/TemporalMeasurement.cs
@@ -206,17 +206,18 @@ namespace GSF.TimeSeries
         /// <remarks>
         /// <para>Operation will only store a value that is newer than the cached value.</para>
         /// </remarks>
+        /// <param name="currentTime">Timestamp, in ticks, used to constrain <see cref="TemporalMeasurement"/> (typically set to real-time, i.e. "now").</param>
         /// <param name="timestamp">New timestamp, in ticks, for <see cref="TemporalMeasurement"/>.</param>
         /// <param name="value">New value for <see cref="TemporalMeasurement"/>, only stored if <paramref name="timestamp"/> are newer than current <see cref="Ticks"/>.</param>
         /// <param name="flags">New flags for <see cref="TemporalMeasurement"/>.</param>
         /// <returns><c>true</c> if value was updated; otherwise <c>false</c>.</returns>
-        public bool SetValue(Ticks timestamp, double value, MeasurementStateFlags flags)
+        public bool SetValue(Ticks currentTime, Ticks timestamp, double value, MeasurementStateFlags flags)
         {
             // We only store a value that is newer than the current value
             if (timestamp <= Timestamp)
                 return false;
 
-            bool timeInBounds = timestamp.UtcTimeIsValid(m_lagTime, m_leadTime);
+            bool timeInBounds = timestamp.TimeIsValid(currentTime, m_lagTime, m_leadTime);
 
             if (!timeInBounds && OutlierOperation == TemporalOutlierOperation.PublishValueAsNan)
                 return false;


### PR DESCRIPTION
It's unintuitive when `ImmediateMeasurements` has a `RealTimeFunction` property, but doesn't use it when validating timestamps during measurement updates. Since `ImmediateMeasurements` is the only user of the `TemporalMeasurement` class, we can just change the signature of `TemporalMeasurement.SetValue()` to receive the value returned by `ImmediateMeasurements.RealTimeFunction()` and use it for validation.