### PR TITLE
GSF.Phasorprotocols.UI.WPF: Use ranked matching algorithm in input device wizard to map configuration cells to existing devices

### DIFF
--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputWizardUserControl.xaml.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/InputWizardUserControl.xaml.cs
@@ -86,14 +86,14 @@ namespace GSF.PhasorProtocols.UI.UserControls
                 m_dataContext.PdcName = device.Name;
                 m_dataContext.PdcVendorDeviceID = device.VendorDeviceID ?? 0;
 
-                ObservableCollection<Device> devices = Device.GetDevices(null, "WHERE ParentID = " + device.ID);
-                m_dataContext.DeviceIDs = devices.Select(childDevice => childDevice.ID).ToArray();
-                m_dataContext.DeviceAcronyms = devices.Select(childDevice => childDevice.Acronym).ToArray();
+                m_dataContext.Devices = Device
+                    .GetDevices(null, "WHERE ParentID = " + device.ID)
+                    .OrderBy(device => device.LoadOrder)
+                    .ToArray();
             }
             else
             {
-                m_dataContext.DeviceIDs = new[] { device.ID };
-                m_dataContext.DeviceAcronyms = new[] { device.Acronym };
+                m_dataContext.Devices = [device];
             }
 
             m_dataContext.StepTwoExpanded = true;


### PR DESCRIPTION
This PR resolves an issue that was reported where updating configuration for existing IEEE C37.118 input devices would often shuffle the order of the child devices returned by the database query.

* Use `LoadOrder` to sort child devices returned by the database query. This is consistent with how the input device wizard assigns `LoadOrder` when saving child device records.
* `DeviceMapping` class provides information used to rank how closely a child device record matches a cell from the configuration frame.
  * If the global ID from a config frame 3 matches the unique ID of the device record, it gets fast tracked to rank 100. Otherwise, set it to 0.
  * If the ID code matches, add 1 to the rank.
  * Add the inverse of the square of the ordinal distance between the device and the cell. The ordinal distance is the difference between the index of the device and the index of the cell.
  * Add the inverse of the square of the Levenshtein distance between the device acronym and the acronym computed from the cell's station name.
  * Levenshtein distance can be expensive to compute so a handful of optimizations have been employed to avoid computing it when possible.
* `MappingQueue` processes mappings in priority order based on the ranking from `DeviceMapping`.
  * Ensures that only one mapping per device is used.
  * Ensures that only one mapping per cell is used.
  * Filters out any mapping with a ranking less than 1, which indicates that none of the ID code, label, or ordinal match very closely.