### PR TITLE
Sc controller activation

### DIFF
--- a/Source/Libraries/GSF.Web/Model/ModelController.cs
+++ b/Source/Libraries/GSF.Web/Model/ModelController.cs
@@ -83,8 +83,11 @@ namespace GSF.Web.Model
             PrimaryKeyField = typeof(T).GetProperties().FirstOrDefault(p => p.GetCustomAttributes<PrimaryKeyAttribute>().Any())?.Name ?? "ID";
 
             ParentKey = typeof(T).GetProperties().FirstOrDefault(p => p.GetCustomAttributes<ParentKeyAttribute>().Any())?.Name ?? "";
-            Connection = typeof(T).GetCustomAttribute<SettingsCategoryAttribute>()?.SettingsCategory ?? "systemSettings";
 
+            // Prioritize Controller Attribute then Model Attribute
+            Connection = this.GetType().GetCustomAttribute<SettingsCategoryAttribute>()?.SettingsCategory
+                ?? typeof(T).GetCustomAttribute<SettingsCategoryAttribute>()?.SettingsCategory
+                ?? "systemSettings";
             PropertyInfo pi = typeof(T).GetProperties().FirstOrDefault(p => p.GetCustomAttributes<DefaultSortOrderAttribute>().Any());
             DefaultSortOrderAttribute dsoa = pi?.GetCustomAttribute<DefaultSortOrderAttribute>();
             if (dsoa != null)


### PR DESCRIPTION
[SC-246](https://gridprotectionalliance.atlassian.net/browse/SC-246)

---
<h4>Description</h4>  

<h6>Adding a property to GSF model controller to allow most model controllers to support controller activation in system center.</h6>
<br />

---
<h4>Related PRs</h4>  
[
SC #745](https://github.com/GridProtectionAlliance/SystemCenter/pull/745)