### PR TITLE
GSF.TimeSeries: Write service client logs to the local app data folder

### DIFF
--- a/Source/Libraries/GSF.TimeSeries/ServiceClientBase.cs
+++ b/Source/Libraries/GSF.TimeSeries/ServiceClientBase.cs
@@ -126,7 +126,10 @@ namespace GSF.TimeSeries
                 remotingClientSettings = ConfigurationFile.Current.Settings["remotingClient"];
 
                 // Setup default logging parameters for remote console applications
-                string logPath = FilePath.GetAbsolutePath("Logs");
+                Environment.SpecialFolder appDataFolder = Environment.SpecialFolder.LocalApplicationData;
+                string appDataPath = Environment.GetFolderPath(appDataFolder);
+                string appName = AssemblyInfo.EntryAssembly.Name;
+                string logPath = Path.Combine(appDataPath, appName, "Logs");
 
                 if (!Directory.Exists(logPath))
                     Directory.CreateDirectory(logPath);


### PR DESCRIPTION
This PR redirects openPDC Console logs to `%localappdata%\openPDCConsole\Logs\`.