### PR TITLE
Fixes PDC child lat/long save operations

### DIFF
--- a/Source/Libraries/Adapters/PhasorWebUI/PhasorHub.cs
+++ b/Source/Libraries/Adapters/PhasorWebUI/PhasorHub.cs
@@ -784,9 +784,9 @@ namespace PhasorWebUI
                     {
                         ID = childDevice.ID,
                         ParentID = device.ID,
-                        UniqueID = device.UniqueID,
-                        Longitude = device.Longitude,
-                        Latitude = device.Latitude,
+                        UniqueID = childDevice.UniqueID,
+                        Longitude = childDevice.Longitude,
+                        Latitude = childDevice.Latitude,
                         IDCode = (ushort)childDevice.AccessID,
                         StationName = childDevice.Name,
                         IDLabel = childDevice.Acronym,

--- a/Source/Libraries/Adapters/PhasorWebUI/Views/AddSynchrophasorDevice.cshtml
+++ b/Source/Libraries/Adapters/PhasorWebUI/Views/AddSynchrophasorDevice.cshtml
@@ -1344,12 +1344,18 @@
                 for (let i = 0; i < deviceCount; i++) {
                     const cell = self.configFrame().Cells[i];
 
+                    // For an existing device the lat/long loaded from the database via queryDeviceByID is
+                    // authoritative; do not let the (possibly stale, or parent-derived) coordinates carried in the
+                    // config frame / auto-saved JSON mapping overwrite it. Only seed the screen-level lat/long from
+                    // cell values when defining a new device (fresh analyze / config import).
                     // TODO: Update screen to accommodate lat/long at the device level
-                    if (!isEmpty(cell.Latitude))
-                        self.latitude(cell.Latitude);
+                    if (deviceID === 0) {
+                        if (!isEmpty(cell.Latitude))
+                            self.latitude(cell.Latitude);
 
-                    if (!isEmpty(cell.Longitude))
-                        self.longitude(cell.Longitude);
+                        if (!isEmpty(cell.Longitude))
+                            self.longitude(cell.Longitude);
+                    }
 
                     let cellAcronym = cell.IDLabel;
 
@@ -3465,7 +3471,7 @@
                                     break;
                                 default:
                                     // All other template types are assumed to be custom action adapter definitions. Since
-                                    // these adpater definitions are singletons, only execute save for first device:
+                                    // these adapter definitions are singletons, only execute save for first device:
                                     if (index === 0)
                                         promises.push(saveCustomActionAdapter(tagTemplate));
                                     break;
@@ -3535,6 +3541,13 @@
                                 device.FrameRate = configFrame.FrameRate;
                                 device.AccessID = cell.IDCode;
                                 device.Acronym = cell.IDLabel();
+
+                                // Save lat/long for child devices: prefer the cell's own coordinates when present,
+                                // otherwise fall back to the on-screen value - matches parent / direct-connected device
+                                // behavior. A zero or null coordinate is treated as "unset" by isEmpty, consistent with
+                                // the load-time logic that pushes cell coordinates onto the screen.
+                                device.Longitude = isEmpty(cell.Longitude) ? viewModel.longitude() : cell.Longitude;
+                                device.Latitude = isEmpty(cell.Latitude) ? viewModel.latitude() : cell.Latitude;
 
                                 if (isEmpty(device.Name))
                                     device.Name = device.Acronym;
@@ -3674,14 +3687,18 @@
                 device.ProtocolID = configFrame.ProtocolID;
                 device.FrameRate = configFrame.FrameRate;
                 device.AccessID = configFrame.IDCode;
-                device.IsConcentrator = !isEmpty(connectionString) && (configFrame.IsConcentrator || configFrame.Cells.length > 1);
 
                 if (isEmpty(device.Name))
                     device.Name = device.Acronym;
 
-                // Only update connection string if one has been defined, prevents changing any existing one to blank
-                if (connectionString.length > 0)
+                // Only update connection string and concentrator flag when a connection string has been defined.
+                // This prevents changing any existing connection string to blank and, just as importantly, prevents
+                // clearing the concentrator flag on an existing PDC when it is re-saved from an auto-loaded JSON config
+                // that does not carry a connection string (see connection string preservation for auto-JSON config I/O).
+                if (connectionString.length > 0) {
                     device.ConnectionString = connectionString;
+                    device.IsConcentrator = configFrame.IsConcentrator || configFrame.Cells.length > 1;
+                }
 
                 device.AutoStartDataParsingSequence = autoStartDataParsingSequence;
                 device.SkipDisableRealTimeData = skipDisableRealTimeData;


### PR DESCRIPTION
Fixes issue noted when saving a PDC child device lat/long from web UI and prevents accidental overwrite of `IsConcentrator` flag on parent device, when directly edited.