### PR TITLE
GSF.TimeSeries: Move filter adapter processing into routing tables

### DIFF
--- a/Source/Libraries/GSF.TimeSeries/Adapters/IRouteMappingTables.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/IRouteMappingTables.cs
@@ -47,8 +47,9 @@ namespace GSF.TimeSeries.Adapters
         /// Patches the existing routing table with the supplied adapters.
         /// </summary>
         /// <param name="producerAdapters">all of the producers</param>
+        /// <param name="filterAdapters">all of the filters</param>
         /// <param name="consumerAdapters">all of the consumers</param>
-        void PatchRoutingTable(RoutingTablesAdaptersList producerAdapters, RoutingTablesAdaptersList consumerAdapters);
+        void PatchRoutingTable(RoutingTablesAdaptersList producerAdapters, IFilterAdapter[] filterAdapters, RoutingTablesAdaptersList consumerAdapters);
 
         /// <summary>
         /// This method will directly inject measurements into the routing table and use a shared local input adapter. For

--- a/Source/Libraries/GSF.TimeSeries/Adapters/IaonSession.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/IaonSession.cs
@@ -31,7 +31,6 @@ using GSF.Annotations;
 using GSF.Collections;
 using GSF.Configuration;
 using GSF.Diagnostics;
-using System.Collections.Generic;
 
 // ReSharper disable InconsistentlySynchronizedField
 namespace GSF.TimeSeries.Adapters
@@ -185,12 +184,10 @@ namespace GSF.TimeSeries.Adapters
             
                 // Create input adapters collection
             m_inputAdapters = new InputAdapterCollection();
-            m_inputAdapters.NewMeasurements += NewMeasurementsHandler;
             m_inputAdapters.ProcessingComplete += ProcessingCompleteHandler;
 
             // Create action adapters collection
             m_actionAdapters = new ActionAdapterCollection();
-            m_actionAdapters.NewMeasurements += NewMeasurementsHandler;
             m_actionAdapters.UnpublishedSamples += UnpublishedSamplesHandler;
             m_actionAdapters.RequestTemporalSupport += RequestTemporalSupportHandler;
 
@@ -200,6 +197,7 @@ namespace GSF.TimeSeries.Adapters
 
             // Associate adapter collections with routing tables
             m_routingTables.InputAdapters = m_inputAdapters;
+            m_routingTables.FilterAdapters = m_filterAdapters;
             m_routingTables.ActionAdapters = m_actionAdapters;
             m_routingTables.OutputAdapters = m_outputAdapters;
 
@@ -370,7 +368,6 @@ namespace GSF.TimeSeries.Adapters
                 if (m_inputAdapters is not null)
                 {
                     m_inputAdapters.Stop();
-                    m_inputAdapters.NewMeasurements -= NewMeasurementsHandler;
                     m_inputAdapters.ProcessingComplete -= ProcessingCompleteHandler;
                     m_inputAdapters.Dispose();
                 }
@@ -380,7 +377,6 @@ namespace GSF.TimeSeries.Adapters
                 if (m_actionAdapters is not null)
                 {
                     m_actionAdapters.Stop();
-                    m_actionAdapters.NewMeasurements -= NewMeasurementsHandler;
                     m_actionAdapters.UnpublishedSamples -= UnpublishedSamplesHandler;
                     m_actionAdapters.RequestTemporalSupport -= RequestTemporalSupportHandler;
                     m_actionAdapters.Dispose();
@@ -768,14 +764,6 @@ namespace GSF.TimeSeries.Adapters
             // Bubble message up to any event subscribers
             OnUnprocessedMeasurements(sender, e.Argument);
         }
-
-        /// <summary>
-        /// Event handler for new measurement notifications from input adapters and action adapters.
-        /// </summary>
-        /// <param name="sender">Event source reference to the adapter that is reporting new measurements.</param>
-        /// <param name="e">Event arguments for event that contains references to the new measurements.</param>
-        public virtual void NewMeasurementsHandler(object sender, EventArgs<ICollection<IMeasurement>> e) => 
-            m_filterAdapters?.HandleNewMeasurements(e.Argument);
 
         /// <summary>
         /// Event handler for processing complete notifications from input adapters.

--- a/Source/Libraries/GSF.TimeSeries/Adapters/RouteMappingDoubleBufferQueue.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/RouteMappingDoubleBufferQueue.cs
@@ -40,13 +40,15 @@ namespace GSF.TimeSeries.Adapters
 
         private class GlobalCache
         {
+            public readonly IFilterAdapter[] FilterAdapters;
             public readonly Dictionary<Guid, List<Consumer>> GlobalSignalLookup;
             public readonly Dictionary<IAdapter, Consumer> GlobalDestinationLookup;
             public readonly List<Consumer> BroadcastConsumers;
             public readonly int Version;
 
-            public GlobalCache(Dictionary<IAdapter, Consumer> consumers, int version)
+            public GlobalCache(IFilterAdapter[] filterAdapters, Dictionary<IAdapter, Consumer> consumers, int version)
             {
+                FilterAdapters = filterAdapters;
                 GlobalSignalLookup = new Dictionary<Guid, List<Consumer>>();
                 GlobalDestinationLookup = consumers;
                 BroadcastConsumers = new List<Consumer>();
@@ -79,18 +81,23 @@ namespace GSF.TimeSeries.Adapters
 
         private class LocalCache
         {
+            private readonly AsyncQueue<ICollection<IMeasurement>> m_asyncRouter;
             private readonly Dictionary<Guid, List<Producer>> m_localSignalLookup;
             private readonly Dictionary<Consumer, Producer> m_localDestinationLookup;
-            private readonly RouteMappingDoubleBufferQueue m_routingTables;
+            private readonly Func<GlobalCache> m_fetchGlobalCache;
             private readonly object m_localCacheLock;
+            private int m_asyncJobCount;
             private int m_version;
 
-            public LocalCache(RouteMappingDoubleBufferQueue routingTables, IAdapter producerAdapter)
+            public LocalCache(Func<GlobalCache> fetchGlobalCache, IAdapter producerAdapter, Action<Exception> exceptionHandler)
             {
                 m_localCacheLock = new object();
+                m_asyncRouter = new AsyncQueue<ICollection<IMeasurement>>();
+                m_asyncRouter.ProcessItemFunction = FilterAndRoute;
+                m_asyncRouter.ProcessException += (_, args) => exceptionHandler(args.Argument);
                 m_localSignalLookup = new Dictionary<Guid, List<Producer>>();
                 m_localDestinationLookup = new Dictionary<Consumer, Producer>();
-                m_routingTables = routingTables;
+                m_fetchGlobalCache = fetchGlobalCache;
 
                 if (producerAdapter is IInputAdapter inputAdapter)
                     inputAdapter.NewMeasurements += Route;
@@ -106,64 +113,113 @@ namespace GSF.TimeSeries.Adapters
                     return;
 
                 // Get the global cache from the routing tables
-                GlobalCache globalCache = Interlocked.CompareExchange(ref m_routingTables.m_globalCache, null, null);
+                GlobalCache globalCache = m_fetchGlobalCache();
 
                 // Return if routes are still being calculated
                 if (globalCache is null)
                     return;
 
+                if (RequiresAsync(globalCache))
+                {
+                    Interlocked.Increment(ref m_asyncJobCount);
+                    m_asyncRouter.Enqueue(measurements);
+                    return;
+                }
+
                 lock (m_localCacheLock)
                 {
-                    // Check the version of the local cache against that of the global cache.
-                    // We need to clear the local cache if the versions don't match because
-                    // that means routes have changed
-                    if (m_version != globalCache.Version)
+                    // Fetch again, inside the lock
+                    globalCache = m_fetchGlobalCache();
+
+                    if (RequiresAsync(globalCache))
                     {
-                        // Dump the signal lookup
-                        m_localSignalLookup.Clear();
-
-                        // Best if we hang onto producers for adapters that still have routes
-                        foreach (Consumer consumer in m_localDestinationLookup.Keys.Where(consumer => !globalCache.GlobalDestinationLookup.ContainsKey(consumer.Adapter)).ToList())
-                        {
-                            m_localDestinationLookup[consumer].QueueProducer.Dispose();
-                            m_localDestinationLookup.Remove(consumer);
-                        }
-
-                        // Update the local cache version
-                        m_version = globalCache.Version;
+                        Interlocked.Increment(ref m_asyncJobCount);
+                        m_asyncRouter.Enqueue(measurements);
+                        return;
                     }
 
-                    foreach (IMeasurement measurement in measurements)
-                    {
-                        // Attempt to look up the signal in the local cache
-                        if (!m_localSignalLookup.TryGetValue(measurement.ID, out List<Producer> producers))
-                        {
-                            // Not in the local cache - check the global cache and fall back on broadcast consumers
-                            if (!globalCache.GlobalSignalLookup.TryGetValue(measurement.ID, out List<Consumer> consumers))
-                                consumers = globalCache.BroadcastConsumers;
-
-                            // Get a producer for each of the consumers
-                            producers = consumers
-                                .Select(consumer => m_localDestinationLookup.GetOrAdd(consumer, c => new Producer(c.Manager)))
-                                .ToList();
-
-                            // Add this signal to the local cache
-                            m_localSignalLookup.Add(measurement.ID, producers);
-                        }
-
-                        // Add this measurement to the producers' list
-                        foreach (Producer producer in producers)
-                            producer.Measurements.Add(measurement);
-                    }
-
-                    // Produce measurements to consumers in the local destination
-                    // cache which have measurements to be received
-                    foreach (Producer producer in m_localDestinationLookup.Values.Where(producer => producer.Measurements.Count > 0))
-                    {
-                        producer.QueueProducer.Produce(producer.Measurements);
-                        producer.Measurements.Clear();
-                    }
+                    UpdateFrom(globalCache);
+                    RouteMeasurements(measurements, globalCache);
                 }
+            }
+
+            private void FilterAndRoute(ICollection<IMeasurement> measurements)
+            {
+                lock (m_localCacheLock)
+                {
+                    // Get the global cache from the routing tables
+                    GlobalCache globalCache = m_fetchGlobalCache();
+                    UpdateFrom(globalCache);
+
+                    foreach (IFilterAdapter filterAdapter in globalCache.FilterAdapters)
+                        filterAdapter.HandleNewMeasurements(measurements);
+
+                    RouteMeasurements(measurements, globalCache);
+                    Interlocked.Decrement(ref m_asyncJobCount);
+                }
+            }
+
+            private void UpdateFrom(GlobalCache globalCache)
+            {
+                // Check the version of the local cache against that of the global cache.
+                // We need to clear the local cache if the versions don't match because
+                // that means routes have changed
+                if (m_version == globalCache.Version)
+                    return;
+
+                // Dump the signal lookup
+                m_localSignalLookup.Clear();
+
+                // Best if we hang onto producers for adapters that still have routes
+                foreach (Consumer consumer in m_localDestinationLookup.Keys.Where(consumer => !globalCache.GlobalDestinationLookup.ContainsKey(consumer.Adapter)).ToList())
+                {
+                    m_localDestinationLookup[consumer].QueueProducer.Dispose();
+                    m_localDestinationLookup.Remove(consumer);
+                }
+
+                // Update the local cache version
+                m_version = globalCache.Version;
+            }
+
+            private void RouteMeasurements(ICollection<IMeasurement> measurements, GlobalCache globalCache)
+            {
+                foreach (IMeasurement measurement in measurements)
+                {
+                    // Attempt to look up the signal in the local cache
+                    if (!m_localSignalLookup.TryGetValue(measurement.ID, out List<Producer> producers))
+                    {
+                        // Not in the local cache - check the global cache and fall back on broadcast consumers
+                        if (!globalCache.GlobalSignalLookup.TryGetValue(measurement.ID, out List<Consumer> consumers))
+                            consumers = globalCache.BroadcastConsumers;
+
+                        // Get a producer for each of the consumers
+                        producers = consumers
+                            .Select(consumer => m_localDestinationLookup.GetOrAdd(consumer, c => new Producer(c.Manager)))
+                            .ToList();
+
+                        // Add this signal to the local cache
+                        m_localSignalLookup.Add(measurement.ID, producers);
+                    }
+
+                    // Add this measurement to the producers' list
+                    foreach (Producer producer in producers)
+                        producer.Measurements.Add(measurement);
+                }
+
+                // Produce measurements to consumers in the local destination
+                // cache which have measurements to be received
+                foreach (Producer producer in m_localDestinationLookup.Values.Where(producer => producer.Measurements.Count > 0))
+                {
+                    producer.QueueProducer.Produce(producer.Measurements);
+                    producer.Measurements.Clear();
+                }
+            }
+
+            private bool RequiresAsync(GlobalCache globalCache)
+            {
+                return
+                    globalCache.FilterAdapters.Length > 0 ||
+                    Interlocked.CompareExchange(ref m_asyncJobCount, 0, 0) > 0;
             }
         }
 
@@ -222,9 +278,14 @@ namespace GSF.TimeSeries.Adapters
         {
             m_onStatusMessage = _ => { };
             m_onProcessException = _ => { };
-            m_globalCache = new GlobalCache(new Dictionary<IAdapter, Consumer>(), 0);
-            m_injectMeasurementsLocalCache = new LocalCache(this, null);
+            m_globalCache = new GlobalCache(Array.Empty<IFilterAdapter>(), new Dictionary<IAdapter, Consumer>(), 0);
+            m_injectMeasurementsLocalCache = new LocalCache(GetGlobalCache, null, m_onProcessException);
         }
+
+        /// <summary>
+        /// Gets the number of routes in this routing table.
+        /// </summary>
+        public int RouteCount => GetGlobalCache().GlobalSignalLookup.Count;
 
         /// <summary>
         /// Assigns the status messaging callbacks.
@@ -238,17 +299,13 @@ namespace GSF.TimeSeries.Adapters
         }
 
         /// <summary>
-        /// Gets the number of routes in this routing table.
-        /// </summary>
-        public int RouteCount => m_globalCache.GlobalSignalLookup.Count;
-
-        /// <summary>
         /// Patches the existing routing table with the supplied adapters.
         /// </summary>
         /// <param name="producerAdapters">all of the producers</param>
+        /// <param name="filterAdapters">all of the filters</param>
         /// <param name="consumerAdapters">all of the consumers</param>
         [SuppressMessage("SonarQube.UnusedObject", "S1848", Justification = "Class instantiation of \"LocalCache\" attaches event handlers for adapters.")]
-        public void PatchRoutingTable(RoutingTablesAdaptersList producerAdapters, RoutingTablesAdaptersList consumerAdapters)
+        public void PatchRoutingTable(RoutingTablesAdaptersList producerAdapters, IFilterAdapter[] filterAdapters, RoutingTablesAdaptersList consumerAdapters)
         {
             if (producerAdapters is null)
                 throw new ArgumentNullException(nameof(producerAdapters));
@@ -259,7 +316,7 @@ namespace GSF.TimeSeries.Adapters
             // Attach to NewMeasurements event of all producer adapters that are new
             // ReSharper disable once ObjectCreationAsStatement
             foreach (IAdapter producerAdapter in producerAdapters.NewAdapter)
-                new LocalCache(this, producerAdapter);
+                new LocalCache(GetGlobalCache, producerAdapter, m_onProcessException);
 
             Dictionary<IAdapter, Consumer> consumerLookup = new(m_globalCache.GlobalDestinationLookup);
 
@@ -271,7 +328,7 @@ namespace GSF.TimeSeries.Adapters
             foreach (IAdapter consumerAdapter in consumerAdapters.OldAdapter)
                 consumerLookup.Remove(consumerAdapter);
 
-            Interlocked.Exchange(ref m_globalCache, new GlobalCache(consumerLookup, m_globalCache.Version + 1));
+            Interlocked.Exchange(ref m_globalCache, new GlobalCache(filterAdapters, consumerLookup, m_globalCache.Version + 1));
         }
 
         /// <summary>
@@ -282,5 +339,10 @@ namespace GSF.TimeSeries.Adapters
         /// <param name="measurements">the event arguments</param>
         public void InjectMeasurements(object sender, EventArgs<ICollection<IMeasurement>> measurements) => 
             m_injectMeasurementsLocalCache.Route(sender, measurements);
+
+        private GlobalCache GetGlobalCache()
+        {
+            return Interlocked.CompareExchange(ref m_globalCache, null, null);
+        }
     }
 }

--- a/Source/Libraries/GSF.TimeSeries/Adapters/RouteMappingDoubleBufferQueue.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/RouteMappingDoubleBufferQueue.cs
@@ -92,7 +92,7 @@ namespace GSF.TimeSeries.Adapters
             public LocalCache(Func<GlobalCache> fetchGlobalCache, IAdapter producerAdapter, Action<Exception> exceptionHandler)
             {
                 m_localCacheLock = new object();
-                m_asyncRouter = new AsyncQueue<ICollection<IMeasurement>>();
+                m_asyncRouter = new AsyncQueue<ICollection<IMeasurement>>(Threading.SynchronizedOperationType.LongBackground);
                 m_asyncRouter.ProcessItemFunction = FilterAndRoute;
                 m_asyncRouter.ProcessException += (_, args) => exceptionHandler(args.Argument);
                 m_localSignalLookup = new Dictionary<Guid, List<Producer>>();

--- a/Source/Libraries/GSF.TimeSeries/Adapters/RouteMappingHighLatencyLowCpu.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/RouteMappingHighLatencyLowCpu.cs
@@ -87,6 +87,12 @@ namespace GSF.TimeSeries.Adapters
         private class GlobalCache
         {
             /// <summary>
+            /// Contains all the adapters that get a chance at filtering
+            /// input measurements before passing them along to consumers.
+            /// </summary>
+            public readonly IFilterAdapter[] FilterAdapters;
+
+            /// <summary>
             /// Contains all consumers for all adapters regardless of if they are optimized or not.
             /// </summary>
             public readonly Dictionary<IAdapter, Consumer> GlobalDestinationLookup;
@@ -103,8 +109,9 @@ namespace GSF.TimeSeries.Adapters
             public readonly List<Consumer> NormalDestinationAdapters;
             public readonly int Version;
 
-            public GlobalCache(Dictionary<IAdapter, Consumer> consumers, int version)
+            public GlobalCache(IFilterAdapter[] filterAdapters, Dictionary<IAdapter, Consumer> consumers, int version)
             {
+                FilterAdapters = filterAdapters;
                 NormalDestinationAdapters = new List<Consumer>();
                 RoutingPassthroughAdapters = new List<RoutingPassthroughMethod>();
                 GlobalSignalLookup = new IndexedArray<List<Consumer>>();
@@ -195,7 +202,7 @@ namespace GSF.TimeSeries.Adapters
 
             m_onStatusMessage = _ => { };
             m_onProcessException = _ => { };
-            m_globalCache = new GlobalCache(new Dictionary<IAdapter, Consumer>(), 0);
+            m_globalCache = new GlobalCache(Array.Empty<IFilterAdapter>(), new Dictionary<IAdapter, Consumer>(), 0);
             RouteCount = m_globalCache.GlobalSignalLookup.Count(x => x is not null);
         }
 
@@ -219,8 +226,9 @@ namespace GSF.TimeSeries.Adapters
         /// Patches the existing routing table with the supplied adapters.
         /// </summary>
         /// <param name="producerAdapters">all of the producers</param>
+        /// <param name="filterAdapters">all of the filters</param>
         /// <param name="consumerAdapters">all of the consumers</param>
-        public void PatchRoutingTable(RoutingTablesAdaptersList producerAdapters, RoutingTablesAdaptersList consumerAdapters)
+        public void PatchRoutingTable(RoutingTablesAdaptersList producerAdapters, IFilterAdapter[] filterAdapters, RoutingTablesAdaptersList consumerAdapters)
         {
             if (producerAdapters is null)
                 throw new ArgumentNullException(nameof(producerAdapters));
@@ -252,7 +260,7 @@ namespace GSF.TimeSeries.Adapters
             foreach (IAdapter consumerAdapter in consumerAdapters.OldAdapter)
                 consumerLookup.Remove(consumerAdapter);
 
-            m_globalCache = new GlobalCache(consumerLookup, m_globalCache.Version + 1);
+            m_globalCache = new GlobalCache(filterAdapters, consumerLookup, m_globalCache.Version + 1);
             RouteCount = m_globalCache.GlobalSignalLookup.Count(x => x is not null);
         }
 
@@ -290,6 +298,9 @@ namespace GSF.TimeSeries.Adapters
                     Interlocked.Add(ref m_pendingMeasurements, -measurements.Count);
 
                     //For loops are faster than ForEach for List<T>
+
+                    for (int x = 0; x < map.FilterAdapters.Length; x++)
+                        map.FilterAdapters[x].HandleNewMeasurements(measurements);
                     
                     //Process Optimized Consumers
                     for (int x = 0; x < map.RoutingPassthroughAdapters.Count; x++)

--- a/Source/Libraries/GSF.TimeSeries/Adapters/RoutingTables.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/RoutingTables.cs
@@ -116,6 +116,11 @@ namespace GSF.TimeSeries.Adapters
         public InputAdapterCollection InputAdapters { get; set; }
 
         /// <summary>
+        /// Gets or sets the active <see cref="FilterAdapterCollection"/>.
+        /// </summary>
+        public FilterAdapterCollection FilterAdapters { get; set; }
+
+        /// <summary>
         /// Gets or sets the active <see cref="ActionAdapterCollection"/>.
         /// </summary>
         public ActionAdapterCollection ActionAdapters { get; set; }
@@ -188,6 +193,7 @@ namespace GSF.TimeSeries.Adapters
             long startTime = DateTime.UtcNow.Ticks;
 
             IInputAdapter[] inputAdapterCollection = null;
+            IFilterAdapter[] filterAdapterCollection = null;
             IActionAdapter[] actionAdapterCollection = null;
             IOutputAdapter[] outputAdapterCollection = null;
             bool retry = true;
@@ -206,6 +212,9 @@ namespace GSF.TimeSeries.Adapters
                     if (InputAdapters is not null)
                         inputAdapterCollection = InputAdapters.ToArray<IInputAdapter>();
 
+                    if (FilterAdapters is not null)
+                        filterAdapterCollection = FilterAdapters.ToArray<IFilterAdapter>();
+
                     if (ActionAdapters is not null)
                         actionAdapterCollection = ActionAdapters.ToArray<IActionAdapter>();
 
@@ -222,6 +231,7 @@ namespace GSF.TimeSeries.Adapters
                 {
                     // Catch rare exceptions where IaonSession is disposed during a context switch
                     inputAdapterCollection = null;
+                    filterAdapterCollection = null;
                     actionAdapterCollection = null;
                     outputAdapterCollection = null;
                     retry = false;
@@ -238,10 +248,13 @@ namespace GSF.TimeSeries.Adapters
                 HashSet<IAdapter> consumerAdapters = new((actionAdapterCollection ?? Enumerable.Empty<IAdapter>())
                     .Concat(outputAdapterCollection ?? Enumerable.Empty<IAdapter>()));
 
+                // Put filter adapters in execution order
+                Array.Sort(filterAdapterCollection, (adapter1, adapter2) => adapter1.ExecutionOrder.CompareTo(adapter2.ExecutionOrder));
+
                 RoutingTablesAdaptersList producerChanges = new(m_prevCalculatedProducers, producerAdapters);
                 RoutingTablesAdaptersList consumerChanges = new(m_prevCalculatedConsumers, consumerAdapters);
 
-                m_routeMappingTables.PatchRoutingTable(producerChanges, consumerChanges);
+                m_routeMappingTables.PatchRoutingTable(producerChanges, filterAdapterCollection, consumerChanges);
                 m_prevCalculatedProducers = producerAdapters;
                 m_prevCalculatedConsumers = consumerAdapters;
 

--- a/Source/Libraries/GSF.TimeSeries/Adapters/RoutingTables.cs
+++ b/Source/Libraries/GSF.TimeSeries/Adapters/RoutingTables.cs
@@ -249,12 +249,13 @@ namespace GSF.TimeSeries.Adapters
                     .Concat(outputAdapterCollection ?? Enumerable.Empty<IAdapter>()));
 
                 // Put filter adapters in execution order
-                Array.Sort(filterAdapterCollection, (adapter1, adapter2) => adapter1.ExecutionOrder.CompareTo(adapter2.ExecutionOrder));
+                IFilterAdapter[] filterAdapters = filterAdapterCollection ?? Array.Empty<IFilterAdapter>();
+                Array.Sort(filterAdapters, (adapter1, adapter2) => adapter1.ExecutionOrder.CompareTo(adapter2.ExecutionOrder));
 
                 RoutingTablesAdaptersList producerChanges = new(m_prevCalculatedProducers, producerAdapters);
                 RoutingTablesAdaptersList consumerChanges = new(m_prevCalculatedConsumers, consumerAdapters);
 
-                m_routeMappingTables.PatchRoutingTable(producerChanges, filterAdapterCollection, consumerChanges);
+                m_routeMappingTables.PatchRoutingTable(producerChanges, filterAdapters, consumerChanges);
                 m_prevCalculatedProducers = producerAdapters;
                 m_prevCalculatedConsumers = consumerAdapters;
 


### PR DESCRIPTION
The strategy is:
1. Remove code from `IaonSession` that passes measurements into the filter adapters collection.
2. Expose the filter adapters collection to the routing tables.
3. Pass filter adapters into the routing tables' patch method.
4. Within the routing tables, add filter adapters into the global cache.
5. Do not invoke `IFilterAdapter.HandleNewMeasurements()` on the input adapter's `NewMeasurements` handler's thread!

In `RouteMappingDoubleBufferQueue`, this means we needed to introduce an `AsyncQueue<ICollection<IMeasurement>>` to pass the measurements into if there are filter adapters that need to process the measurements. Ideally, we'd be able to skip the async queue if there are no filter adapters, but this turned out to be a bit complicated because measurements from the input adapter could get published to consumers out of order if all filter adapters are disabled while the async queue has a backlog. Thus, I introduced a new field into the local cache for tracking whether there are any pending async jobs. That way, we can publish to the async queue even when there are no filter adapters, just to keep processing measurements in the correct order.

`RouteMappingHighLatencyLowCpu` was already doing all of its routing on a separate thread via the `ScheduledTask` class so the changes were much easier.