### PR TITLE
Fix errors on the Graph Measurements page

### DIFF
--- a/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/RealTimeStream.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/DataModels/RealTimeStream.cs
@@ -301,7 +301,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
 
                 // Get non-statistical measurement list
                 resultSet.Tables.Add(database.Connection.RetrieveData(database.AdapterType, database.ParameterizedQueryString("SELECT ID, DeviceID, SignalID, PointID, PointTag, SignalReference, " +
-                    "SignalAcronym, Description, SignalName, EngineeringUnits, HistorianAcronym, Subscribed, Internal FROM MeasurementDetail WHERE NodeID = {0} AND " +
+                    "SignalAcronym, Description, SignalName, EngineeringUnits, HistorianAcronym, Subscribed, Internal, Enabled FROM MeasurementDetail WHERE NodeID = {0} AND " +
                     "SignalAcronym <> {1} ORDER BY SignalReference", "nodeID", "signalAcronym"), DefaultTimeout, database.CurrentNodeID(), "STAT").Copy());
 
                 resultSet.Tables[2].TableName = "MeasurementTable";
@@ -309,7 +309,7 @@ namespace GSF.PhasorProtocols.UI.DataModels
                 // Query for any non-statistical measurements that are subscribed via GEP, but are a part of another node in the same database
                 // IMPORTANT: Make sure columns in this external node query exactly match those of the previous primary measurement query
                 DataTable otherMeasurements = database.Connection.RetrieveData(database.AdapterType, database.ParameterizedQueryString("SELECT ID, 0 AS DeviceID, SignalID, PointID, PointTag, SignalReference, " +
-                    "SignalAcronym, Description, SignalName, EngineeringUnits, HistorianAcronym, Subscribed, Internal FROM MeasurementDetail WHERE NodeID <> {0} AND " +
+                    "SignalAcronym, Description, SignalName, EngineeringUnits, HistorianAcronym, Subscribed, Internal, Enabled FROM MeasurementDetail WHERE NodeID <> {0} AND " +
                     "SignalAcronym <> {1} AND Subscribed <> 0 ORDER BY SignalReference", "nodeID", "signalAcronym"), DefaultTimeout, database.CurrentNodeID(), "STAT");
 
                 Dictionary<string, string> parseKeyValuePairs(string connectionString)

--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputStatusMonitorUserControl.xaml
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputStatusMonitorUserControl.xaml
@@ -587,7 +587,7 @@
             <!-- Measurement Tree -->
             <TreeView ItemsSource="{tsfBinding:Column Path=ItemsSource}" ItemTemplate="{StaticResource RootNodeTemplate}" ItemContainerStyle="{StaticResource ExpandedItemStyle}" 
                       Height="615" Width="275" VerticalAlignment="Top" HorizontalAlignment="Left" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"
-                      VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling">
+                      VirtualizingStackPanel.IsVirtualizing="True">
                 <TreeView.Resources>
                     <SolidColorBrush Color="White" x:Key="{x:Static SystemColors.HighlightBrushKey}"/>
                 </TreeView.Resources>


### PR DESCRIPTION
I failed to notice that the `Enabled` column was missing from the `MeasurementDetail` page. Apparently I forgot to roll down when testing the last commit from my previous PR.

Also, the UI virtualization was causing spurious checkbox unchecked events for measurements that were already unchecked, which led to null reference exceptions. I tested the performance of the scrollbar in the `TreeView` without the `VirtualizingStackPanel.VirtualizationMode="Recycling"` parameter which was causing the issue, and performance seems fine so I simply removed it. The other monitoring pages don't have checkboxes so they shouldn't have the same issue.