### PR TITLE
GSF.Core: Fix NullReferenceException in initial file enumeration

### DIFF
--- a/Source/Libraries/GSF.Core/IO/FileProcessor.cs
+++ b/Source/Libraries/GSF.Core/IO/FileProcessor.cs
@@ -260,7 +260,8 @@ namespace GSF.IO
                 if (m_disposed)
                     return null;
 
-                CancellationToken cancellationToken = Interlocked.CompareExchange(ref m_cancellationToken, new CancellationToken(), null);
+                CancellationToken newToken = new CancellationToken();
+                CancellationToken cancellationToken = Interlocked.CompareExchange(ref m_cancellationToken, newToken, null) ?? newToken;
 
                 if (cancellationToken.IsCancelled)
                     return null;


### PR DESCRIPTION
Just a basic logic error. `Interlocked.CompareExchange()` returns the value before the exchange, not after. If the return value is null, we know the exchange succeeded, so we can use the new token. Otherwise, the exchange did not succeed and we should use the return value.