### PR TITLE
Optimize monitoring screens in Manager applications

### DIFF
--- a/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/RealTimeStream.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/RealTimeStream.cs
@@ -358,6 +358,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
                                     {
                                         device.Info,
                                         MeasurementList = new ObservableCollection<RealTimeMeasurement>(device.Measurements
+                                            .Where(measurement => measurement.ConvertField<bool>("Enabled"))
                                             .Where(measurement => measurement.ConvertField<bool>("Subscribed") || measurement.ConvertField<bool>("Internal") || (settings.ContainsKey("securityMode") && settings["securityMode"].Equals("None", StringComparison.OrdinalIgnoreCase))) // We will only display measurements which are internal or subscribed to avoid confusion.
                                             .Select(measurement => new RealTimeMeasurement
                                             {
@@ -412,6 +413,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
                         Expanded = false,
                         DeviceList = new ObservableCollection<RealTimeDevice>(otherMeasurements
                             .AsEnumerable()
+                            .Where(measurement => measurement.ConvertField<bool>("Enabled"))
                             .Where(measurement => measurement.ConvertNullableField<int>("DeviceID") is null)
                             .GroupBy(measurement => GetSourceName(measurement.Field<string>("SignalReference")))
                             .Select(grouping => new RealTimeDevice
@@ -465,6 +467,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
                         Expanded = false,
                         DeviceList = new ObservableCollection<RealTimeDevice>(resultSet.Tables["MeasurementTable"]
                             .AsEnumerable()
+                            .Where(measurement => measurement.ConvertField<bool>("Enabled"))
                             .Where(measurement => measurement.ConvertNullableField<int>("DeviceID") is null)
                             .GroupBy(measurement => GetSourceName(measurement.Field<string>("SignalReference")))
                             .Select(grouping => new RealTimeDevice

--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputStatusMonitorUserControl.xaml
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputStatusMonitorUserControl.xaml
@@ -586,7 +586,8 @@
             
             <!-- Measurement Tree -->
             <TreeView ItemsSource="{tsfBinding:Column Path=ItemsSource}" ItemTemplate="{StaticResource RootNodeTemplate}" ItemContainerStyle="{StaticResource ExpandedItemStyle}" 
-                      Height="615" Width="275" VerticalAlignment="Top" HorizontalAlignment="Left" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      Height="615" Width="275" VerticalAlignment="Top" HorizontalAlignment="Left" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling">
                 <TreeView.Resources>
                     <SolidColorBrush Color="White" x:Key="{x:Static SystemColors.HighlightBrushKey}"/>
                 </TreeView.Resources>

--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/RealTimeMeasurementUserControl.xaml
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/RealTimeMeasurementUserControl.xaml
@@ -596,7 +596,7 @@
             </StackPanel>
 
             <TreeView ItemsSource="{tsfBinding:Column Path=ItemsSource}" ItemTemplate="{StaticResource RootNodeTemplate}" ItemContainerStyle="{StaticResource ExpandedItemStyle}"
-                      Height="610" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                      Height="610" VerticalAlignment="Top" HorizontalAlignment="Left" VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling" />
 
         </StackPanel>
 

--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/RealTimeStatisticUserControl.xaml
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/RealTimeStatisticUserControl.xaml
@@ -151,7 +151,8 @@
         </StackPanel>
 
             <TreeView ItemsSource="{tsfBinding:Column Path=ItemsSource}" ItemTemplate="{StaticResource RootNodeTemplate}" ItemContainerStyle="{StaticResource ExpandedItemStyle}"
-                      Height="610" VerticalAlignment="Top" HorizontalAlignment="Left" Width="850" ScrollViewer.HorizontalScrollBarVisibility="Disabled"/>
+                      Height="610" VerticalAlignment="Top" HorizontalAlignment="Left" Width="850" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                      VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling" />
 
       </StackPanel>
 


### PR DESCRIPTION
The first commit introduces `GroupJoin()` and `GroupBy()` in the Linq queries when loading `RealTimeStream` models from the database. This reduces nested loops over the device and measurement tables, improving performance when first navigating to the page.

The second commit enables UI virtualization on `TreeView` instances, which vastly improves performance when expanding a node with a lot of children. With virtualization enabled, the WPF renderer will limit the number of rendering objects it allocates based on what's currently visible in the scroll view. See: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/how-to-improve-the-performance-of-a-treeview

The last commit limits these pages to show only enabled measurements, which just seems like a good UX feature for testing. A user who is attempting to monitor their data probably doesn't care about measurements they have explicitly disabled which are therefore obviously not reporting.