### PR TITLE
PIAdapters: Apply the PI connect timeout to the PIServer instance

### DIFF
--- a/Source/Libraries/Adapters/PIAdapters/PIConnection.cs
+++ b/Source/Libraries/Adapters/PIAdapters/PIConnection.cs
@@ -161,6 +161,9 @@ public class PIConnection : IComparable<PIConnection>, IComparable, IDisposable
             if (Server is null)
                 throw new InvalidOperationException("Server not found in the PI servers collection.");
 
+            if (ConnectTimeout > 0)
+                Server.ConnectionInfo.ConnectionTimeOut = TimeSpan.FromMilliseconds(ConnectTimeout);
+
             Server.ConnectChanged += PIConnection_ConnectChanged;
         }
         catch (Exception ex)


### PR DESCRIPTION
I noticed this parameter was unused. FYI, PI seems to require that the timeout must be at least 1 second.