### PR TITLE
Fix output adapter measurement alternate tag configuration to accept `DNP3{...}` match anywhere within string

### DIFF
--- a/Source/Libraries/Adapters/Dnp3Adapters/Dnp3OutputAdapter.cs
+++ b/Source/Libraries/Adapters/Dnp3Adapters/Dnp3OutputAdapter.cs
@@ -1259,7 +1259,7 @@ public class Dnp3OutputAdapter : OutputAdapterBase, IDnp3Adapter
 
     // Regex for parsing AlternateTag configuration
     // Format: DNP3{Type=Analog;Index=0;Class=1;Deadband=0.001;StaticVar=Group30Var1;EventVar=Group32Var7}
-    private static readonly Regex s_alternateTagRegex = new(@"^DNP3\{(?<config>[^}]+)\}$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex s_alternateTagRegex = new(@"DNP3\{(?<config>[^}]+)\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // Static Constructor
     static Dnp3OutputAdapter()


### PR DESCRIPTION
Currently matches whole string. `DNP3{...}` configuration should be accepted anywhere in `AlternateTag` field, this way same measurement could have different protocol targets, e.g., `ICCP{...}` as well. 