### PR TITLE
CsvAdapters: Input adapter improvements back ported from Gemstone

### DIFF
--- a/Source/Libraries/Adapters/CsvAdapters/CsvInputAdapter.cs
+++ b/Source/Libraries/Adapters/CsvAdapters/CsvInputAdapter.cs
@@ -61,7 +61,7 @@ public class CsvInputAdapter : InputAdapterBase
     private readonly Dictionary<int, IMeasurement> m_columnMappings;
 
     private Timer? m_looseTimer;
-    private ShortSynchronizedOperation? m_readRow;
+    private LongSynchronizedOperation? m_readRow;
 
     private PrecisionInputTimer? m_precisionTimer;
     private long[]? m_subsecondDistribution;
@@ -307,7 +307,7 @@ public class CsvInputAdapter : InputAdapterBase
         if (!UseHighResolutionInputTimer)
         {
             m_looseTimer = new Timer();
-            m_readRow = new ShortSynchronizedOperation(ReadRow, ex => OnProcessException(MessageLevel.Warning, ex));
+            m_readRow = new LongSynchronizedOperation(ReadRow, ex => OnProcessException(MessageLevel.Warning, ex));
         }
 
         if (TransverseMode)
@@ -349,15 +349,18 @@ public class CsvInputAdapter : InputAdapterBase
                     return measurement;
                 }).ToArray();
 
-                int timestampColumn = columnMappings.First(kvp => string.Compare(kvp.Value, "Timestamp", StringComparison.OrdinalIgnoreCase) == 0).Key;
-
-                // Reserve a column mapping for timestamp value
-                IMeasurement timestampMeasurement = new Measurement
+                if (!SimulateTimestamp)
                 {
-                    Metadata = new MeasurementMetadata(null!, "Timestamp", 0, 1, null)
-                };
+                    int timestampColumn = columnMappings.First(kvp => string.Compare(kvp.Value, "Timestamp", StringComparison.OrdinalIgnoreCase) == 0).Key;
 
-                m_columnMappings[timestampColumn] = timestampMeasurement;
+                    // Reserve a column mapping for timestamp value
+                    IMeasurement timestampMeasurement = new Measurement
+                    {
+                        Metadata = new MeasurementMetadata(null!, "Timestamp", 0, 1, null)
+                    };
+
+                    m_columnMappings[timestampColumn] = timestampMeasurement;
+                }
             }
             else
             {
@@ -595,7 +598,15 @@ public class CsvInputAdapter : InputAdapterBase
                     if (m_columnMappings.TryGetValue(i, out measurement))
                     {
                         measurement = Measurement.Clone(measurement);
-                        measurement.Value = double.Parse(fields[i]);
+
+                        try
+                        {
+                            measurement.Value = double.Parse(fields[i]);
+                        }
+                        catch
+                        {
+                            measurement.Value = double.NaN;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
1) Updated measurement value to fall back on `double.NaN` if value fails to parse
2) Updated transverse mode to ignore any existing timestamp column when using simulating time (allows same CSV to be used for both simulated and non-simulated timestamps)
3) Changed read row operation to use a dedicated thread with `LongSynchronizedOperation`