### PR TITLE
PhasorWebUI: Don't reuse phasors in line groupings for 3-phase MW

### DIFF
--- a/Source/Libraries/Adapters/PhasorWebUI/Views/AddSynchrophasorDevice.cshtml
+++ b/Source/Libraries/Adapters/PhasorWebUI/Views/AddSynchrophasorDevice.cshtml
@@ -2632,6 +2632,10 @@
                     if (!nextVoltage)
                         continue;
 
+                    // See if this line current has already been matched
+                    if (lineCurrentExists(lines, nextCurrent))
+                        continue;
+
                     // See if this next current is for matching line based on label minus phase designations
                     if (match === nextCurrent.Label().trim().toUpperCase().replace(/[ABCRYB]/gi, "")) {
                         line[nextPhase] = {


### PR DESCRIPTION
We encountered a situation with the following phase labels...

```
IA-CUST._BANK_A_230KV
IB-CUST._BANK_A_230KV
IC-CUST._BANK_A_230KV
IA-CUST._BANK_B_230KV
IB-CUST._BANK_B_230KV
IC-CUST._BANK_B_230KV
IA-CUST._BANK_C_230KV
IB-CUST._BANK_C_230KV
IC-CUST._BANK_C_230KV
```

Because the line grouping logic removes A/B/C, the primary differentiating factor between these phasors went away so all 9 phasors looked like they were on the same line.

```
I-UST._NK__230KV
I-UST._NK__230KV
I-UST._NK__230KV
I-UST._NK__230KV
I-UST._NK__230KV
I-UST._NK__230KV
I-UST._NK__230KV
I-UST._NK__230KV
I-UST._NK__230KV
```

Since these phasors are in a logical order, this wouldn't have mattered except that the inner loop wasn't checking if phasors had been used before. So what ended up happening was something like this...

1. Outer loop selects IA from Bank A, inner loop selects IB and IC from Bank A.
2. Outer loop skips IB and IC from Bank A because they were already used.
3. Outer loop selects IA from Bank B, inner loop selects IB and IC from Bank A (!!).
4. Outer loop selects IB from Bank B (!!), inner loop selects IA and IC from Bank A (!!!).
5. etc...

I'm pretty sure this is not how that was supposed to work here so I'm submitting this for review.