### PR TITLE
Menu.Custom.xml manager deployment option

### DIFF
--- a/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/HomeUserControl.xaml.cs
+++ b/Source/Libraries/GSF.PhasorProtocols/UI/WPF/UserControls/HomeUserControl.xaml.cs
@@ -144,7 +144,7 @@ public partial class HomeUserControl
         XmlRootAttribute xmlRootAttribute = new("MenuDataItems");
         XmlSerializer serializer = new(typeof(ObservableCollection<MenuDataItem>), xmlRootAttribute);
 
-        using XmlReader reader = XmlReader.Create(FilePath.GetAbsolutePath("Menu.xml"));
+        using XmlReader reader = XmlReader.Create(CommonFunctions.GetMenuFilePath());
 
         m_menuDataItems = (ObservableCollection<MenuDataItem>)serializer.Deserialize(reader);
     }

--- a/Source/Libraries/GSF.TimeSeries/Transport/UI/WPF/UserControls/HomeUserControl.xaml.cs
+++ b/Source/Libraries/GSF.TimeSeries/Transport/UI/WPF/UserControls/HomeUserControl.xaml.cs
@@ -146,7 +146,7 @@ public partial class HomeUserControl
         XmlRootAttribute xmlRootAttribute = new("MenuDataItems");
         XmlSerializer serializer = new(typeof(ObservableCollection<MenuDataItem>), xmlRootAttribute);
 
-        using XmlReader reader = XmlReader.Create(FilePath.GetAbsolutePath("Menu.xml"));
+        using XmlReader reader = XmlReader.Create(CommonFunctions.GetMenuFilePath());
 
         m_menuDataItems = (ObservableCollection<MenuDataItem>)serializer.Deserialize(reader);
     }

--- a/Source/Libraries/GSF.TimeSeries/UI/CommonFunctions.cs
+++ b/Source/Libraries/GSF.TimeSeries/UI/CommonFunctions.cs
@@ -153,6 +153,22 @@ namespace GSF.TimeSeries.UI
 
         // Static Methods
 
+        /// <summary>
+        /// Gets the absolute path to the manager menu definition file, preferring a deployment-specific
+        /// <c>Menu.Custom.xml</c> when present and otherwise falling back to the default <c>Menu.xml</c>.
+        /// </summary>
+        /// <returns>Absolute path to <c>Menu.Custom.xml</c> when it exists; otherwise to <c>Menu.xml</c>.</returns>
+        /// <remarks>
+        /// This allows custom or licensed deployments to override the manager menu by simply adding a
+        /// <c>Menu.Custom.xml</c> alongside the application, without overwriting the base-installed
+        /// <c>Menu.xml</c> (which would create a Windows Installer component-ownership conflict).
+        /// </remarks>
+        public static string GetMenuFilePath()
+        {
+            string customMenuPath = FilePath.GetAbsolutePath("Menu.Custom.xml");
+            return System.IO.File.Exists(customMenuPath) ? customMenuPath : FilePath.GetAbsolutePath("Menu.xml");
+        }
+
         #region [ AdoDataConnection Extension Methods ]
 
         /// <summary>

--- a/Source/Libraries/GSF.TimeSeries/UI/WPF/UserControls/HomeUserControl.xaml.cs
+++ b/Source/Libraries/GSF.TimeSeries/UI/WPF/UserControls/HomeUserControl.xaml.cs
@@ -54,7 +54,7 @@ namespace GSF.TimeSeries.UI.UserControls
             XmlRootAttribute xmlRootAttribute = new XmlRootAttribute("MenuDataItems");
             XmlSerializer serializer = new XmlSerializer(typeof(ObservableCollection<MenuDataItem>), xmlRootAttribute);
 
-            using (XmlReader reader = XmlReader.Create(FilePath.GetAbsolutePath("Menu.xml")))
+            using (XmlReader reader = XmlReader.Create(CommonFunctions.GetMenuFilePath()))
             {
                 m_menuDataItems = (ObservableCollection<MenuDataItem>)serializer.Deserialize(reader);
             }


### PR DESCRIPTION
Update allows custom deployments to override the manager menu by simply adding a `Menu.Custom.xml` alongside the application, without overwriting the base-installed `Menu.xml`.

This allows custom override without removing/changing original `Menu.xml` and also prevents possible Windows Installer component-ownership conflict for chained installs.