### PR TITLE
Fix SEL CWS data-frame sample misalignment (samples 1-49 read 16 bytes early)

### DIFF
--- a/Source/Libraries/GSF.PhasorProtocols/SelCWS/FrameParser.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/SelCWS/FrameParser.cs
@@ -400,9 +400,12 @@ public class FrameParser : FrameParserBase<FrameType>
         // Ensure nanosecond frame distribution is initialized
         m_nanosecondPacketFrameOffsets ??= CalculateNanosecondPacketFrameOffsets(FramesPerPacket);
 
-        // Move offset past initial data frame which includes 64-bit nanosecond timestamp
-        offset += 32;
-        length -= 32;
+        // Move offset past the entire initial data frame to reach the second sample. The initial
+        // frame spans the 16-byte common header + 8-byte nanosecond timestamp + first 24-byte sample
+        // (6 analogs x 4 bytes) = 48 bytes. (Previously skipped only 32, omitting the common header,
+        // which misaligned samples 1-49 of every packet by 16 bytes / 4 analog channels.)
+        offset += 48;
+        length -= 48;
 
         // In the case of data frames in CWS, the source buffer has 49 more frames to parse after the first
         for (int i = 1; i < FramesPerPacket; i++)


### PR DESCRIPTION
## Summary
- SEL CWS `FrameParser.ParseFrame` advanced the buffer by 32 bytes (timestamp +
  first sample) after the base parser handled sample 0, omitting the 16-byte
  common header. Samples 1-49 of every 50-sample packet were therefore read 16
  bytes (4 analog channels) too early.
- Effect: each misaligned sample returned `[VC(prev), IA(prev), IB(prev),
  IC(prev), VA(cur), VB(cur)]` mislabeled as `[VA,VB,VC,IA,IB,IC]`; only the
  first sample per packet was correct, corrupting analog values and phase
  estimates.
- Fix: advance `offset`/`length` by 48 (header 16 + timestamp 8 + first sample
  24) so all 50 samples align; sample 49 now ends exactly at the 1224-byte
  frame boundary.

## Root cause
`base.ParseFrame` takes `offset` by value and leaves the caller's offset at the
frame start, so the manual loop must skip the entire initial frame (48 bytes),
not just its body (32). The bare `32` literal hid the missing header.

## Not affected
On-wire framing and the voltage-first channel order (VA,VB,VC,IA,IB,IC,
confirmed by config-frame SignalNames) parse correctly. This was a local
offset-arithmetic defect, not a protocol/device issue.