### PR TITLE
Fix logic when rounding to second distribution

### DIFF
--- a/Source/Libraries/GSF.Core.Shared/Ticks.cs
+++ b/Source/Libraries/GSF.Core.Shared/Ticks.cs
@@ -1629,33 +1629,66 @@ namespace GSF
         /// </summary>
         /// <param name="timestamp">Timestamp to align.</param>
         /// <param name="samplesPerSecond">Samples per second to use for distribution.</param>
-        /// <param name="Baseline"> Starting Timestamp of the Distribution.</param>
+        /// <param name="baseline">Starting timestamp of the distribution.</param>
         /// <returns>The nearest distribution timestamp for given <paramref name="timestamp"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Ticks RoundToSecondDistribution(Ticks timestamp, double samplesPerSecond, Ticks Baseline)
+        public static Ticks RoundToSecondDistribution(Ticks timestamp, double samplesPerSecond, Ticks baseline)
         {
-            // Calculate destination ticks for this frame
-            long ticks = timestamp.Value;
-            long baseTicks, ticksBeyondSecond, destinationTicks;
-            double frameIndex;
+            if (double.IsNaN(samplesPerSecond) || double.IsInfinity(samplesPerSecond))
+                throw new ArgumentOutOfRangeException(nameof(samplesPerSecond));
 
-            // Baseline timestamp based on start Time
-            baseTicks = ticks - ticks % Baseline;
+            if (samplesPerSecond <= 0.0D)
+                throw new ArgumentOutOfRangeException(nameof(samplesPerSecond));
 
-            // Remove the seconds from ticks
-            ticksBeyondSecond = ticks - baseTicks;
+            // Using [y - y0 = m(t - t0)] where
+            //   y = sample number at time t
+            //   y0 = baseline sample number (0)
+            //   m = samples per tick
+            //   t = timestamp in ticks
+            //   t0 = baseline timestamp in ticks
+            //
+            // The goal is to compute y, round to the nearest sample number,
+            // and then compute the equivalent timestamp. Ignoring y0 and
+            // solving for t, we can produce the following simplified forms
+            // of the equation to do the conversions
+            //   y = m(t - t0)
+            //   t = y/m + t0
 
-            // Calculate a frame index between 0 and m_framesPerSecond-1,
-            // corresponding to ticks rounded to the nearest frame
-            frameIndex = Math.Round((double)ticksBeyondSecond / (double)(Ticks.PerSecond / (double)samplesPerSecond));
+            // Adjust units to compute m
+            double samplesPerTick = samplesPerSecond / Ticks.PerSecond;
 
-            // Calculate the timestamp of the nearest frame
-            destinationTicks = (long)(frameIndex * Ticks.PerSecond / samplesPerSecond);
+            // If 1/m is too large, it breaks some assumptions
+            double ticksPerSample = 1.0D / samplesPerTick;
 
-            // Recover the seconds that were removed
-            destinationTicks += baseTicks;
+            if (ticksPerSample >= (1L << 53))
+                throw new ArgumentOutOfRangeException(nameof(samplesPerSecond));
 
-            return new Ticks(destinationTicks);
+            // Pick a new baseline [t0 = t + x/m] to mitigate
+            // loss of precision when converting to double.
+            // x and x/m must both be integers.
+            // Note: Start by extracting the mantissa because
+            //       if you multiply a double by 2 until the
+            //       exponent is 52, you get an integer multiple
+            //       of that number with 53 bits of precision
+            const long Prefix = 1L << 52;
+            const long Mask = Prefix - 1;
+            long bits = BitConverter.DoubleToInt64Bits(ticksPerSample);
+            long x0m = Prefix | (bits & Mask);
+
+            // Compute the largest multiple x1 of x0/m that
+            // is smaller than [timestamp - baseline]. When x/m
+            // is added to baseline, the value of [timestamp - t0]
+            // will be smaller than x0/m, which should fit in 53 bits
+            long x1 = (timestamp - baseline) / x0m;
+            long xm = x0m * x1;
+            long t0 = baseline + xm;
+
+            // Solve for [y = m(t - t0)] and round the result
+            double sampleNum = samplesPerTick * (timestamp - t0);
+            double nearest = Math.Round(sampleNum);
+
+            // Solve for [t = y/m + t0] to return the rounded timestamp
+            return (long)(nearest / samplesPerTick) + t0;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR corrects a couple issues with the previous implementation of `Ticks.RoundToSecondDistribution()`.

* Passing a baseline timestamp of 0 would inexplicably cause a divide-by-zero error despite the fact that it should be a valid (and common) starting timestamp.
* Passing a framerate with a reciprocal that is not divisible by the baseline would cause "hiccups" in the distribution, where the end of every "baseline interval" would be shorter than it's supposed to be.

To simplify the logic, I tried to conceptualize the operation of converting between timestamp and sample number as a linear equation that passes through the baseline at frame index 0. The comments in the code describe the mathematical model and how it is applied to produce the rounded result.

The further your timestamp is from the baseline, the more likely you are to lose precision in the computation because that time difference (`timestamp - baseline`) is converted to a floating-point number--from 64 bits of precision down to 53. Notably, `DateTime.UtcNow` already returns a number with 60 bits of precision, which would cause 7 bits of precision to be lost when using a baseline of 0. This can be mitigated by picking a different baseline closer to the given timestamp that produces the same result, which can be done by adding an integer multiple of the sampling interval to the given baseline. This is a bit tricky, since the sample rate--and by extension, its reciprocal--can be any floating-point number, but it's done quickly and precisely by simply extracting the mantissa to an integer, as if we had multiplied the number by 2 until the exponent is equal to the maximum precision of the floating-point representation.

---

I tested this code using the following test app.

```c#
using System;
using GSF;

namespace SecondDistributionTest
{
    internal class Program
    {
        static void Main(string[] args)
        {
            Ticks now = DateTime.UtcNow.Ticks;
            Ticks round0 = Ticks.RoundToSecondDistribution(now, 1.0D / 1.5D, 0L * Ticks.PerSecond);
            Ticks round1 = Ticks.RoundToSecondDistribution(now, 1.0D / 1.5D, 1L * Ticks.PerSecond);
            Ticks round2 = Ticks.RoundToSecondDistribution(now, 1.0D / 1.5D, 2L * Ticks.PerSecond);
            Ticks round3 = Ticks.RoundToSecondDistribution(now, 1.0D / 1.5D, 3L * Ticks.PerSecond);

            // These should all be within 1.5 seconds
            double diff0 = TimeSpan.FromTicks(now - round0).TotalSeconds;
            double diff1 = TimeSpan.FromTicks(now - round1).TotalSeconds;
            double diff2 = TimeSpan.FromTicks(now - round2).TotalSeconds;
            double diff3 = TimeSpan.FromTicks(now - round3).TotalSeconds;

            // These should all be zero
            long interval = TimeSpan.FromSeconds(1.5D).Ticks;
            long mod0 = (round0 - 0L * Ticks.PerSecond) % interval;
            long mod1 = (round1 - 1L * Ticks.PerSecond) % interval;
            long mod2 = (round2 - 2L * Ticks.PerSecond) % interval;
            long mod3 = (round3 - 3L * Ticks.PerSecond) % interval;

            Console.WriteLine(ToString(now));
            Console.WriteLine($"{ToString(round0)} {diff0} {mod0}");
            Console.WriteLine($"{ToString(round1)} {diff1} {mod1}");
            Console.WriteLine($"{ToString(round2)} {diff2} {mod2}");
            Console.WriteLine($"{ToString(round3)} {diff3} {mod3}");
        }

        static string ToString(Ticks timestamp) =>
            $"{timestamp:yyyy-MM-dd HH:mm:ss.fffffff}";
    }
}
```