### PR TITLE
XDA-83 Automatically enumerate a directory where the 'too many changes' error occurs

### DIFF
--- a/Source/Libraries/GSF.Core.Shared/GSF.Core.Shared.projitems
+++ b/Source/Libraries/GSF.Core.Shared/GSF.Core.Shared.projitems
@@ -152,6 +152,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Threading\StateMachine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\SharedTimer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\SynchronizedOperationBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Threading\SynchronizedTask.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\TaskSynchronizedOperation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\ThreadContainerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\ThreadContainerDedicated.cs" />

--- a/Source/Libraries/GSF.Core.Shared/Threading/SynchronizedTask.cs
+++ b/Source/Libraries/GSF.Core.Shared/Threading/SynchronizedTask.cs
@@ -1,0 +1,173 @@
+﻿//******************************************************************************************************
+//  SynchronizedTask.cs - Gbtc
+//
+//  Copyright © 2026, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  05/19/2026 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace GSF.Core.Threading
+{
+    /// <summary>
+    /// Represents a task that cannot run while it is already in progress.
+    /// </summary>
+    /// <typeparam name="T">The type of object returned by the task when it executes.</typeparam>
+    public class SynchronizedTask<T>
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="SynchronizedTask{T}"/> class.
+        /// </summary>
+        /// <param name="callback">The callback to be executed when the task runs</param>
+        /// <exception cref="ArgumentNullException"><paramref name="callback"/> is null</exception>
+        public SynchronizedTask(Func<Task<T>> callback)
+        {
+            if (callback is null)
+                throw new ArgumentNullException(nameof(callback));
+
+            Callback = callback;
+        }
+
+        /// <summary>
+        /// Gets a value to indicate whether the synchronized
+        /// task is currently executing its callback.
+        /// </summary>
+        public bool IsRunning
+        {
+            get
+            {
+                lock (TaskLock)
+                    return RunningTask is not null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value to indiate whether the synchronized task
+        /// has an additional callback that is pending execution after
+        /// the currently running task has completed.
+        /// </summary>
+        public bool IsPending
+        {
+            get
+            {
+                lock (TaskLock)
+                    return PendingTask is not null;
+            }
+        }
+
+        private Func<Task<T>> Callback { get; }
+
+        private object TaskLock { get; } = new();
+        private Task<T> LastCompletedTask { get; set; }
+        private Task<T> RunningTask { get; set; }
+        private Task<T> PendingTask { get; set; }
+
+        /// <summary>
+        /// Executes the callback on another thread or marks the
+        /// task as pending if the callback is already running.
+        /// </summary>
+        /// <returns>A task that completes when the callback completes.</returns>
+        public Task<T> RunAsync()
+        {
+            lock (TaskLock)
+            {
+                if (RunningTask is null)
+                {
+                    RunningTask = Task.Run(ExecuteCallback);
+                    return RunningTask;
+                }
+
+                if (PendingTask is null)
+                {
+                    Task<T> runningTask = RunningTask;
+
+                    PendingTask = Task.Run(async () =>
+                    {
+                        await runningTask.ConfigureAwait(false);
+                        return await ExecuteCallback().ConfigureAwait(false);
+                    });
+                }
+
+                return PendingTask;
+            }
+        }
+
+        /// <summary>
+        /// Returns a task that completes when the currently
+        /// running and pending tasks are both complete.
+        /// </summary>
+        /// <returns>A task instance.</returns>
+        public async Task FlushAsync()
+        {
+            Task pendingTask;
+
+            lock (TaskLock)
+                pendingTask = PendingTask ?? RunningTask ?? Task.CompletedTask;
+
+            try { await pendingTask; }
+            catch { /* Ignore errors when flushing */ }
+        }
+
+        /// <summary>
+        /// Returns an awaiter used to await the most recently completed callback.
+        /// </summary>
+        /// <returns>An awaiter instance.</returns>
+        public TaskAwaiter<T> GetAwaiter()
+        {
+            lock (TaskLock)
+            {
+                Task<T> task = LastCompletedTask ?? RunningTask ?? RunAsync();
+                return task.GetAwaiter();
+            }
+        }
+
+        /// <summary>
+        /// Configures an awaiter used to await the most recently completed callback.
+        /// </summary>
+        /// <param name="continueOnCapturedContext">true to attempt to marshal the continuation back to the original context captured; otherwise, false</param>
+        /// <returns>An object used to await the most recently completed callback.</returns>
+        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext)
+        {
+            lock (TaskLock)
+            {
+                Task<T> task = LastCompletedTask ?? RunningTask ?? RunAsync();
+                return task.ConfigureAwait(continueOnCapturedContext);
+            }
+        }
+
+        private async Task<T> ExecuteCallback()
+        {
+            try
+            {
+                return await Callback().ConfigureAwait(false);
+            }
+            finally
+            {
+                lock (TaskLock)
+                {
+                    LastCompletedTask = RunningTask;
+                    RunningTask = PendingTask;
+                    PendingTask = null;
+                }
+            }
+        }
+    }
+}

--- a/Source/Libraries/GSF.Core/IO/FileProcessor.cs
+++ b/Source/Libraries/GSF.Core/IO/FileProcessor.cs
@@ -456,7 +456,7 @@ namespace GSF.IO
                 m_fileWatcher.Changed += m_fileProcessor.Watcher_Changed;
                 m_fileWatcher.Renamed += m_fileProcessor.Watcher_Renamed;
                 m_fileWatcher.Deleted += m_fileProcessor.Watcher_Deleted;
-                m_fileWatcher.Error += m_fileProcessor.Watcher_Error;
+                m_fileWatcher.Error += Watcher_Error;
 
                 m_fileWatcher.EnableRaisingEvents = true;
             }
@@ -467,8 +467,13 @@ namespace GSF.IO
                 m_fileWatcher.Changed -= m_fileProcessor.Watcher_Changed;
                 m_fileWatcher.Renamed -= m_fileProcessor.Watcher_Renamed;
                 m_fileWatcher.Deleted -= m_fileProcessor.Watcher_Deleted;
-                m_fileWatcher.Error -= m_fileProcessor.Watcher_Error;
+                m_fileWatcher.Error -= Watcher_Error;
                 m_fileWatcher.Dispose();
+            }
+
+            private void Watcher_Error(object sender, ErrorEventArgs args)
+            {
+                m_fileProcessor.HandleWatcherError(sender, this, args);
             }
 
             #endregion
@@ -1178,8 +1183,14 @@ namespace GSF.IO
         }
 
         // Triggers the error event for the exception encountered by the file watcher.
-        private void Watcher_Error(object sender, ErrorEventArgs args)
+        private void HandleWatcherError(object sender, TrackedDirectory directory, ErrorEventArgs args)
         {
+            if (args.GetException() is InternalBufferOverflowException)
+            {
+                _ = directory.EnumerateAsync();
+                return;
+            }
+
             Error?.Invoke(sender, args);
         }
 

--- a/Source/Libraries/GSF.Core/IO/FileProcessor.cs
+++ b/Source/Libraries/GSF.Core/IO/FileProcessor.cs
@@ -963,9 +963,16 @@ namespace GSF.IO
                     return new List<TrackedDirectory>(m_trackedDirectories);
             }
 
-            List<TrackedDirectory> trackedDirectories = GetTrackedDirectories();
-            IEnumerable<Task> enumerationTasks = trackedDirectories.Select(dir => dir.EnumerateAsync());
-            await Task.WhenAll(enumerationTasks).ConfigureAwait(false);
+            try
+            {
+                List<TrackedDirectory> trackedDirectories = GetTrackedDirectories();
+                IEnumerable<Task> enumerationTasks = trackedDirectories.Select(dir => dir.EnumerateAsync());
+                await Task.WhenAll(enumerationTasks).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                OnError(ex);
+            }
         }
         
         // Checks and updates the touchedFiles lookup table, then starts the processing loop.
@@ -975,7 +982,7 @@ namespace GSF.IO
 
             async Task ProcessAsync()
             {
-                await RunProcessLoopAsync(filePath, raisedByFileWatcher);
+                await RunProcessLoopAsync(filePath, raisedByFileWatcher).ConfigureAwait(false);
 
                 if (!touched)
                     Interlocked.Increment(ref m_processedFileCount);
@@ -1187,11 +1194,17 @@ namespace GSF.IO
         {
             if (args.GetException() is InternalBufferOverflowException)
             {
-                _ = directory.EnumerateAsync();
+                _ = TryEnumerateAsync();
                 return;
             }
 
             Error?.Invoke(sender, args);
+
+            async Task TryEnumerateAsync()
+            {
+                try { await directory.EnumerateAsync().ConfigureAwait(false); }
+                catch (Exception ex) { OnError(ex); }
+            }
         }
 
         // Picks up files that were missed by the file watchers.

--- a/Source/Libraries/GSF.Core/IO/FileProcessor.cs
+++ b/Source/Libraries/GSF.Core/IO/FileProcessor.cs
@@ -361,12 +361,13 @@ namespace GSF.IO
                     bool matchesFilter = m_fileProcessor.MatchesFilter(trackedPath);
 
                     // The file must be processed on the processing thread
-                    await processingThread.Join(FileProcessor.ProcessNormalPriority);
-
-                    if (matchesFilter)
-                        m_fileProcessor.TouchAndProcess(trackedPath, lastWriteTime, false);
-                    else
-                        m_fileProcessor.TouchAndSkip(trackedPath, lastWriteTime);
+                    processingThread.Push(FileProcessor.ProcessNormalPriority, () =>
+                    {
+                        if (matchesFilter)
+                            m_fileProcessor.TouchAndProcess(trackedPath, lastWriteTime, false);
+                        else
+                            m_fileProcessor.TouchAndSkip(trackedPath, lastWriteTime);
+                    });
                 }
 
                 async Task EnumerateSubdirectoriesAsync()
@@ -398,10 +399,6 @@ namespace GSF.IO
 
                     IEnumerable<Task> processTasks = files.Select(VisitFileAsync);
                     await Task.WhenAll(processTasks).ConfigureAwait(false);
-
-                    // The continuation of VisitFileAsync() will execute on the
-                    // processing thread so we need to join back to the appropriate thread
-                    await enumerationThread.Join();
                 }
 
                 EventHandler<EventArgs<List<string>>> handler = (sender, args) =>

--- a/Source/Libraries/GSF.Core/IO/FileProcessor.cs
+++ b/Source/Libraries/GSF.Core/IO/FileProcessor.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
+using GSF.Core.Threading;
 using GSF.Threading;
 using CancellationToken = GSF.Threading.CancellationToken;
 using Timer = System.Timers.Timer;
@@ -167,6 +168,7 @@ namespace GSF.IO
 
             // Fields
             private readonly FileProcessor m_fileProcessor;
+            private readonly SynchronizedTask<object> m_enumerationTask;
             private SafeFileWatcher m_fileWatcher;
             private CancellationToken m_cancellationToken;
             private bool m_disposed;
@@ -178,6 +180,7 @@ namespace GSF.IO
             public TrackedDirectory(FileProcessor fileProcessor, string path)
             {
                 m_fileProcessor = fileProcessor;
+                m_enumerationTask = new SynchronizedTask<object>(StartEnumerationAsync);
                 Path = path;
                 CreateFileWatcher();
             }
@@ -187,6 +190,8 @@ namespace GSF.IO
             #region [ Properties ]
 
             public string Path { get; }
+
+            public bool IsRunning => m_enumerationTask.IsRunning;
 
             public List<string> ActivelyEnumeratedPaths
             {
@@ -203,21 +208,23 @@ namespace GSF.IO
 
             #region [ Methods ]
 
-            public async Task EnumerateAsync(FileEnumerationStrategy fileEnumerationStrategy, bool sort)
+            public Task EnumerateAsync()
             {
-                if (m_disposed)
-                    return;
-
-                CancellationToken cancellationToken = new CancellationToken();
-                Interlocked.Exchange(ref m_cancellationToken, cancellationToken);
-                DirectoryInfo directory = new DirectoryInfo(Path);
-                await EnumerateDirectoryAsync(directory, fileEnumerationStrategy, sort, cancellationToken);
+                return m_enumerationTask.RunAsync();
             }
 
             public void CancelEnumeration()
             {
                 CancellationToken cancellationToken = Interlocked.CompareExchange(ref m_cancellationToken, null, null);
-                cancellationToken?.Cancel();
+
+                if (cancellationToken is null)
+                    return;
+
+                cancellationToken.Cancel();
+
+                m_enumerationTask
+                    .FlushAsync()
+                    .ContinueWith(_ => Interlocked.Exchange(ref m_cancellationToken, null));
             }
 
             public void CheckFileWatcher()
@@ -248,19 +255,55 @@ namespace GSF.IO
                 }
             }
 
+            private async Task<object> StartEnumerationAsync()
+            {
+                if (m_disposed)
+                    return null;
+
+                CancellationToken cancellationToken = Interlocked.CompareExchange(ref m_cancellationToken, new CancellationToken(), null);
+
+                if (cancellationToken.IsCancelled)
+                    return null;
+
+                FileEnumerationStrategy fileEnumerationStrategy = m_fileProcessor.EnumerationStrategy;
+                bool sequential = fileEnumerationStrategy == FileEnumerationStrategy.Sequential;
+                bool sort = m_fileProcessor.OrderedEnumeration;
+
+                TaskCompletionSource<object> promise = null;
+
+                if (sequential)
+                {
+                    // Use promises to chain sequential enumeration jobs so they
+                    // run in order and won't try to interleave LogicalThread tasks
+                    promise = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                    await Interlocked
+                        .Exchange(ref m_fileProcessor.m_sequentialEnumerationPromise, promise.Task)
+                        .ConfigureAwait(false);
+                }
+
+                // Ensure execution is joined with the appropriate
+                // logical thread before calling EnumerateDirectoryAsync()
+                LogicalThread thread = sequential
+                    ? m_fileProcessor.m_sequentialEnumerationThread
+                    : m_fileProcessor.m_threadScheduler.CreateThread();
+
+                await thread.Join();
+
+                DirectoryInfo directory = new DirectoryInfo(Path);
+                await EnumerateDirectoryAsync(directory, fileEnumerationStrategy, sort, cancellationToken).ConfigureAwait(false);
+                promise?.SetResult(null);
+                return null;
+            }
+
             private async Task EnumerateDirectoryAsync(DirectoryInfo directory, FileEnumerationStrategy fileEnumerationStrategy, bool sort, CancellationToken cancellationToken)
             {
-                bool parallelSubdirectories =
-                    fileEnumerationStrategy == FileEnumerationStrategy.ParallelSubdirectories;
+                bool sequential = fileEnumerationStrategy == FileEnumerationStrategy.Sequential;
+                bool parallelSubdirectories = fileEnumerationStrategy == FileEnumerationStrategy.ParallelSubdirectories;
 
-                LogicalThread thread = LogicalThread.CurrentThread;
-
-                if (parallelSubdirectories)
-                {
-                    LogicalThreadScheduler scheduler = m_fileProcessor.m_threadScheduler;
-                    thread = scheduler.CreateThread();
-                    await thread.Join();
-                }
+                LogicalThread enumerationThread = LogicalThread.CurrentThread;
+                LogicalThread processingThread = m_fileProcessor.m_processingThread;
+                string activePath = null;
 
                 async Task ForEach(IEnumerable<Task> tasks)
                 {
@@ -269,13 +312,13 @@ namespace GSF.IO
                         if (cancellationToken.IsCancelled)
                             return;
 
-                        await task;
-                        await thread.Yield();
+                        await task.ConfigureAwait(false);
+
+                        // Lazy evaluation of the IEnumerable may execute on the wrong
+                        // thread if we don't join back to the enumeration thread here
+                        await enumerationThread.Join();
                     }
                 }
-
-                LogicalThread processingThread = m_fileProcessor.m_processingThread;
-                string activePath = null;
 
                 async Task VisitSubdirectoryAsync(DirectoryInfo subdirectory)
                 {
@@ -284,36 +327,46 @@ namespace GSF.IO
                     if (cancellationToken.IsCancelled)
                         return;
 
+                    // Each subdirectory should have its own task on the logical thread to
+                    // allow for round-robin execution of tasks on other logical threads
+                    await enumerationThread.Yield();
+
                     if (m_fileProcessor.MatchesFolderExclusion(subdirectory.FullName))
                         return;
 
-                    await EnumerateDirectoryAsync(subdirectory, fileEnumerationStrategy, sort, cancellationToken);
+                    if (parallelSubdirectories)
+                    {
+                        // Give the subdirectory its own thread so all subdirectories can enumerate in parallel
+                        LogicalThreadScheduler scheduler = m_fileProcessor.m_threadScheduler;
+                        enumerationThread = scheduler.CreateThread();
+                        await enumerationThread.Join();
+                    }
+
+                    await EnumerateDirectoryAsync(subdirectory, fileEnumerationStrategy, sort, cancellationToken).ConfigureAwait(false);
                 }
 
-                async Task<Task> VisitFileAsync(FileInfo file)
+                async Task VisitFileAsync(FileInfo file)
                 {
                     activePath = file.FullName;
 
                     if (cancellationToken.IsCancelled)
-                        return Task.CompletedTask;
+                        return;
 
-                    async Task InvokeOnProcessingThread(Action action)
-                    {
-                        await processingThread.Join();
-                        action();
-                    }
+                    // Each file should have its own task on the logical thread to
+                    // allow for round-robin execution of tasks on other logical threads
+                    await enumerationThread.Yield();
 
                     string trackedPath = ToTrackedPath(file.FullName);
                     DateTime lastWriteTime = file.LastWriteTimeUtc;
-                    void Process() => m_fileProcessor.TouchAndProcess(trackedPath, lastWriteTime, false);
-                    void Skip() => m_fileProcessor.TouchAndSkip(trackedPath, lastWriteTime);
+                    bool matchesFilter = m_fileProcessor.MatchesFilter(trackedPath);
 
-                    if (!m_fileProcessor.MatchesFilter(trackedPath))
-                        return InvokeOnProcessingThread(Skip);
+                    // The file must be processed on the processing thread
+                    await processingThread.Join(FileProcessor.ProcessNormalPriority);
 
-                    Task processTask = InvokeOnProcessingThread(Process);
-                    await thread.Yield();
-                    return processTask;
+                    if (matchesFilter)
+                        m_fileProcessor.TouchAndProcess(trackedPath, lastWriteTime, false);
+                    else
+                        m_fileProcessor.TouchAndSkip(trackedPath, lastWriteTime);
                 }
 
                 async Task EnumerateSubdirectoriesAsync()
@@ -328,7 +381,11 @@ namespace GSF.IO
                         subdirectories = subdirectories.OrderBy(info => info.Name);
 
                     IEnumerable<Task> subdirectoryTasks = subdirectories.Select(VisitSubdirectoryAsync);
-                    await whenAll(subdirectoryTasks);
+                    await whenAll(subdirectoryTasks).ConfigureAwait(false);
+
+                    // The continuation of VisitSubdirectoryAsync() may run on a
+                    // subdirectory thread so we should join back to the appropriate thread
+                    await enumerationThread.Join();
                 }
 
                 async Task EnumerateFilesAsync()
@@ -339,13 +396,12 @@ namespace GSF.IO
                     if (sort)
                         files.OrderBy(info => info.Name);
 
-                    IEnumerable<Task<Task>> fileTasks = files.Select(VisitFileAsync);
-                    List<Task> processTasks = new List<Task>();
+                    IEnumerable<Task> processTasks = files.Select(VisitFileAsync);
+                    await Task.WhenAll(processTasks).ConfigureAwait(false);
 
-                    foreach (Task<Task> fileTask in fileTasks)
-                        processTasks.Add(await fileTask);
-
-                    await Task.WhenAll(processTasks);
+                    // The continuation of VisitFileAsync() will execute on the
+                    // processing thread so we need to join back to the appropriate thread
+                    await enumerationThread.Join();
                 }
 
                 EventHandler<EventArgs<List<string>>> handler = (sender, args) =>
@@ -361,14 +417,14 @@ namespace GSF.IO
                     if (parallelSubdirectories)
                     {
                         Task subdirectoriesTask = EnumerateSubdirectoriesAsync();
-                        await EnumerateFilesAsync();
+                        await EnumerateFilesAsync().ConfigureAwait(false);
                         ActivelyVisitedPathsRequested -= handler;
-                        await subdirectoriesTask;
+                        await subdirectoriesTask.ConfigureAwait(false);
                     }
                     else
                     {
-                        await EnumerateFilesAsync();
-                        await EnumerateSubdirectoriesAsync();
+                        await EnumerateFilesAsync().ConfigureAwait(false);
+                        await EnumerateSubdirectoriesAsync().ConfigureAwait(false);
                     }
                 }
                 finally
@@ -445,6 +501,10 @@ namespace GSF.IO
         /// </summary>
         public const FileEnumerationStrategy DefaultEnumerationStrategy = FileEnumerationStrategy.ParallelSubdirectories;
 
+        private const int ProcessHighPriority = 4;
+        private const int ProcessNormalPriority = 3;
+        private const int WatcherPriority = 2;
+
         // Events
 
         /// <summary>
@@ -468,7 +528,6 @@ namespace GSF.IO
 
         private readonly object m_trackedDirectoriesLock;
         private readonly List<TrackedDirectory> m_trackedDirectories;
-        private readonly TaskSynchronizedOperation m_enumerationOperation;
 
         private readonly LogicalThreadScheduler m_threadScheduler;
         private readonly LogicalThread m_processingThread;
@@ -478,6 +537,8 @@ namespace GSF.IO
         private readonly ManagedCancellationTokenSource m_requeueTokenSource;
 
         private readonly Dictionary<string, DateTime> m_touchedFiles;
+
+        private Task m_sequentialEnumerationPromise;
 
         private int m_processedFileCount;
         private int m_skippedFileCount;
@@ -502,9 +563,8 @@ namespace GSF.IO
 
             m_trackedDirectoriesLock = new object();
             m_trackedDirectories = new List<TrackedDirectory>();
-            m_enumerationOperation = new TaskSynchronizedOperation(EnumerateWatchDirectoriesAsync, OnError);
 
-            m_threadScheduler = new LogicalThreadScheduler(2);
+            m_threadScheduler = new LogicalThreadScheduler(4);
             m_threadScheduler.UnhandledException += (sender, args) => OnError(args.Argument);
             m_processingThread = m_threadScheduler.CreateThread();
             m_watcherThread = m_threadScheduler.CreateThread();
@@ -514,6 +574,8 @@ namespace GSF.IO
             m_requeueTokenSource = new ManagedCancellationTokenSource();
 
             m_touchedFiles = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+
+            m_sequentialEnumerationPromise = Task.CompletedTask;
         }
 
         #endregion
@@ -664,7 +726,14 @@ namespace GSF.IO
         /// <summary>
         /// Gets the flag indicating if the file processor is actively enumerating.
         /// </summary>
-        public bool IsEnumerating => m_enumerationOperation.IsRunning;
+        public bool IsEnumerating
+        {
+            get
+            {
+                lock (m_trackedDirectoriesLock)
+                    return m_trackedDirectories.Any(dir => dir.IsRunning);
+            }
+        }
 
         /// <summary>
         /// Gets the number of files
@@ -765,7 +834,7 @@ namespace GSF.IO
             if (m_disposed)
                 throw new ObjectDisposedException(nameof(FileProcessor));
 
-            m_enumerationOperation.RunOnceAsync();
+            _ = EnumerateWatchDirectoriesAsync();
         }
 
         /// <summary>
@@ -848,7 +917,7 @@ namespace GSF.IO
             if (m_disposed)
                 throw new ObjectDisposedException(nameof(FileProcessor));
 
-            m_processingThread.Push(2, () =>
+            m_processingThread.Push(ProcessHighPriority, () =>
             {
                 m_touchedFiles.Clear();
                 Interlocked.Exchange(ref m_processedFileCount, 0);
@@ -890,41 +959,8 @@ namespace GSF.IO
             }
 
             List<TrackedDirectory> trackedDirectories = GetTrackedDirectories();
-            FileEnumerationStrategy enumerationStrategy = m_enumerationStrategy;
-            bool sequential = enumerationStrategy == FileEnumerationStrategy.Sequential;
-            bool sort = m_orderedEnumeration;
-
-            Func<LogicalThread> getEnumerationThread = sequential
-                ? () => m_sequentialEnumerationThread
-                : () => m_threadScheduler.CreateThread();
-
-            async Task EnumerateTrackedDirectoryAsync(TrackedDirectory trackedDirectory)
-            {
-                try
-                {
-                    LogicalThread enumerationThread = getEnumerationThread();
-                    await enumerationThread.Join();
-                    await trackedDirectory.EnumerateAsync(enumerationStrategy, sort);
-                }
-                catch (Exception ex)
-                {
-                    OnError(ex);
-                }
-            }
-
-            IEnumerable<Task> enumerationTasks = trackedDirectories
-                .Select(EnumerateTrackedDirectoryAsync);
-
-            async Task ForEach(IEnumerable<Task> tasks)
-            {
-                foreach (Task task in tasks)
-                    await task;
-            }
-
-            Func<IEnumerable<Task>, Task> whenAll =
-                sequential ? ForEach : Task.WhenAll;
-
-            await whenAll(enumerationTasks);
+            IEnumerable<Task> enumerationTasks = trackedDirectories.Select(dir => dir.EnumerateAsync());
+            await Task.WhenAll(enumerationTasks).ConfigureAwait(false);
         }
         
         // Checks and updates the touchedFiles lookup table, then starts the processing loop.
@@ -1005,7 +1041,10 @@ namespace GSF.IO
                     if (cancellationToken.IsCancellationRequested)
                         break;
 
-                    int priority = (retryCount < RelaxedRetryLimit) ? 2 : 1;
+                    int priority = raisedByFileWatcher && (retryCount < RelaxedRetryLimit)
+                        ? ProcessHighPriority
+                        : ProcessNormalPriority;
+
                     await m_processingThread.Join(priority);
 
                     if (cancellationToken.IsCancellationRequested)
@@ -1021,7 +1060,7 @@ namespace GSF.IO
 
                     retryCount++;
                     int delay = GetDelay();
-                    try { await Task.Delay(delay, cancellationToken); }
+                    try { await Task.Delay(delay, cancellationToken).ConfigureAwait(false); }
                     catch (TaskCanceledException) { break; }
                 }
 
@@ -1063,17 +1102,17 @@ namespace GSF.IO
         {
             string fullPath = args.FullPath;
 
-            m_watcherThread.Push(() =>
+            m_watcherThread.Push(WatcherPriority, () =>
             {
                 DateTime lastWriteTime = File.GetLastWriteTimeUtc(fullPath);
 
                 if (!MatchesFilter(fullPath))
                 {
-                    m_processingThread.Push(1, () => TouchAndSkip(fullPath, lastWriteTime));
+                    m_processingThread.Push(ProcessNormalPriority, () => TouchAndSkip(fullPath, lastWriteTime));
                     return;
                 }
 
-                m_processingThread.Push(2, () => TouchAndProcess(fullPath, lastWriteTime, true));
+                m_processingThread.Push(ProcessHighPriority, () => TouchAndProcess(fullPath, lastWriteTime, true));
             });
         }
 
@@ -1085,17 +1124,17 @@ namespace GSF.IO
 
             string fullPath = args.FullPath;
 
-            m_watcherThread.Push(() =>
+            m_watcherThread.Push(WatcherPriority, () =>
             {
                 DateTime lastWriteTime = File.GetLastWriteTimeUtc(fullPath);
 
                 if (!MatchesFilter(fullPath))
                 {
-                    m_processingThread.Push(1, () => TouchAndSkip(fullPath, lastWriteTime));
+                    m_processingThread.Push(ProcessNormalPriority, () => TouchAndSkip(fullPath, lastWriteTime));
                     return;
                 }
 
-                m_processingThread.Push(2, () =>
+                m_processingThread.Push(ProcessHighPriority, () =>
                 {
                     m_touchedFiles.Remove(fullPath);
                     TouchAndProcess(fullPath, lastWriteTime, true);
@@ -1109,11 +1148,11 @@ namespace GSF.IO
             string oldFullPath = args.OldFullPath;
             string fullPath = args.FullPath;
 
-            m_watcherThread.Push(() =>
+            m_watcherThread.Push(WatcherPriority, () =>
             {
                 DateTime lastWriteTime = File.GetLastWriteTimeUtc(fullPath);
                 bool matchesFilter = MatchesFilter(fullPath);
-                int priority = matchesFilter ? 2 : 1;
+                int priority = matchesFilter ? ProcessHighPriority : ProcessNormalPriority;
 
                 m_processingThread.Push(priority, () =>
                 {
@@ -1135,7 +1174,7 @@ namespace GSF.IO
         private void Watcher_Deleted(object sender, FileSystemEventArgs args)
         {
             string fullPath = args.FullPath;
-            m_processingThread.Push(2, () => m_touchedFiles.Remove(fullPath));
+            m_processingThread.Push(ProcessHighPriority, () => m_touchedFiles.Remove(fullPath));
         }
 
         // Triggers the error event for the exception encountered by the file watcher.


### PR DESCRIPTION
* The `SynchronizedTask` class is similar conceptually to the `ISynchronizedOperation` interface, but it is specifically designed to manage `Task<T>` objects so that those operations can be awaited to see when the operation is complete. Originally, I thought I'd need this for sequential enumeration strategy, but ultimately it seems I only needed it to implement cancellation.
* Each `TrackedDirectory` now has a `SynchronizedTask` which allows the user to queue up a pending enumeration task if one is already running.
* Cancelling enumeration on a `TrackedDirectory` will cancel both the currently running and pending enumerations, but any enumerations that queue up after that are not cancelled.
* I reworked prioritization a bit. The processing thread always has highest priority, with file watcher's processing events taking priority over file enumeration's processing events. Below that, the file watcher thread has priority over the enumeration threads. This more granular prioritization helps to avoid starvation due to the sheer number of logical threads created by `FileEnumerationStrategy.ParallelSubdirectories`.
* Thankfully, some of the async/await logic could be simplified, particulary in `VisitFileAsync()`. I also added some comments to make it clearer what the `LogicalThread.Join()` and `LogicalThread.Yield()` calls are used for.