### PR TITLE
GSF.TimeSeries.UI.WPF: Add external process execution function to Menu.xml

### DIFF
--- a/Source/Libraries/GSF.TimeSeries/UI/WPF/Commands/MenuCommand.cs
+++ b/Source/Libraries/GSF.TimeSeries/UI/WPF/Commands/MenuCommand.cs
@@ -26,6 +26,7 @@
 //******************************************************************************************************
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Input;
@@ -45,6 +46,7 @@ namespace GSF.TimeSeries.UI.Commands
         private string m_roles;
         private string m_userControlAssembly;
         private string m_userControlPath;
+        private string m_externalProcessPath;
         private string m_description;
 
         //Events
@@ -82,6 +84,7 @@ namespace GSF.TimeSeries.UI.Commands
             set
             {
                 m_roles = value;
+                OnCanExecuteChanged();
             }
         }
 
@@ -112,6 +115,21 @@ namespace GSF.TimeSeries.UI.Commands
             set
             {
                 m_userControlPath = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets path to the external process to be executed.
+        /// </summary>
+        public string ExternalProcessPath
+        {
+            get
+            {
+                return m_externalProcessPath;
+            }
+            set
+            {
+                m_externalProcessPath = value;
             }
         }
 
@@ -154,6 +172,8 @@ namespace GSF.TimeSeries.UI.Commands
         /// Handles <see cref="ICommand"/> action. 
         /// Loads user control as defined in the <see cref="UserControlPath"/> property from assembly name set in the 
         /// <see cref="UserControlAssembly"/> property.
+        /// - OR -
+        /// Executes external process as defined in the <see cref="ExternalProcessPath"/> property.
         /// </summary>
         /// <param name="parameter">
         /// Data used by the <see cref="MenuCommand"/>. If the <see cref="MenuCommand"/> does not require
@@ -161,8 +181,24 @@ namespace GSF.TimeSeries.UI.Commands
         /// </param>
         public void Execute(object parameter)
         {
+            bool hasUserControlAssembly = !string.IsNullOrEmpty(UserControlAssembly);
+            bool hasUserControlPath = !string.IsNullOrEmpty(UserControlPath);
+            bool hasExternalProcessPath = !string.IsNullOrEmpty(ExternalProcessPath);
+
+            if (hasUserControlAssembly != hasUserControlPath)
+                throw new InvalidOperationException("UserControlAssembly and UserControlPath must both be populated or neither");
+
+            if (hasUserControlAssembly == hasExternalProcessPath)
+                throw new InvalidOperationException("One of UserControlAssembly and ExternalProcessPath must be populated, but not both");
+
             try
             {
+                if (hasExternalProcessPath)
+                {
+                    Process.Start(ExternalProcessPath).Dispose();
+                    return;
+                }
+
                 Assembly assembly = Assembly.LoadFrom(FilePath.GetAbsolutePath(m_userControlAssembly));
                 CommonFunctions.LoadUserControl(m_description, assembly.GetType(m_userControlPath));
             }

--- a/Source/Libraries/GSF.TimeSeries/UI/WPF/MenuDataItem.cs
+++ b/Source/Libraries/GSF.TimeSeries/UI/WPF/MenuDataItem.cs
@@ -44,6 +44,7 @@ namespace GSF.TimeSeries.UI
         private string m_roles;
         private string m_userControlAssembly;
         private string m_userControlPath;
+        private string m_externalProcessPath;
         private MenuCommand m_command;
         private ObservableCollection<MenuDataItem> m_subMenuItems;
 
@@ -148,6 +149,22 @@ namespace GSF.TimeSeries.UI
         }
 
         /// <summary>
+        /// Gets or sets path for the external process to be executed when <see cref="MenuDataItem"/> is clicked.
+        /// </summary>
+        [XmlAttribute]
+        public string ExternalProcessPath
+        {
+            get
+            {
+                return m_externalProcessPath;
+            }
+            set
+            {
+                m_externalProcessPath = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the commnad to execute when <see cref="MenuDataItem"/> is clicked.
         /// </summary> 
         [XmlIgnore]
@@ -161,6 +178,7 @@ namespace GSF.TimeSeries.UI
                 m_command.Roles = Roles;
                 m_command.UserControlAssembly = UserControlAssembly;
                 m_command.UserControlPath = UserControlPath;
+                m_command.ExternalProcessPath = ExternalProcessPath;
                 m_command.Description = Description;
 
                 return m_command;


### PR DESCRIPTION
If `ExternalProcessPath` is not specified, the XML serializer will populate the property with `null`. Tested using the following entries added to the `Menu.xml` file in the openPDC Manager.

```xml
  </MenuDataItem>
  <MenuDataItem Icon="" MenuText="_Tools" Description="Run External Tools" Roles="*" UserControlAssembly="" UserControlPath="">
    <SubMenuItems>
        <MenuDataItem Icon="" MenuText="_Config Crypter" Description="Config Crypter" Roles="Administrator" ExternalProcessPath="ConfigCrypter.exe" />
    </SubMenuItems>
  </MenuDataItem>
```

I considered adding the `hasExternalProcessPath` validation logic to the `MenuCommand.CanExecute()` method instead of the `MenuCommand.Execute()` method. However, the menu items that merely contain sub-menu items use `CanExecute()` to determine whether the item is enabled despite the fact that they do not get executed when clicked. 🤷 