### PR TITLE
GSF.Core: Fix performance of regex used to parse console args

### DIFF
--- a/Source/Libraries/GSF.Core/Console/Arguments.cs
+++ b/Source/Libraries/GSF.Core/Console/Arguments.cs
@@ -104,7 +104,7 @@ namespace GSF.Console
         /// <summary>
         /// Regular expression pattern for tokenizing a list of arguments.
         /// </summary>
-        public const string TokenRegex = @"(?:(?<Open>"")(?:[^\\""]*(?:\\.)*)*(?<Close-Open>"")(?(Open)(?!))|\S)+";
+        public const string TokenRegex = /* lang=regex */ @"(?:""(?:\\.|[^\\""])*""|\S)+";
 
         /// <summary>
         /// Default value for <see cref="OrderedArgID"/>.


### PR DESCRIPTION
Let's break it down.

1. `(?<Open>")` matches the opening quote. The named capturing group is used later in two other capturing groups.
2. `(?:[^\\"]*(?:\\.)*)*` first attempts to match as many characters as it can, so long as they're not a backslash or a quote. If it's a backslash, it will forcefully match the character after the backslash and continue to look for backslashes. The asterisk on the outside allows us to go back and match not-backslash-or-quote characters again as many times as we need to until we find a quote.
3. `(?<Close-Open>")` matches the closing quote. The capturing group syntax causes the regex engine to delete the `Open` capturing group and capture everything in between the quotes as the `Close` capturing group.
4. `(?(Open)(?!))` conditionally fails to match `(?!)` if the `Open` capturing group has a match. `(?!)` is a negative lookahead expression that fails if it matches the empty string. Since any input will always match the empty string, then the `(?!)` expression always fails. In other words, this forces the match to fail if the `Open` capturing group was not deleted by the `Close-Open` capturing group.

2 is the part that causes the performance issues. The asterisk quantifiers on both the inside and outside of the outer non-capturing group turn this into an O(n^2) match, and the worst-case is when the close-quote can't be found. Regex Storm takes over 3 seconds and bails once you reach 24 characters after the open-quote. To fix the performance issue, I replaced it with a much simpler `(?:\\.|[^\\""])*` that first attempts to match backslash with the character after it, then attempts to match a character that isn't backslash or quote. Since there is only one asterisk quantifier, the regex can easily match this in O(n) time.

As for where the grouping constructs went, let's start with 4. It might make sense to include this construct if it were possible to reach it without having already matched `Close-Open`, like if we were matching open/close parens with the possibility of nesting. We're not doing that, though, so it's completely useless and can be removed entirely.

Next is `Close-Open`. This group would be useful if we cared about the contents of the double quotes, but we do not. It was also useful for deleting the `Open` capturing group, but since we already eliminated 4, we can also eliminate this capturing group and replace it with a simple `"`.

Lastly, we have `Open`. The only reason this existed was to be referenced by `Close-Open` and 4. Since we eliminated those constructs, this group is no longer necessary and can similarly be replaced by a simple `"`. 