### PR TITLE
GSF.Core: Revert SafeDisposal in GSF.Console

### DIFF
--- a/Source/Libraries/GSF.Core/Console/Command.cs
+++ b/Source/Libraries/GSF.Core/Console/Command.cs
@@ -18,9 +18,9 @@
 //  ----------------------------------------------------------------------------------------------------
 //  08/27/2014 - J. Ritchie Carroll
 //       Generated original version of source code.
-//
 //  05/28/2025 - AJ Stadlin
-//       CustomProcessStartInfo and SafeDisposal added
+//       CustomProcessStartInfo added
+//
 //******************************************************************************************************
 
 using System;
@@ -85,9 +85,6 @@ namespace GSF.Console
 
                     m_process.StartInfo = CustomProcessStartInfo;
                 }
-
-                // When safe disposal is true, process.Close() and Kill() will be performed prior to process.Dispose()
-                m_safeDisposal = SafeDisposal;
 
                 m_process.OutputDataReceived += m_process_OutputDataReceived;
                 m_process.ErrorDataReceived += m_process_ErrorDataReceived;
@@ -165,17 +162,6 @@ namespace GSF.Console
                                 m_process.OutputDataReceived -= m_process_OutputDataReceived;
                                 m_process.ErrorDataReceived -= m_process_ErrorDataReceived;
 
-                                if (m_safeDisposal)
-                                {
-                                    // Close the process if it has not yet exited
-                                    if (!m_process.HasExited)
-                                        m_process.Close();
-
-                                    // Kill the process if it has exited but is a zombie
-                                    if (m_process.HasExited)
-                                        m_process.Kill();
-                                }
-
                                 m_process.Dispose();
                             }
                         }
@@ -224,13 +210,6 @@ namespace GSF.Console
         }
 
         /// <summary>
-        /// When Command.SafeDisposal is true, process.Close() and Kill() are performed prior to performing process.Dispose()
-        /// Set SafeDisposal before Creating or Executing the CommandProcess
-        /// SafeDisposal Default is false for backward compatibility
-        /// </summary>
-        public static bool SafeDisposal { get; set; } = false;
-
-        /// <summary>
         /// Customizable Command.ProcessStartInfo to set prior to Creating or Executing the CommandProcess.
         /// The original Process.StartInfo defaults are used when Command.CustomProcessStartInfo is null.
         /// Command.CustomProcessStartInfo is null to be consistent with earlier implementations.
@@ -243,7 +222,7 @@ namespace GSF.Console
         ///     CreateNoWindow = true
         /// };
         /// </summary>
-        public static ProcessStartInfo? CustomProcessStartInfo { get; set; } = null;
+        public static ProcessStartInfo CustomProcessStartInfo { get; set; } = null;
 
         /// <summary>
         /// Executes a command line operation and returns its standard output and exit code or throws an exception with the standard error.


### PR DESCRIPTION
This change broke the build because `m_safeDisposal` does not exist.

---

Also, a bit of testing reveals that the feature is probably broken.

![image](https://github.com/user-attachments/assets/f67e0e8e-ae82-4f7b-b3ae-6960c87023dd)

---

Lastly, It looks like `Process.Close()` is redundant when calling `Process.Dispose()`.

> https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.close?view=netframework-4.8&redirectedfrom=MSDN#remarks
> 
>The Dispose method calls Close. Placing the Process object in a using block disposes of resources without the need to call Close.