### PR TITLE
GSF.PhasorProtocols.UI.WPF: Observe the Data Format parameter when computing Data Frame Size on the Concentrator Output Streams page

### DIFF
--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/ViewModels/OutputStreams.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/ViewModels/OutputStreams.cs
@@ -499,6 +499,10 @@ namespace GSF.PhasorProtocols.UI.ViewModels
                     {
                         concentrator.ID = Convert.ToUInt32(RuntimeID);
                         concentrator.DataSource = dataSource;
+
+                        if (Enum.TryParse(CurrentItem.DataFormat, true, out DataFormat dataFormat))
+                            concentrator.DataFormat = dataFormat;
+
                         concentrator.UpdateConfiguration();
 
                         frameSize = C37Concentrator.CreateDataFrame(DateTime.UtcNow.Ticks, concentrator.ConfigurationFrame as IEEEC37_118.ConfigurationFrame1).BinaryLength;


### PR DESCRIPTION
This PR adjusts the logic in the `Concentrator Output Streams` page of the Manager for computing the size of a data frame for the `IEEE C37.118-2011`  protocol to observe the `Data Format` parameter. Before this change, the concentrator would assume `FixedInteger` format, which causes the openPDC Manager to report the wrong number when `FloatingPoint` format is selected. Only the logic for `IEEE C37.118-2011` needs to be adjusted since that is the only protocol that reports data frame size.

The following screenshots show that this change enables the openPDC Manager to differentiate between the two formats when computing the data frame size.

<img width="786" height="693" alt="image (34)" src="https://github.com/user-attachments/assets/92ef3f70-72c3-4e5d-b989-49ad0829e62d" />

<img width="786" height="693" alt="image (35)" src="https://github.com/user-attachments/assets/848f508a-3428-42a7-81ab-550aed271715" />